### PR TITLE
remove IGNORE_VEG_HEIGHTS

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -383,7 +383,6 @@ LSM_CHOICE: @LSM_CHOICE
 # ---------------------
 @LSM_PARMS LAND_PARAMS: NRv7.2
 @LSM_PARMS Z0_FORMULATION: 4
-@LSM_PARMS IGNORE_VEG_HEIGHTS: 1
 
 # Set RUN_ROUTE to 1 to run the runoff routing model
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
this is redundant now that we're using Icarus-NLv3 boundary conditions (both use lookup heights for vegetation based on Dorman & Sellers 1989). Worse, it'll cause confusion when in the future, we move to using LIDAR-based heights. When IGNORE_VEG_HEIGHTS was implemented, it was tested to be 0diff with what is now Icarus-NLv3  BC's