### PR TITLE
Fixes #114. Add link option

### DIFF
--- a/gcm_CPLFCST360NM2_setup
+++ b/gcm_CPLFCST360NM2_setup
@@ -101,6 +101,7 @@ end
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
+set LINKX = FALSE
 set ENSM = @FCSTMEMBER
 
 while ( $#argv > 0 )
@@ -133,6 +134,11 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
+         breaksw
+
+      # Symlink GEOSgcm.x
+      case --link:
+         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1481,7 +1487,11 @@ echo $GROUP > $HOME/.GROUProot
     set EMISSIONS = g5chem
   endif
 
+if ( $LINKX == "TRUE" ) then
+  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+else
   if ( -e $GEOSDIR/$ARCH/bin/GEOSgcm.x ) rsync -avx $GEOSDIR/$ARCH/bin/GEOSgcm.x $EXPDIR
+endif
 
 #######################################################################
 #                      Create SETENV Commands

--- a/gcm_CPLFCST360S2S_setup
+++ b/gcm_CPLFCST360S2S_setup
@@ -101,6 +101,7 @@ end
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
+set LINKX = FALSE
 set ENSM = @FCSTMEMBER
 
 while ( $#argv > 0 )
@@ -133,6 +134,11 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
+         breaksw
+
+      # Symlink GEOSgcm.x
+      case --link:
+         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1478,7 +1484,11 @@ echo $GROUP > $HOME/.GROUProot
     set EMISSIONS = g5chem
   endif
 
+if ( $LINKX == "TRUE" ) then
+  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+else
   if ( -e $GEOSDIR/$ARCH/bin/GEOSgcm.x ) rsync -avx $GEOSDIR/$ARCH/bin/GEOSgcm.x $EXPDIR
+endif
 
 #######################################################################
 #                      Create SETENV Commands

--- a/gcm_setup
+++ b/gcm_setup
@@ -59,6 +59,7 @@ endif
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
+set LINKX = FALSE
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -80,6 +81,11 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
+         breaksw
+
+      # Symlink GEOSgcm.x
+      case --link:
+         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1704,7 +1710,11 @@ echo $GROUP > $HOME/.GROUProot
      set EMISSIONS = g5chem
   endif
 
+if ( $LINKX == "TRUE" ) then
+  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+else
   if ( -e $GEOSBIN/GEOSgcm.x ) rsync -avx $GEOSBIN/GEOSgcm.x $EXPDIR
+endif
 
 #######################################################################
 #                      Create SETENV Commands

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -59,6 +59,7 @@ endif
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
+set LINKX = FALSE
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -80,6 +81,11 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
+         breaksw
+
+      # Symlink GEOSgcm.x
+      case --link:
+         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1796,7 +1802,11 @@ echo $GROUP > $HOME/.GROUProot
      set EMISSIONS = g5chem
   endif
 
+if ( $LINKX == "TRUE" ) then
+  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+else
   if ( -e $GEOSBIN/GEOSgcm.x ) rsync -avx $GEOSBIN/GEOSgcm.x $EXPDIR
+endif
 
 #######################################################################
 #                      Create SETENV Commands

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -59,6 +59,7 @@ endif
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
+set LINKX = FALSE
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -80,6 +81,11 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
+         breaksw
+
+      # Symlink GEOSgcm.x
+      case --link:
+         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1939,7 +1945,11 @@ echo $GROUP > $HOME/.GROUProot
         /bin/cp $GEOSDIR/etc/$GMIEXP/chemistry_files/*.rc $EXPDIR/RC
   endif
 
+if ( $LINKX == "TRUE" ) then
+  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+else
   if ( -e $GEOSBIN/GEOSgcm.x ) rsync -avx $GEOSBIN/GEOSgcm.x $EXPDIR
+endif
 
 #######################################################################
 #                      Create SETENV Commands

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -59,6 +59,7 @@ endif
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
+set LINKX = FALSE
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -80,6 +81,11 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
+         breaksw
+
+      # Symlink GEOSgcm.x
+      case --link:
+         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1787,7 +1793,11 @@ echo $GROUP > $HOME/.GROUProot
      set EMISSIONS = g5chem
   endif
 
+if ( $LINKX == "TRUE" ) then
+  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+else
   if ( -e $GEOSBIN/GEOSgcm.x ) rsync -avx $GEOSBIN/GEOSgcm.x $EXPDIR
+endif
 
 #######################################################################
 #                      Create SETENV Commands


### PR DESCRIPTION
This adds a hidden `--link` option to symlink `GEOSgcm.x` rather than copy it (or, I guess `rsync` it). 

This is mainly for us @GEOS-ESM/gmao-si-team folks that tend to link `GEOSgcm.x` to our experiment so we can build-rebuild many times and not worry about re-copying it. If you never pass in `--link` you'll never see a difference.