### PR TITLE
Fixes #118. Change Intel MPI GATHERV algorithm

### DIFF
--- a/gcm_CPLFCST360NM2_setup
+++ b/gcm_CPLFCST360NM2_setup
@@ -1543,6 +1543,7 @@ else if( $MPI == intelmpi ) then
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
 EOF
 
 endif # if mpi

--- a/gcm_CPLFCST360S2S_setup
+++ b/gcm_CPLFCST360S2S_setup
@@ -1540,6 +1540,7 @@ else if( $MPI == intelmpi ) then
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
 EOF
 
 endif # if mpi

--- a/gcm_CPLFCST360S2Sallsetup
+++ b/gcm_CPLFCST360S2Sallsetup
@@ -1553,6 +1553,7 @@ else if( $MPI == intelmpi ) then
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
 EOF
 
 endif # if mpi

--- a/gcm_setup
+++ b/gcm_setup
@@ -1777,6 +1777,7 @@ else if( $MPI == intelmpi ) then
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
 EOF
 
 endif # if mpi

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1869,6 +1869,7 @@ else if( $MPI == intelmpi ) then
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
 EOF
 
 endif # if mpi

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2012,6 +2012,7 @@ else if( $MPI == intelmpi ) then
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
 EOF
 
 endif # if mpi

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1860,6 +1860,7 @@ else if( $MPI == intelmpi ) then
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
 EOF
 
 endif # if mpi


### PR DESCRIPTION
Using `I_MPI_ADJUST_GATHERV=3` seems to fix #118. Tests at c48 are zero-diff.