### PR TITLE
MOM6 in GEOS

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -684,7 +684,7 @@ USE_SATSIM_MISR:  @MISR_SATSIM
 
 >>>COUPLED<<<# Section for ocean
 >>>COUPLED<<<# ----------------
->>>COUPLED<<<USE_DATASEA:0
+>>>COUPLED<<<OCEAN_MODEL:MOM
 >>>COUPLED<<<USE_DATASEAICE:0
 >>>COUPLED<<<steady_state_ocean: 0
 >>>COUPLED<<<OCEAN_PICE_SCALING: 0.0


### PR DESCRIPTION
`AGCM.rc.tmpl` in coupled mode sets `USE_DATASEA: 0` to use a live ocean model (MOM5).
This option has been replaced with `OCEAN_MODEL:` in `GuestOcean_GridComp.F90`.  Valid choices for `OCEAN_MODEL:` are `DATASEA`, `MOM` or `MOM6`.