### PR TITLE
MOM6 in GEOS

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -685,6 +685,7 @@ USE_SATSIM_MISR:  @MISR_SATSIM
 >>>COUPLED<<<# Section for ocean
 >>>COUPLED<<<# ----------------
 >>>COUPLED<<<USE_DATASEA:0
+>>>COUPLED<<<OCEAN_NAME: @OCEAN_NAME
 >>>COUPLED<<<USE_DATASEAICE:0
 >>>COUPLED<<<steady_state_ocean: 0
 >>>COUPLED<<<OCEAN_PICE_SCALING: 0.0

--- a/gcm_setup
+++ b/gcm_setup
@@ -326,7 +326,35 @@ if( $OGCM == TRUE ) then
     set COUPLED   = ""
     set OGRIDTYP  = "TM"
     set DATAOCEAN = "#DELETE"
-    
+    set OCEAN_NAME = ""
+
+    # Ocean Model
+    # -----------
+    OCNMODEL:
+    echo "Choose an ${C1}Ocean Model${CN}: (Default: ${C2}MOM5${CN})"
+    echo "   ${C2}MOM5${CN}"
+    echo "   ${C2}MOM6${CN}"
+
+	set OCNMODEL  = $<
+	if ( .$OCNMODEL == . ) then
+		set OCNMODEL  = "MOM5"
+	else
+		set OCNMODEL = `echo $OCNMODEL | tr "[:lower:]" "[:upper:]"`
+
+    	if ( $OCNMODEL != "MOM5" & $OCNMODEL != "MOM6" ) then
+			echo
+			echo "${C1}Ocean Model${CN} must be either MOM5 or MOM6!"
+			goto OCNMODEL
+		else
+			echo
+		endif
+	endif
+
+    if ( $OCNMODEL == "MOM5" ) then
+        set OCEAN_NAME="MOM"
+    else if ( $OCNMODEL == "MOM6" ) then
+        set OCEAN_NAME="MOM6"
+    endif
 
     # Coupled Ocean Resolution
     # ------------------------
@@ -1771,6 +1799,7 @@ s?>>>HIST_GOCART<<<?$HIST_GOCART?g
 s?>>>OSTIA<<<?$OSTIA?g
 s?>>>HIST_CATCHCN<<<?$HIST_CATCHCN?g
 s?@LSM_PARMS?$LSM_PARMS?g
+s?@OCEAN_NAME?$OCEAN_NAME?g
 
 s?>>>4DIAUDAS<<<?#DELETE?g
 s?>>>REGULAR_REPLAY<<<?#?g
@@ -1880,8 +1909,10 @@ set FILES = "gcm_run.j          \
 set FILES = `echo $FILES`
 
 if( $OGCM == TRUE ) then
-    /bin/cp ${ETCDIR}/MOM5/geos5/${OGCM_IM}x${OGCM_JM}/INPUT/input.nml .
-    /bin/cp ${ETCDIR}/MOM5/geos5/${OGCM_IM}x${OGCM_JM}/INPUT/*table .
+    if ( $OCNMODEL == "MOM5" ) then
+        /bin/cp ${ETCDIR}/MOM5/geos5/${OGCM_IM}x${OGCM_JM}/INPUT/input.nml .
+        /bin/cp ${ETCDIR}/MOM5/geos5/${OGCM_IM}x${OGCM_JM}/INPUT/*table .
+    endif
     /bin/cp ${GEOSDEF}/coupled_diagnostics/g5lib/plotocn.j .
     /bin/cp ${GEOSDEF}/coupled_diagnostics/g5lib/confocn.py __init__.py
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -537,6 +537,7 @@ else
     endif
 
     set DATAOCEAN = ""
+    set OCEAN_NAME = ""
     set OGCM_LM   =  34
     set COUPLED   = "#DELETE"
 


### PR DESCRIPTION
This PR selection of Ocean Model (MOM5 or MOM6) when running `gcm_setup`.
This adds a resource `OCEAN_NAME` in `AGCM.rc` that is only used in the `COUPLED` mode.

This is ongoing work related to issue GEOS-ESM/GEOSgcm_GridComp#70

Change-Id: If1c79e9204076c4e78b69fbe1b46d3952e212b8b