### PR TITLE
Fixes #123. Add commented FOR_IGNORE_EXCEPTIONS

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1781,6 +1781,12 @@ cat > $HOMDIR/SETENV.commands << EOF
    # with binarytile.x and other executables.
    unsetenv PMI_RANK
 
+   # Often when debugging on MPT, the traceback from Intel Fortran
+   # is "absorbed" and only MPT's errors are displayed. To allow the
+   # compiler's traceback to be displayed, uncomment this environment
+   # variable
+   #setenv FOR_IGNORE_EXCEPTIONS false
+
 EOF
 
 else if( $MPI == intelmpi ) then

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1873,6 +1873,12 @@ cat > $HOMDIR/SETENV.commands << EOF
    # with binarytile.x and other executables.
    unsetenv PMI_RANK
 
+   # Often when debugging on MPT, the traceback from Intel Fortran
+   # is "absorbed" and only MPT's errors are displayed. To allow the
+   # compiler's traceback to be displayed, uncomment this environment
+   # variable
+   #setenv FOR_IGNORE_EXCEPTIONS false
+
 EOF
 
 else if( $MPI == intelmpi ) then

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2016,6 +2016,12 @@ cat > $HOMDIR/SETENV.commands << EOF
    # with binarytile.x and other executables.
    unsetenv PMI_RANK
 
+   # Often when debugging on MPT, the traceback from Intel Fortran
+   # is "absorbed" and only MPT's errors are displayed. To allow the
+   # compiler's traceback to be displayed, uncomment this environment
+   # variable
+   #setenv FOR_IGNORE_EXCEPTIONS false
+
 EOF
 
 else if( $MPI == intelmpi ) then

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1864,6 +1864,12 @@ cat > $HOMDIR/SETENV.commands << EOF
    # with binarytile.x and other executables.
    unsetenv PMI_RANK
 
+   # Often when debugging on MPT, the traceback from Intel Fortran
+   # is "absorbed" and only MPT's errors are displayed. To allow the
+   # compiler's traceback to be displayed, uncomment this environment
+   # variable
+   #setenv FOR_IGNORE_EXCEPTIONS false
+
 EOF
 
 else if( $MPI == intelmpi ) then


### PR DESCRIPTION
This commit adds a commented out `setenv` for running with MPT which can help in debugging when Intel's traceback is suppressed by MPT.

Commented out so that current behavior is maintained, but the flag is here for easy enabling