### PR TITLE
Fixes #120. Allows another user to run gcm_setup

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1441,20 +1441,20 @@ while( $check == FALSE )
           echo $HISTORYrc > $HOME/.HISTORYrc
   endif
 
-  echo "Enter the tag or directory (/filename) of the ${C1}HISTORY.AGCM.rc.tmpl${CN} to use"
+  echo "Enter the directory (/filename) of the ${C1}HISTORY.AGCM.rc.tmpl${CN} to use"
   echo "(To use ${C1}HISTORY.AGCM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
   echo "-------------------------------------------------------------------------"
-  echo "Hit ENTER to use Default Tag/Location: (${C2}${HISTORYrc}${CN})"
+  echo "Hit ENTER to use Default Location: (${C2}${HISTORYrc}${CN})"
   set   NUHISTORY  = $<
   if( .$NUHISTORY != . ) set HISTORYrc = $NUHISTORY
-  if( -e $BINDIR/HISTORY.rc.hold ) /bin/mv -f $BINDIR/HISTORY.rc.hold $BINDIR/HISTORY.rc.tmpl
-  if( -e $BINDIR/HISTORY.rc.tmpl ) /bin/mv -f $BINDIR/HISTORY.rc.tmpl $BINDIR/HISTORY.rc.hold
+
+  set TMPHIST = `mktemp`
 
   if( "$HISTORYrc" == "Current" ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/HISTORY.AGCM.rc.tmpl $BINDIR/HISTORY.rc.tmpl
+            /bin/cp -f $ETCDIR/HISTORY.AGCM.rc.tmpl $TMPHIST
   endif
 
   if( "$HISTORYrc" != "Current" ) then
@@ -1462,27 +1462,28 @@ while( $check == FALSE )
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/$HISTORYrc $BINDIR/HISTORY.rc.tmp1
+            set TMPHIST1 = `mktemp`
+            /bin/cp -f $ETCDIR/$HISTORYrc $TMPHIST1
 
-            set  EXPID_old = `grep  "EXPID:" $BINDIR/HISTORY.rc.tmp1 | cut -d: -f2`
-            set EXPDSC_old = `grep "EXPDSC:" $BINDIR/HISTORY.rc.tmp1 | cut -d: -f2`
+            set  EXPID_old = `grep  "EXPID:" $TMPHIST1 | cut -d: -f2`
+            set EXPDSC_old = `grep "EXPDSC:" $TMPHIST1 | cut -d: -f2`
 
-            /bin/rm -f command
+            set  TMPCMD = `mktemp`
             set  string = "EXPID:"
-            echo cat $BINDIR/HISTORY.rc.tmp1 \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-                 \{sub \( \"${EXPID_old}\" , \"${EXPID}\"  \)\;print\} else print\}\' \> $BINDIR/HISTORY.rc.tmpl > command
-            chmod +x   command
-                     ./command
-            /bin/rm -f command
-            /bin/mv -f $BINDIR/HISTORY.rc.tmpl $BINDIR/HISTORY.rc.tmp1
-                   cat $BINDIR/HISTORY.rc.tmp1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $BINDIR/HISTORY.rc.tmpl
-            /bin/rm -f $BINDIR/HISTORY.rc.tmp1
+            echo cat $TMPHIST1 \| awk \'\{if \( \$1 \~ \"${string}\" \) \
+                 \{sub \( \"${EXPID_old}\" , \"${EXPID}\"  \)\;print\} else print\}\' \> $TMPHIST > $TMPCMD
+            chmod +x   $TMPCMD
+                       $TMPCMD
+            /bin/rm -f $TMPCMD
+            /bin/mv -f $TMPHIST $TMPHIST1
+                   cat $TMPHIST1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $TMPHIST
+            /bin/rm -f $TMPHIST1
 
        else if( -e $HISTORYrc/HISTORY.AGCM.rc.tmpl ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $HISTORYrc/HISTORY.AGCM.rc.tmpl $BINDIR/HISTORY.rc.tmpl
+            /bin/cp -f $HISTORYrc/HISTORY.AGCM.rc.tmpl $TMPHIST
        else
            echo "This condition is based on updating HISTORY.AGCM.rc.tmpl with CVS"
            echo "This has no equivalent in git at present. Please contact Matt"
@@ -2097,14 +2098,16 @@ endif
 
 echo " "
 
-# Operate on files in BINDIR
+# Operate on files in ETCDIR
 
 foreach FILE ($FILES)
 
    /bin/rm -f $HOMDIR/tmpfile
    /bin/rm -f $HOMDIR/$FILE
 
-   if (      -e $BINDIR/$FILE ) then
+   if ( $FILE == "HISTORY.rc.tmpl" ) then
+      cat            $TMPHIST > $HOMDIR/tmpfile
+   else if ( -e $BINDIR/$FILE ) then
       cat       $BINDIR/$FILE > $HOMDIR/tmpfile
    else if ( -e $ETCDIR/$FILE ) then
       cat       $ETCDIR/$FILE > $HOMDIR/tmpfile
@@ -2128,11 +2131,7 @@ if ($GPU == "TRUE") then
 /bin/rm -f $HOMDIR/GPUEND.commands
 endif
 
-if(     -e $BINDIR/HISTORY.rc.hold ) then
-/bin/mv -f $BINDIR/HISTORY.rc.hold $BINDIR/HISTORY.rc.tmpl
-else
-/bin/rm -f $BINDIR/HISTORY.rc.tmpl
-endif
+/bin/rm -f $TMPHIST
 
 echo $HOMDIR > $EXPDIR/.HOMDIR
 echo " "
@@ -2152,7 +2151,6 @@ set LSTRATCHEM = FALSE
 set RSNAMES = "LH2O LMAM LCARMA LGMICHEM LSTRATCHEM"
 set RSTYPES = "INTERNAL IMPORT"
 
-/bin/rm -f command
 set FILE = AGCM.rc.tmpl
 
 if( -e $HOMDIR/$FILE ) set LOCDIR = $HOMDIR
@@ -2163,14 +2161,15 @@ foreach rsname ($RSNAMES)
    set  test = `eval echo \$$rsname`
    if( $test == FALSE ) then
        foreach type ($RSTYPES)
+          set  TMPCMD = `mktemp`
           set  string = ${name}_${type}
           /bin/rm -f $LOCDIR/$FILE.tmp
           /bin/mv -f $LOCDIR/$FILE $LOCDIR/$FILE.tmp
           echo cat   $LOCDIR/$FILE.tmp \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-               \{sub \( \/${string}\/ ,\"\#${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > command
-          chmod +x   command
-          ./command
-          /bin/rm -f command
+               \{sub \( \/${string}\/ ,\"\#${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > $TMPCMD
+          chmod +x   $TMPCMD
+                     $TMPCMD
+          /bin/rm -f $TMPCMD
        end
    endif
 end

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1533,20 +1533,20 @@ while( $check == FALSE )
           echo $HISTORYrc > $HOME/.HISTORYrc
   endif
 
-  echo "Enter the tag or directory (/filename) of the ${C1}HISTORY_GEOSCHEMCHEM.rc.tmpl${CN} to use"
-  echo "(To use ${C1}HISTORY_GEOSCHEMCHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
+  echo "Enter the directory (/filename) of the ${C1}HISTORY.GEOSCHEMCHEM.rc.tmpl${CN} to use"
+  echo "(To use ${C1}HISTORY.GEOSCHEMCHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
   echo "-------------------------------------------------------------------------"
-  echo "Hit ENTER to use Default Tag/Location: (${C2}${HISTORYrc}${CN})"
+  echo "Hit ENTER to use Default Location: (${C2}${HISTORYrc}${CN})"
   set   NUHISTORY  = $<
   if( .$NUHISTORY != . ) set HISTORYrc = $NUHISTORY
-  if( -e $BINDIR/HISTORY.rc.hold ) /bin/mv -f $BINDIR/HISTORY.rc.hold $BINDIR/HISTORY.rc.tmpl
-  if( -e $BINDIR/HISTORY.rc.tmpl ) /bin/mv -f $BINDIR/HISTORY.rc.tmpl $BINDIR/HISTORY.rc.hold
+
+  set TMPHIST = `mktemp`
 
   if( "$HISTORYrc" == "Current" ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/HISTORY_GEOSCHEMCHEM.rc.tmpl $BINDIR/HISTORY.rc.tmpl
+            /bin/cp -f $ETCDIR/HISTORY.GEOSCHEMCHEM.rc.tmpl $TMPHIST
   endif
 
   if( "$HISTORYrc" != "Current" ) then
@@ -1554,29 +1554,30 @@ while( $check == FALSE )
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/$HISTORYrc $BINDIR/HISTORY.rc.tmp1
+            set TMPHIST1 = `mktemp`
+            /bin/cp -f $ETCDIR/$HISTORYrc $TMPHIST1
 
-            set  EXPID_old = `grep  "EXPID:" $BINDIR/HISTORY.rc.tmp1 | cut -d: -f2`
-            set EXPDSC_old = `grep "EXPDSC:" $BINDIR/HISTORY.rc.tmp1 | cut -d: -f2`
+            set  EXPID_old = `grep  "EXPID:" $TMPHIST1 | cut -d: -f2`
+            set EXPDSC_old = `grep "EXPDSC:" $TMPHIST1 | cut -d: -f2`
 
-            /bin/rm -f command
+            set  TMPCMD = `mktemp`
             set  string = "EXPID:"
-            echo cat $BINDIR/HISTORY.rc.tmp1 \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-                 \{sub \( \"${EXPID_old}\" , \"${EXPID}\"  \)\;print\} else print\}\' \> $BINDIR/HISTORY.rc.tmpl > command
-            chmod +x   command
-                     ./command
-            /bin/rm -f command
-            /bin/mv -f $BINDIR/HISTORY.rc.tmpl $BINDIR/HISTORY.rc.tmp1
-                   cat $BINDIR/HISTORY.rc.tmp1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $BINDIR/HISTORY.rc.tmpl
-            /bin/rm -f $BINDIR/HISTORY.rc.tmp1
+            echo cat $TMPHIST1 \| awk \'\{if \( \$1 \~ \"${string}\" \) \
+                 \{sub \( \"${EXPID_old}\" , \"${EXPID}\"  \)\;print\} else print\}\' \> $TMPHIST > $TMPCMD
+            chmod +x   $TMPCMD
+                       $TMPCMD
+            /bin/rm -f $TMPCMD
+            /bin/mv -f $TMPHIST $TMPHIST1
+                   cat $TMPHIST1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $TMPHIST
+            /bin/rm -f $TMPHIST1
 
-       else if( -e $HISTORYrc/HISTORY_GEOSCHEMCHEM.rc.tmpl ) then
+       else if( -e $HISTORYrc/HISTORY.GEOSCHEMCHEM.rc.tmpl ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $HISTORYrc/HISTORY_GEOSCHEMCHEM.rc.tmpl $BINDIR/HISTORY.rc.tmpl
+            /bin/cp -f $HISTORYrc/HISTORY.GEOSCHEMCHEM.rc.tmpl $TMPHIST
        else
-           echo "This condition is based on updating HISTORY.AGCM.rc.tmpl with CVS"
+           echo "This condition is based on updating HISTORY.GEOSCHEMCHEM.rc.tmpl with CVS"
            echo "This has no equivalent in git at present. Please contact Matt"
            echo "Thompson or Larry Takacs to help resolve this."
            exit 2
@@ -2193,14 +2194,16 @@ endif
 
 echo " "
 
-# Operate on files in BINDIR
+# Operate on files in ETCDIR
 
 foreach FILE ($FILES)
 
    /bin/rm -f $HOMDIR/tmpfile
    /bin/rm -f $HOMDIR/$FILE
 
-   if (      -e $BINDIR/$FILE ) then
+   if ( $FILE == "HISTORY.rc.tmpl" ) then
+      cat            $TMPHIST > $HOMDIR/tmpfile
+   else if ( -e $BINDIR/$FILE ) then
       cat       $BINDIR/$FILE > $HOMDIR/tmpfile
    else if ( -e $ETCDIR/$FILE ) then
       cat       $ETCDIR/$FILE > $HOMDIR/tmpfile
@@ -2223,6 +2226,8 @@ if ($GPU == "TRUE") then
 /bin/rm -f $HOMDIR/GPUSTART.commands
 /bin/rm -f $HOMDIR/GPUEND.commands
 endif
+
+/bin/rm -f $TMPHIST
 
 # Add 5 snippets to the run script, specialized for GEOS-Chem
 # -----------------------------------------------------------
@@ -2332,7 +2337,6 @@ endif
 set RSNAMES = "LH2O LMAM LCARMA LPCHEM LSTRATCHEM LGMICHEM LGEOSCHEMCHEM LHEMCO LGOCART LGOCART_DATA"
 set RSTYPES = "INTERNAL IMPORT"
 
-/bin/rm -f command
 set FILE = AGCM.rc.tmpl
 
 if( -e $HOMDIR/$FILE ) set LOCDIR = $HOMDIR
@@ -2345,20 +2349,21 @@ foreach rsname ($RSNAMES)
    if( $name == GOCART_DATA ) set name = GOCART.data
 
    foreach type ($RSTYPES)
+      set  TMPCMD = `mktemp`
       set  string = ${name}_${type}
       /bin/rm -f $LOCDIR/$FILE.tmp
       /bin/mv -f $LOCDIR/$FILE $LOCDIR/$FILE.tmp
       if( $test == TRUE ) then
          echo cat   $LOCDIR/$FILE.tmp \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-              \{sub \( \/\#${string}\/ ,\"${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > command
+              \{sub \( \/\#${string}\/ ,\"${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > $TMPCMD
       endif
       if( $test == FALSE ) then
          echo cat   $LOCDIR/$FILE.tmp \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-              \{sub \( \/${string}\/ ,\"\#${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > command
+              \{sub \( \/${string}\/ ,\"\#${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > $TMPCMD
       endif
-      chmod +x   command
-      ./command
-      /bin/rm -f command
+      chmod +x   $TMPCMD
+                 $TMPCMD
+      /bin/rm -f $TMPCMD
    end
 end
 /bin/rm -f $LOCDIR/$FILE.tmp

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1533,8 +1533,8 @@ while( $check == FALSE )
           echo $HISTORYrc > $HOME/.HISTORYrc
   endif
 
-  echo "Enter the directory (/filename) of the ${C1}HISTORY.GEOSCHEMCHEM.rc.tmpl${CN} to use"
-  echo "(To use ${C1}HISTORY.GEOSCHEMCHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
+  echo "Enter the directory (/filename) of the ${C1}HISTORY_GEOSCHEMCHEM.rc.tmpl${CN} to use"
+  echo "(To use ${C1}HISTORY_GEOSCHEMCHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
   echo "-------------------------------------------------------------------------"
   echo "Hit ENTER to use Default Location: (${C2}${HISTORYrc}${CN})"
   set   NUHISTORY  = $<
@@ -1546,7 +1546,7 @@ while( $check == FALSE )
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/HISTORY.GEOSCHEMCHEM.rc.tmpl $TMPHIST
+            /bin/cp -f $ETCDIR/HISTORY_GEOSCHEMCHEM.rc.tmpl $TMPHIST
   endif
 
   if( "$HISTORYrc" != "Current" ) then
@@ -1571,13 +1571,13 @@ while( $check == FALSE )
                    cat $TMPHIST1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $TMPHIST
             /bin/rm -f $TMPHIST1
 
-       else if( -e $HISTORYrc/HISTORY.GEOSCHEMCHEM.rc.tmpl ) then
+       else if( -e $HISTORYrc/HISTORY_GEOSCHEMCHEM.rc.tmpl ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $HISTORYrc/HISTORY.GEOSCHEMCHEM.rc.tmpl $TMPHIST
+            /bin/cp -f $HISTORYrc/HISTORY_GEOSCHEMCHEM.rc.tmpl $TMPHIST
        else
-           echo "This condition is based on updating HISTORY.GEOSCHEMCHEM.rc.tmpl with CVS"
+           echo "This condition is based on updating HISTORY_GEOSCHEMCHEM.rc.tmpl with CVS"
            echo "This has no equivalent in git at present. Please contact Matt"
            echo "Thompson or Larry Takacs to help resolve this."
            exit 2

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1672,8 +1672,8 @@ while( $check == FALSE )
           echo $HISTORYrc > $HOME/.HISTORYrc
   endif
 
-  echo "Enter the directory (/filename) of the ${C1}HISTORY.GMICHEM.rc.tmpl${CN} to use"
-  echo "(To use ${C1}HISTORY.GMICHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
+  echo "Enter the directory (/filename) of the ${C1}HISTORY_GMICHEM.rc.tmpl${CN} to use"
+  echo "(To use ${C1}HISTORY_GMICHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
   echo "-------------------------------------------------------------------------"
   echo "Hit ENTER to use Default Location: (${C2}${HISTORYrc}${CN})"
   set   NUHISTORY  = $<
@@ -1685,7 +1685,7 @@ while( $check == FALSE )
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/HISTORY.GMICHEM.rc.tmpl $TMPHIST
+            /bin/cp -f $ETCDIR/HISTORY_GMICHEM.rc.tmpl $TMPHIST
   endif
 
   if( "$HISTORYrc" != "Current" ) then
@@ -1710,13 +1710,13 @@ while( $check == FALSE )
                    cat $TMPHIST1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $TMPHIST
             /bin/rm -f $TMPHIST1
 
-       else if( -e $HISTORYrc/HISTORY.GMICHEM.rc.tmpl ) then
+       else if( -e $HISTORYrc/HISTORY_GMICHEM.rc.tmpl ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $HISTORYrc/HISTORY.GMICHEM.rc.tmpl $TMPHIST
+            /bin/cp -f $HISTORYrc/HISTORY_GMICHEM.rc.tmpl $TMPHIST
        else
-           echo "This condition is based on updating HISTORY.GMICHEM.rc.tmpl with CVS"
+           echo "This condition is based on updating HISTORY_GMICHEM.rc.tmpl with CVS"
            echo "This has no equivalent in git at present. Please contact Matt"
            echo "Thompson or Larry Takacs to help resolve this."
            exit 2

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1672,20 +1672,20 @@ while( $check == FALSE )
           echo $HISTORYrc > $HOME/.HISTORYrc
   endif
 
-  echo "Enter the tag or directory (/filename) of the ${C1}HISTORY_GMICHEM.rc.tmpl${CN} to use"
-  echo "(To use ${C1}HISTORY_GMICHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
+  echo "Enter the directory (/filename) of the ${C1}HISTORY.GMICHEM.rc.tmpl${CN} to use"
+  echo "(To use ${C1}HISTORY.GMICHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
   echo "-------------------------------------------------------------------------"
-  echo "Hit ENTER to use Default Tag/Location: (${C2}${HISTORYrc}${CN})"
+  echo "Hit ENTER to use Default Location: (${C2}${HISTORYrc}${CN})"
   set   NUHISTORY  = $<
   if( .$NUHISTORY != . ) set HISTORYrc = $NUHISTORY
-  if( -e $BINDIR/HISTORY.rc.hold ) /bin/mv -f $BINDIR/HISTORY.rc.hold $BINDIR/HISTORY.rc.tmpl
-  if( -e $BINDIR/HISTORY.rc.tmpl ) /bin/mv -f $BINDIR/HISTORY.rc.tmpl $BINDIR/HISTORY.rc.hold
+
+  set TMPHIST = `mktemp`
 
   if( "$HISTORYrc" == "Current" ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/HISTORY_GMICHEM.rc.tmpl $BINDIR/HISTORY.rc.tmpl
+            /bin/cp -f $ETCDIR/HISTORY.GMICHEM.rc.tmpl $TMPHIST
   endif
 
   if( "$HISTORYrc" != "Current" ) then
@@ -1693,29 +1693,30 @@ while( $check == FALSE )
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/$HISTORYrc $BINDIR/HISTORY.rc.tmp1
+            set TMPHIST1 = `mktemp`
+            /bin/cp -f $ETCDIR/$HISTORYrc $TMPHIST1
 
-            set  EXPID_old = `grep  "EXPID:" $BINDIR/HISTORY.rc.tmp1 | cut -d: -f2`
-            set EXPDSC_old = `grep "EXPDSC:" $BINDIR/HISTORY.rc.tmp1 | cut -d: -f2`
+            set  EXPID_old = `grep  "EXPID:" $TMPHIST1 | cut -d: -f2`
+            set EXPDSC_old = `grep "EXPDSC:" $TMPHIST1 | cut -d: -f2`
 
-            /bin/rm -f command
+            set  TMPCMD = `mktemp`
             set  string = "EXPID:"
-            echo cat $BINDIR/HISTORY.rc.tmp1 \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-                 \{sub \( \"${EXPID_old}\" , \"${EXPID}\"  \)\;print\} else print\}\' \> $BINDIR/HISTORY.rc.tmpl > command
-            chmod +x   command
-                     ./command
-            /bin/rm -f command
-            /bin/mv -f $BINDIR/HISTORY.rc.tmpl $BINDIR/HISTORY.rc.tmp1
-                   cat $BINDIR/HISTORY.rc.tmp1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $BINDIR/HISTORY.rc.tmpl
-            /bin/rm -f $BINDIR/HISTORY.rc.tmp1
+            echo cat $TMPHIST1 \| awk \'\{if \( \$1 \~ \"${string}\" \) \
+                 \{sub \( \"${EXPID_old}\" , \"${EXPID}\"  \)\;print\} else print\}\' \> $TMPHIST > $TMPCMD
+            chmod +x   $TMPCMD
+                       $TMPCMD
+            /bin/rm -f $TMPCMD
+            /bin/mv -f $TMPHIST $TMPHIST1
+                   cat $TMPHIST1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $TMPHIST
+            /bin/rm -f $TMPHIST1
 
-       else if( -e $HISTORYrc/HISTORY_GMICHEM.rc.tmpl ) then
+       else if( -e $HISTORYrc/HISTORY.GMICHEM.rc.tmpl ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $HISTORYrc/HISTORY_GMICHEM.rc.tmpl $BINDIR/HISTORY.rc.tmpl
+            /bin/cp -f $HISTORYrc/HISTORY.GMICHEM.rc.tmpl $TMPHIST
        else
-           echo "This condition is based on updating HISTORY.AGCM.rc.tmpl with CVS"
+           echo "This condition is based on updating HISTORY.GMICHEM.rc.tmpl with CVS"
            echo "This has no equivalent in git at present. Please contact Matt"
            echo "Thompson or Larry Takacs to help resolve this."
            exit 2
@@ -2337,14 +2338,16 @@ endif
 
 echo " "
 
-# Operate on files in BINDIR
+# Operate on files in ETCDIR
 
 foreach FILE ($FILES)
 
    /bin/rm -f $HOMDIR/tmpfile
    /bin/rm -f $HOMDIR/$FILE
 
-   if (      -e $BINDIR/$FILE ) then
+   if ( $FILE == "HISTORY.rc.tmpl" ) then
+      cat            $TMPHIST > $HOMDIR/tmpfile
+   else if ( -e $BINDIR/$FILE ) then
       cat       $BINDIR/$FILE > $HOMDIR/tmpfile
    else if ( -e $ETCDIR/$FILE ) then
       cat       $ETCDIR/$FILE > $HOMDIR/tmpfile
@@ -2368,11 +2371,7 @@ if ($GPU == "TRUE") then
 /bin/rm -f $HOMDIR/GPUEND.commands
 endif
 
-if(     -e $BINDIR/HISTORY.rc.hold ) then
-/bin/mv -f $BINDIR/HISTORY.rc.hold $BINDIR/HISTORY.rc.tmpl
-else
-/bin/rm -f $BINDIR/HISTORY.rc.tmpl
-endif
+/bin/rm -f $TMPHIST
 
 echo $HOMDIR > $EXPDIR/.HOMDIR
 echo " "
@@ -2401,7 +2400,6 @@ endif
 set RSNAMES = "LH2O LMAM LCARMA LPCHEM LSTRATCHEM LGMICHEM LGEOSCHEMCHEM LHEMCO LGOCART LGOCART_DATA"
 set RSTYPES = "INTERNAL IMPORT"
 
-/bin/rm -f command
 set FILE = AGCM.rc.tmpl
 
 if( -e $HOMDIR/$FILE ) set LOCDIR = $HOMDIR
@@ -2414,20 +2412,21 @@ foreach rsname ($RSNAMES)
    if( $name == GOCART_DATA ) set name = GOCART.data
 
    foreach type ($RSTYPES)
+      set  TMPCMD = `mktemp`
       set  string = ${name}_${type}
       /bin/rm -f $LOCDIR/$FILE.tmp
       /bin/mv -f $LOCDIR/$FILE $LOCDIR/$FILE.tmp
       if( $test == TRUE ) then
          echo cat   $LOCDIR/$FILE.tmp \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-              \{sub \( \/\#${string}\/ ,\"${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > command
+              \{sub \( \/\#${string}\/ ,\"${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > $TMPCMD
       endif
       if( $test == FALSE ) then
          echo cat   $LOCDIR/$FILE.tmp \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-              \{sub \( \/${string}\/ ,\"\#${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > command
+              \{sub \( \/${string}\/ ,\"\#${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > $TMPCMD
       endif
-      chmod +x   command
-      ./command
-      /bin/rm -f command
+      chmod +x   $TMPCMD
+                 $TMPCMD
+      /bin/rm -f $TMPCMD
    end
 end
 /bin/rm -f $LOCDIR/$FILE.tmp

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1524,20 +1524,20 @@ while( $check == FALSE )
           echo $HISTORYrc > $HOME/.HISTORYrc
   endif
 
-  echo "Enter the tag or directory (/filename) of the ${C1}HISTORY_STRATCHEM.rc.tmpl${CN} to use"
-  echo "(To use ${C1}HISTORY_STRATCHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
+  echo "Enter the directory (/filename) of the ${C1}HISTORY.STRATCHEM.rc.tmpl${CN} to use"
+  echo "(To use ${C1}HISTORY.STRATCHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
   echo "-------------------------------------------------------------------------"
-  echo "Hit ENTER to use Default Tag/Location: (${C2}${HISTORYrc}${CN})"
+  echo "Hit ENTER to use Default Location: (${C2}${HISTORYrc}${CN})"
   set   NUHISTORY  = $<
   if( .$NUHISTORY != . ) set HISTORYrc = $NUHISTORY
-  if( -e $BINDIR/HISTORY.rc.hold ) /bin/mv -f $BINDIR/HISTORY.rc.hold $BINDIR/HISTORY.rc.tmpl
-  if( -e $BINDIR/HISTORY.rc.tmpl ) /bin/mv -f $BINDIR/HISTORY.rc.tmpl $BINDIR/HISTORY.rc.hold
+
+  set TMPHIST = `mktemp`
 
   if( "$HISTORYrc" == "Current" ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/HISTORY_STRATCHEM.rc.tmpl $BINDIR/HISTORY.rc.tmpl
+            /bin/cp -f $ETCDIR/HISTORY.STRATCHEM.rc.tmpl $TMPHIST
   endif
 
   if( "$HISTORYrc" != "Current" ) then
@@ -1545,29 +1545,30 @@ while( $check == FALSE )
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/$HISTORYrc $BINDIR/HISTORY.rc.tmp1
+            set TMPHIST1 = `mktemp`
+            /bin/cp -f $ETCDIR/$HISTORYrc $TMPHIST1
 
-            set  EXPID_old = `grep  "EXPID:" $BINDIR/HISTORY.rc.tmp1 | cut -d: -f2`
-            set EXPDSC_old = `grep "EXPDSC:" $BINDIR/HISTORY.rc.tmp1 | cut -d: -f2`
+            set  EXPID_old = `grep  "EXPID:" $TMPHIST1 | cut -d: -f2`
+            set EXPDSC_old = `grep "EXPDSC:" $TMPHIST1 | cut -d: -f2`
 
-            /bin/rm -f command
+            set  TMPCMD = `mktemp`
             set  string = "EXPID:"
-            echo cat $BINDIR/HISTORY.rc.tmp1 \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-                 \{sub \( \"${EXPID_old}\" , \"${EXPID}\"  \)\;print\} else print\}\' \> $BINDIR/HISTORY.rc.tmpl > command
-            chmod +x   command
-                     ./command
-            /bin/rm -f command
-            /bin/mv -f $BINDIR/HISTORY.rc.tmpl $BINDIR/HISTORY.rc.tmp1
-                   cat $BINDIR/HISTORY.rc.tmp1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $BINDIR/HISTORY.rc.tmpl
-            /bin/rm -f $BINDIR/HISTORY.rc.tmp1
+            echo cat $TMPHIST1 \| awk \'\{if \( \$1 \~ \"${string}\" \) \
+                 \{sub \( \"${EXPID_old}\" , \"${EXPID}\"  \)\;print\} else print\}\' \> $TMPHIST > $TMPCMD
+            chmod +x   $TMPCMD
+                       $TMPCMD
+            /bin/rm -f $TMPCMD
+            /bin/mv -f $TMPHIST $TMPHIST1
+                   cat $TMPHIST1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $TMPHIST
+            /bin/rm -f $TMPHIST1
 
-       else if( -e $HISTORYrc/HISTORY_STRATCHEM.rc.tmpl ) then
+       else if( -e $HISTORYrc/HISTORY.STRATCHEM.rc.tmpl ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $HISTORYrc/HISTORY_STRATCHEM.rc.tmpl $BINDIR/HISTORY.rc.tmpl
+            /bin/cp -f $HISTORYrc/HISTORY.STRATCHEM.rc.tmpl $TMPHIST
        else
-           echo "This condition is based on updating HISTORY_STRATCHEM.rc.tmpl with CVS"
+           echo "This condition is based on updating HISTORY.STRATCHEM.rc.tmpl with CVS"
            echo "This has no equivalent in git at present. Please contact Matt"
            echo "Thompson or Larry Takacs to help resolve this."
            exit 2
@@ -2183,14 +2184,16 @@ endif
 
 echo " "
 
-# Operate on files in BINDIR
+# Operate on files in ETCDIR
 
 foreach FILE ($FILES)
 
    /bin/rm -f $HOMDIR/tmpfile
    /bin/rm -f $HOMDIR/$FILE
 
-   if (      -e $BINDIR/$FILE ) then
+   if ( $FILE == "HISTORY.rc.tmpl" ) then
+      cat            $TMPHIST > $HOMDIR/tmpfile
+   else if ( -e $BINDIR/$FILE ) then
       cat       $BINDIR/$FILE > $HOMDIR/tmpfile
    else if ( -e $ETCDIR/$FILE ) then
       cat       $ETCDIR/$FILE > $HOMDIR/tmpfile
@@ -2214,11 +2217,7 @@ if ($GPU == "TRUE") then
 /bin/rm -f $HOMDIR/GPUEND.commands
 endif
 
-if(     -e $BINDIR/HISTORY.rc.hold ) then
-/bin/mv -f $BINDIR/HISTORY.rc.hold $BINDIR/HISTORY.rc.tmpl
-else
-/bin/rm -f $BINDIR/HISTORY.rc.tmpl
-endif
+/bin/rm -f $TMPHIST
 
 echo $HOMDIR > $EXPDIR/.HOMDIR
 echo " "
@@ -2247,7 +2246,6 @@ endif
 set RSNAMES = "LH2O LMAM LCARMA LPCHEM LSTRATCHEM LGMICHEM LGEOSCHEMCHEM LHEMCO LGOCART LGOCART_DATA"
 set RSTYPES = "INTERNAL IMPORT"
 
-/bin/rm -f command
 set FILE = AGCM.rc.tmpl
 
 if( -e $HOMDIR/$FILE ) set LOCDIR = $HOMDIR
@@ -2260,20 +2258,21 @@ foreach rsname ($RSNAMES)
    if( $name == GOCART_DATA ) set name = GOCART.data
 
    foreach type ($RSTYPES)
+      set  TMPCMD = `mktemp`
       set  string = ${name}_${type}
       /bin/rm -f $LOCDIR/$FILE.tmp
       /bin/mv -f $LOCDIR/$FILE $LOCDIR/$FILE.tmp
       if( $test == TRUE ) then
          echo cat   $LOCDIR/$FILE.tmp \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-              \{sub \( \/\#${string}\/ ,\"${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > command
+              \{sub \( \/\#${string}\/ ,\"${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > $TMPCMD
       endif
       if( $test == FALSE ) then
          echo cat   $LOCDIR/$FILE.tmp \| awk \'\{if \( \$1 \~ \"${string}\" \) \
-              \{sub \( \/${string}\/ ,\"\#${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > command
+              \{sub \( \/${string}\/ ,\"\#${string}\"  \)\;print\} else print\}\' \> $LOCDIR/$FILE > $TMPCMD
       endif
-      chmod +x   command
-      ./command
-      /bin/rm -f command
+      chmod +x   $TMPCMD
+                 $TMPCMD
+      /bin/rm -f $TMPCMD
    end
 end
 /bin/rm -f $LOCDIR/$FILE.tmp

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1524,8 +1524,8 @@ while( $check == FALSE )
           echo $HISTORYrc > $HOME/.HISTORYrc
   endif
 
-  echo "Enter the directory (/filename) of the ${C1}HISTORY.STRATCHEM.rc.tmpl${CN} to use"
-  echo "(To use ${C1}HISTORY.STRATCHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
+  echo "Enter the directory (/filename) of the ${C1}HISTORY_STRATCHEM.rc.tmpl${CN} to use"
+  echo "(To use ${C1}HISTORY_STRATCHEM.rc.tmpl${CN} from current build, Type:  ${C2}Current${CN}         )"
   echo "-------------------------------------------------------------------------"
   echo "Hit ENTER to use Default Location: (${C2}${HISTORYrc}${CN})"
   set   NUHISTORY  = $<
@@ -1537,7 +1537,7 @@ while( $check == FALSE )
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $ETCDIR/HISTORY.STRATCHEM.rc.tmpl $TMPHIST
+            /bin/cp -f $ETCDIR/HISTORY_STRATCHEM.rc.tmpl $TMPHIST
   endif
 
   if( "$HISTORYrc" != "Current" ) then
@@ -1562,13 +1562,13 @@ while( $check == FALSE )
                    cat $TMPHIST1 | sed -e "s|${EXPDSC_old}|${EXPDSC}|g" > $TMPHIST
             /bin/rm -f $TMPHIST1
 
-       else if( -e $HISTORYrc/HISTORY.STRATCHEM.rc.tmpl ) then
+       else if( -e $HISTORYrc/HISTORY_STRATCHEM.rc.tmpl ) then
             set check = TRUE
             if( -e $HOME/.HISTORYrc ) /bin/rm $HOME/.HISTORYrc
             echo $HISTORYrc >                 $HOME/.HISTORYrc
-            /bin/cp -f $HISTORYrc/HISTORY.STRATCHEM.rc.tmpl $TMPHIST
+            /bin/cp -f $HISTORYrc/HISTORY_STRATCHEM.rc.tmpl $TMPHIST
        else
-           echo "This condition is based on updating HISTORY.STRATCHEM.rc.tmpl with CVS"
+           echo "This condition is based on updating HISTORY_STRATCHEM.rc.tmpl with CVS"
            echo "This has no equivalent in git at present. Please contact Matt"
            echo "Thompson or Larry Takacs to help resolve this."
            exit 2


### PR DESCRIPTION
My testing so far shows that this should allow one user to run `gcm_setup` in another user's `install/bin` directory.

That said, I've only really tested with `gcm_setup` but I've edited the other chem setups as well. Thus, it might be nice for @GEOS-ESM/chemistry-gatekeepers and @GEOS-ESM/geoschemchem-team to take a look and make sure I didn't screw up the GMI, SC, and GEOSChem scripts. I tried to be careful.

Also, this does get rid of the odd `HISTORY.rc.hold` mechanism. @lltakacs isn't sure anyone is actually using it. If it's needed I think I can see how to bring it back. (The ultimate test is to remove the capability and see if anyone complains. My guess? No one will.)