### PR TITLE
Fixes #111. Use different ALLREDUCE algorithm

### DIFF
--- a/gcm_CPLFCST360NM2_setup
+++ b/gcm_CPLFCST360NM2_setup
@@ -1542,6 +1542,7 @@ else if( $MPI == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
+setenv I_MPI_ADJUST_ALLREDUCE 12
 EOF
 
 endif # if mpi

--- a/gcm_CPLFCST360S2S_setup
+++ b/gcm_CPLFCST360S2S_setup
@@ -1539,6 +1539,7 @@ else if( $MPI == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
+setenv I_MPI_ADJUST_ALLREDUCE 12
 EOF
 
 endif # if mpi

--- a/gcm_CPLFCST360S2Sallsetup
+++ b/gcm_CPLFCST360S2Sallsetup
@@ -1552,6 +1552,7 @@ else if( $MPI == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
+setenv I_MPI_ADJUST_ALLREDUCE 12
 EOF
 
 endif # if mpi

--- a/gcm_setup
+++ b/gcm_setup
@@ -1807,6 +1807,7 @@ else if( $MPI == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
+setenv I_MPI_ADJUST_ALLREDUCE 12
 EOF
 
 endif # if mpi

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1868,6 +1868,7 @@ else if( $MPI == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
+setenv I_MPI_ADJUST_ALLREDUCE 12
 EOF
 
 endif # if mpi

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2011,6 +2011,7 @@ else if( $MPI == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
+setenv I_MPI_ADJUST_ALLREDUCE 12
 EOF
 
 endif # if mpi

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1859,6 +1859,7 @@ else if( $MPI == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
+setenv I_MPI_ADJUST_ALLREDUCE 12
 EOF
 
 endif # if mpi


### PR DESCRIPTION
Testing by @bena-nasa and myself shows that at high core count (say, C720 at 5000+ cores) using Intel MPI on the Skylakes at NCCS needs an additional environment variable.

It turns out that the default [ALLREDUCE algorithm](https://software.intel.com/en-us/mpi-developer-reference-linux-i-mpi-adjust-family-environment-variables) Intel MPI chooses seems to be:
```
2. Rabenseifner's
```
*Any* other algorithm seems to work except for this one!

After some testing it was found algorithm 12:
```
12. Topology aware SHM-based Knary
```
seemed as good as any and might have been the fastest. If nothing else, it allows GEOS to run.

Testing at C48 has shown it to be zero-diff and no substantive throughput difference.