### PR TITLE
Add NISV to histories and default k_split value

### DIFF
--- a/GCMPROG.rc.tmpl
+++ b/GCMPROG.rc.tmpl
@@ -934,6 +934,7 @@ COLLECTIONS: 'prog.eta'
                                'NH4DP'     , 'GOCART'  ,
                                'NH4WT'     , 'GOCART'  ,
                                'NH4SV'     , 'GOCART'  ,
+                               'DNIDT'     , 'MOIST'   , 'NISV'  ,
                                ::
 
   traj.lcv.format:      'CFIO' ,

--- a/HISTORY.AGCM.rc.tmpl
+++ b/HISTORY.AGCM.rc.tmpl
@@ -891,6 +891,7 @@ PC@HIST_IMx@HIST_JM-DC.LM: @AGCM_LM
                                'DOCDT'       , 'MOIST'       ,  'OCSV'    ,
                                'DBCDT'       , 'MOIST'       ,  'BCSV'    ,
                                'DSUDT'       , 'MOIST'       ,  'SUSV'    ,
+                               'DNIDT'       , 'MOIST'       ,  'NISV'    ,
                                ::
 
  tavg3d_aer_p.format:     'CFIO' ,  

--- a/HISTORY.rc.tmpl
+++ b/HISTORY.rc.tmpl
@@ -1491,6 +1491,7 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                'NH4DP'     , 'GOCART'  ,
                                'NH4WT'     , 'GOCART'  ,
                                'NH4SV'     , 'GOCART'  ,
+                               'DNIDT'     , 'MOIST'   , 'NISV'  ,
                                ::
 
   tavg3_2d_chm_Nx-.format:     'CFIO' ,

--- a/HISTORY_FP.rc.03z.tmpl
+++ b/HISTORY_FP.rc.03z.tmpl
@@ -1390,6 +1390,7 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                'NH4DP'     , 'GOCART'  ,
                                'NH4WT'     , 'GOCART'  ,
                                'NH4SV'     , 'GOCART'  ,
+                               'DNIDT'     , 'MOIST'   , 'NISV'  ,
                                ::
 
   tavg3_2d_chm_Nx-.format:     'CFIO' ,

--- a/HISTORY_FP.rc.09z.tmpl
+++ b/HISTORY_FP.rc.09z.tmpl
@@ -1432,6 +1432,7 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                'NH4DP'     , 'GOCART'  ,
                                'NH4WT'     , 'GOCART'  ,
                                'NH4SV'     , 'GOCART'  ,
+                               'DNIDT'     , 'MOIST'   , 'NISV'  ,
                                ::
 
   tavg3_2d_chm_Nx-.format:     'CFIO' ,

--- a/HISTORY_FP.rc.15z.tmpl
+++ b/HISTORY_FP.rc.15z.tmpl
@@ -1390,6 +1390,7 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                'NH4DP'     , 'GOCART'  ,
                                'NH4WT'     , 'GOCART'  ,
                                'NH4SV'     , 'GOCART'  ,
+                               'DNIDT'     , 'MOIST'   , 'NISV'  ,
                                ::
 
   tavg3_2d_chm_Nx-.format:     'CFIO' ,

--- a/HISTORY_FP.rc.21z.tmpl
+++ b/HISTORY_FP.rc.21z.tmpl
@@ -1432,6 +1432,7 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                'NH4DP'     , 'GOCART'  ,
                                'NH4WT'     , 'GOCART'  ,
                                'NH4SV'     , 'GOCART'  ,
+                               'DNIDT'     , 'MOIST'   , 'NISV'  ,
                                ::
 
   tavg3_2d_chm_Nx-.format:     'CFIO' ,

--- a/HISTORY_S2S.rc.tmpl
+++ b/HISTORY_S2S.rc.tmpl
@@ -790,6 +790,7 @@ COLLECTIONS: 'geosgcm_6hrins'
                                'DOCDT'       , 'MOIST'       , 'OCSV'    ,
                                'DBCDT'       , 'MOIST'       , 'BCSV'    ,
                                'DSUDT'       , 'MOIST'       , 'SUSV'    ,
+                               'DNIDT'       , 'MOIST'       , 'NISV'    ,
                                :: 
 
   # 3-D daily mean on 40 depth levels

--- a/fvcore_layout.rc
+++ b/fvcore_layout.rc
@@ -1,4 +1,5 @@
 &fv_core_nml
+  k_split = 2
  /
 
  &main_nml


### PR DESCRIPTION
Enhancements to GF and transport consistent with ops 525land_fpp. Must be taken in conjunction with pull requests in [GEOSgcm_GridComp#190](https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/190), [GEOSchem_GridComp#47](https://github.com/GEOS-ESM/GEOSchem_GridComp/pull/47), and [GMAO_Shared#70](https://github.com/GEOS-ESM/GMAO_Shared/pull/70).