### PR TITLE
Fixes to allow dev/MAPL-2.0 to work on desktop

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -150,6 +150,11 @@ if ( $NCPUS != NULL ) then
 
    endif
 
+else
+   # This is for the desktop path
+
+   @ NPES = $MODEL_NPES
+
 endif
 
 #######################################################################

--- a/gcm_setup
+++ b/gcm_setup
@@ -1320,6 +1320,7 @@ else
               # By default on desktop, just ignore IOSERVER for now
               set USE_IOSERVER = 0
               set IOS_NDS = 0
+              set NCPUS_PER_NODE = 0
 endif
 
 


### PR DESCRIPTION
Turns out I'd never tested the ioserver `gcm_setup` code on the desktop (or, well, Parcel).