### PR TITLE
Update to let MAPL 2 GEOS work with MPT

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1716,22 +1716,13 @@ cat > $HOMDIR/SETENV.commands << EOF
    setenv MPI_COLL_REPRODUCIBLE
    setenv SLURM_DISTRIBUTION block
 
-   setenv MPI_XPMEM_ENABLED no
-   setenv SUPPRESS_XPMEM_TRIM_THRESH 1
-   setenv MPI_NUM_MEMORY_REGIONS 0
-   
    #setenv MPI_DISPLAY_SETTINGS 1
    #setenv MPI_VERBOSE 1
    
-   setenv MPI_COMM_MAX  1024
-   setenv MPI_GROUP_MAX 1024
-   setenv MPI_BUFS_PER_PROC 256
-   
-   setenv MPI_IB_TIMEOUT 23
-
    unsetenv MPI_MEMMAP_OFF
    unsetenv MPI_NUM_MEMORY_REGIONS
    setenv MPI_XPMEM_ENABLED yes
+   unsetenv SUPPRESS_XPMEM_TRIM_THRESH
 
    # For some reason, PMI_RANK is randomly set and interferes
    # with binarytile.x and other executables.

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1777,22 +1777,13 @@ cat > $HOMDIR/SETENV.commands << EOF
    setenv MPI_COLL_REPRODUCIBLE
    setenv SLURM_DISTRIBUTION block
 
-   setenv MPI_XPMEM_ENABLED no
-   setenv SUPPRESS_XPMEM_TRIM_THRESH 1
-   setenv MPI_NUM_MEMORY_REGIONS 0
-   
    #setenv MPI_DISPLAY_SETTINGS 1
    #setenv MPI_VERBOSE 1
    
-   setenv MPI_COMM_MAX  1024
-   setenv MPI_GROUP_MAX 1024
-   setenv MPI_BUFS_PER_PROC 256
-   
-   setenv MPI_IB_TIMEOUT 23
-
    unsetenv MPI_MEMMAP_OFF
    unsetenv MPI_NUM_MEMORY_REGIONS
    setenv MPI_XPMEM_ENABLED yes
+   unsetenv SUPPRESS_XPMEM_TRIM_THRESH
 
    # For some reason, PMI_RANK is randomly set and interferes
    # with binarytile.x and other executables.

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1915,22 +1915,13 @@ cat > $HOMDIR/SETENV.commands << EOF
    setenv MPI_COLL_REPRODUCIBLE
    setenv SLURM_DISTRIBUTION block
 
-   setenv MPI_XPMEM_ENABLED no
-   setenv SUPPRESS_XPMEM_TRIM_THRESH 1
-   setenv MPI_NUM_MEMORY_REGIONS 0
-   
    #setenv MPI_DISPLAY_SETTINGS 1
    #setenv MPI_VERBOSE 1
    
-   setenv MPI_COMM_MAX  1024
-   setenv MPI_GROUP_MAX 1024
-   setenv MPI_BUFS_PER_PROC 256
-   
-   setenv MPI_IB_TIMEOUT 23
-
    unsetenv MPI_MEMMAP_OFF
    unsetenv MPI_NUM_MEMORY_REGIONS
    setenv MPI_XPMEM_ENABLED yes
+   unsetenv SUPPRESS_XPMEM_TRIM_THRESH
 
    # For some reason, PMI_RANK is randomly set and interferes
    # with binarytile.x and other executables.

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1768,22 +1768,13 @@ cat > $HOMDIR/SETENV.commands << EOF
    setenv MPI_COLL_REPRODUCIBLE
    setenv SLURM_DISTRIBUTION block
 
-   setenv MPI_XPMEM_ENABLED no
-   setenv SUPPRESS_XPMEM_TRIM_THRESH 1
-   setenv MPI_NUM_MEMORY_REGIONS 0
-   
    #setenv MPI_DISPLAY_SETTINGS 1
    #setenv MPI_VERBOSE 1
    
-   setenv MPI_COMM_MAX  1024
-   setenv MPI_GROUP_MAX 1024
-   setenv MPI_BUFS_PER_PROC 256
-   
-   setenv MPI_IB_TIMEOUT 23
-
    unsetenv MPI_MEMMAP_OFF
    unsetenv MPI_NUM_MEMORY_REGIONS
    setenv MPI_XPMEM_ENABLED yes
+   unsetenv SUPPRESS_XPMEM_TRIM_THRESH
 
    # For some reason, PMI_RANK is randomly set and interferes
    # with binarytile.x and other executables.


### PR DESCRIPTION
Fixes GEOS-ESM/MAPL#170.

I think we finally have this. These changes should let MAPL 2 GEOS work with MPT at NCCS. This:
```
unsetenv SUPPRESS_XPMEM_TRIM_THRESH
```
is a setting at NAS but not at NCCS and seems to help.

Note that this still isn't sufficient to allow MAPL 2 GEOS with MPT to work on SLES 12 Haswell. There are actual kernel changes needed to allow that, but NCCS is aware.