### PR TITLE
Bring chem setup scripts better in line with gcm_setup

### DIFF
--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -710,11 +710,11 @@ if( $AGCM_IM ==  "c12" ) then
      set       DT = 900
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 12
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 2
@@ -734,10 +734,10 @@ if( $AGCM_IM ==  "72" ) then
      set       DT = 900
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000015
      set NUM_SGMT = 20
      if( $OGCM == TRUE ) then
@@ -756,11 +756,11 @@ if( $AGCM_IM ==  "c24" ) then
      set       DT = 900
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 24
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 4
@@ -780,10 +780,10 @@ if( $AGCM_IM ==  "144" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000015
      set NUM_SGMT = 20
      if( $OGCM == TRUE ) then
@@ -802,11 +802,11 @@ if( $AGCM_IM ==  "c48" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 48
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 4
@@ -824,10 +824,10 @@ if( $AGCM_IM ==  "288" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000008
      set NUM_SGMT = 5
      if( $OGCM == TRUE ) then
@@ -846,7 +846,6 @@ if( $AGCM_IM ==  "c90" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set AGCM_IM  = 90
      set AGCM_JM  = `expr $AGCM_IM \* 6`
@@ -861,6 +860,7 @@ if( $AGCM_IM ==  "c90" ) then
      endif
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set HYDROSTATIC = TRUE
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -874,10 +874,10 @@ if( $AGCM_IM ==  "576" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000016
      set NUM_SGMT = 1
      if( $OGCM == TRUE ) then
@@ -896,10 +896,10 @@ if( $AGCM_IM ==  "c180" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 180
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      if( $OGCM == TRUE ) then
@@ -926,10 +926,10 @@ if( $AGCM_IM == "1152" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000005
      set NUM_SGMT = 1
      set NUM_READERS = 4
@@ -951,11 +951,11 @@ if( $AGCM_IM == "c360" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 360
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 12 
@@ -976,11 +976,11 @@ if( $AGCM_IM == "c500" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 500
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 12
@@ -1002,11 +1002,11 @@ if( $AGCM_IM == "c720" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 720
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 16
@@ -1028,11 +1028,11 @@ if( $AGCM_IM == "c1440" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 30 
@@ -1055,9 +1055,11 @@ if( $AGCM_IM == "c768" ) then
      set       DT = 180
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
+     set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = 900
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = $CHEM_DT
      set AGCM_IM  = 768
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 32
@@ -1079,9 +1081,11 @@ if( $AGCM_IM == "c1536" ) then
      set       DT = 90
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
+     set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = 900
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = $CHEM_DT
      set AGCM_IM  = 1536
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 64
@@ -1103,9 +1107,11 @@ if( $AGCM_IM == "c3072" ) then
      set       DT = 45
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
+     set SATSIM_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = 900
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
+#    set  GOCART_DT = $CHEM_DT
      set AGCM_IM  = 3072
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 64
@@ -1208,43 +1214,12 @@ if( $LSM_BCS == "Icarus-NLv3" ) then
     endif
     if( $LSM_CHOICE == 1 ) set HIST_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set HIST_CATCHCN = ""
+    if( $LSM_CHOICE == 1 ) set GCMRUN_CATCHCN = "#DELETE"
+    if( $LSM_CHOICE == 2 ) set GCMRUN_CATCHCN = ""
 else
     set LSM_CHOICE = 1
     set HIST_CATCHCN = "#DELETE"
-endif
-
-
-# Check for Runoff Routing Model
-# ------------------------------
-RRM:
-echo "Do you wish to run ${C1} the Runoff Routing Model${CN}? (Default: ${C2}NO${CN} or ${C2}FALSE${CN})"
-set   RUNRRM  = $<
-if( .$RUNRRM == . ) then
-set   RUNRRM  = FALSE
-else
-set   RUNRRM  = `echo   $RUNRRM | tr "[:lower:]" "[:upper:]"`
-if(  $RUNRRM == "Y"     | \
-     $RUNRRM == "YES"   | \
-     $RUNRRM == "T"     | \
-     $RUNRRM == "TRUE"  ) set RUNRRM = TRUE
-if(  $RUNRRM == "N"     | \
-     $RUNRRM == "NO"    | \
-     $RUNRRM == "F"     | \
-     $RUNRRM == "FALSE" ) set RUNRRM = FALSE
-
-if( $RUNRRM != TRUE & $RUNRRM != FALSE ) then
-echo
-echo "${C1} the Runoff Routing Model${CN} must be set equal to ${C2}TRUE${CN} or ${C2}FALSE${CN}!"
-goto RRM
-else
-echo
-endif
-endif
-
-if( $RUNRRM == TRUE ) then
-    set RUN_ROUTE = 1
-else
-    set RUN_ROUTE = 0
+    set GCMRUN_CATCHCN = "#DELETE"
 endif
 
 #######################################################################
@@ -1409,7 +1384,6 @@ if( $SITE == 'NAS' ) then
               setenv ARCHIVE_P  "PBS -l select=1:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}"            # PE Configuration for gcm_archive.j
               setenv CONVERT_P  "PBS -l select=${CNV_NX}:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}"    # PE Configuration for gcm_convert.j
               setenv    MOVE_P  "PBS -l select=1:ncpus=1"                                                                      # PE Configuration for gcm_moveplot.j
-
 
               setenv BCSDIR     /nobackup/gmao_SIteam/ModelData/bcs/${LSM_BCS}/${LSM_BCS}_${OCEAN_TAG}      # location of Boundary Conditions
               setenv REPLAY_ANA_EXPID    ONLY_MERRA2_SUPPORTED                                              # Default Analysis Experiment for REPLAY
@@ -2066,6 +2040,7 @@ s?>>>FVLATLON<<<?$FVLATLON?g
 s?>>>HIST_GOCART<<<?$HIST_GOCART?g
 s?>>>OSTIA<<<?$OSTIA?g
 s?>>>HIST_CATCHCN<<<?$HIST_CATCHCN?g
+s?>>>GCMRUN_CATCHCN<<<?$GCMRUN_CATCHCN?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
 
@@ -2092,6 +2067,8 @@ s^@DYCORE^$DYCORE^g
 s^@AGCM_GRIDNAME^$AGCM_GRIDNAME^g
 s^@OGCM_GRIDNAME^$OGCM_GRIDNAME^g
 
+s/@GOCART_DT/$DT/g
+
 s?@IS_FCST?$IS_FCST?g
 s^@BOOT^YES^g
 s^@BCSRES^$BCSRES^g
@@ -2103,7 +2080,6 @@ s^@TILEBIN^$TILEBIN^g
 s/@DT/$DT/g
 s/@SOLAR_DT/$SOLAR_DT/g
 s/@IRRAD_DT/$IRRAD_DT/g
-s/@GOCART_DT/$DT/g
 s/@SATSIM_DT/$SATSIM_DT/g
 s/@OCEAN_DT/$OCEAN_DT/g
 s/@CHEM_DT/$CHEM_DT/g
@@ -2151,7 +2127,6 @@ s/@USE_SKIN_LAYER/1/g
 s/@ANALYZE_TS/0/g
 
 s/@LSM_CHOICE/$LSM_CHOICE/g
-s/@RUN_ROUTE/$RUN_ROUTE/g
 
 s?@CPEXEC?$CPEXEC?g
 s?@TAREXEC?$TAREXEC?g

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1287,43 +1287,12 @@ if( $LSM_BCS == "Icarus-NLv3" ) then
     endif
     if( $LSM_CHOICE == 1 ) set HIST_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set HIST_CATCHCN = ""
+    if( $LSM_CHOICE == 1 ) set GCMRUN_CATCHCN = "#DELETE"
+    if( $LSM_CHOICE == 2 ) set GCMRUN_CATCHCN = ""
 else
     set LSM_CHOICE = 1
     set HIST_CATCHCN = "#DELETE"
-endif
-
-
-# Check for Runoff Routing Model
-# ------------------------------
-RRM:
-echo "Do you wish to run ${C1} the Runoff Routing Model${CN}? (Default: ${C2}NO${CN} or ${C2}FALSE${CN})"
-set   RUNRRM  = $<
-if( .$RUNRRM == . ) then
-set   RUNRRM  = FALSE
-else
-set   RUNRRM  = `echo   $RUNRRM | tr "[:lower:]" "[:upper:]"`
-if(  $RUNRRM == "Y"     | \
-     $RUNRRM == "YES"   | \
-     $RUNRRM == "T"     | \
-     $RUNRRM == "TRUE"  ) set RUNRRM = TRUE
-if(  $RUNRRM == "N"     | \
-     $RUNRRM == "NO"    | \
-     $RUNRRM == "F"     | \
-     $RUNRRM == "FALSE" ) set RUNRRM = FALSE
-
-if( $RUNRRM != TRUE & $RUNRRM != FALSE ) then
-echo
-echo "${C1} the Runoff Routing Model${CN} must be set equal to ${C2}TRUE${CN} or ${C2}FALSE${CN}!"
-goto RRM
-else
-echo
-endif
-endif
-
-if( $RUNRRM == TRUE ) then
-    set RUN_ROUTE = 1
-else
-    set RUN_ROUTE = 0
+    set GCMRUN_CATCHCN = "#DELETE"
 endif
 
 #######################################################################
@@ -1544,7 +1513,6 @@ if( $SITE == 'NAS' ) then
               setenv CONVERT_P  "PBS -l select=${CNV_NX}:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}"    # PE Configuration for gcm_convert.j
               setenv    MOVE_P  "PBS -l select=1:ncpus=1"                                                                      # PE Configuration for gcm_moveplot.j
 
-
               setenv BCSDIR     /nobackup/gmao_SIteam/ModelData/bcs/${LSM_BCS}/${LSM_BCS}_${OCEAN_TAG}      # location of Boundary Conditions
               setenv REPLAY_ANA_EXPID    ONLY_MERRA2_SUPPORTED                                              # Default Analysis Experiment for REPLAY
               setenv REPLAY_ANA_LOCATION ONLY_MERRA2_SUPPORTED                                              # Default Analysis Location   for REPLAY
@@ -1561,7 +1529,7 @@ if( $SITE == 'NAS' ) then
               setenv TAREXEC    mtar                                                   # Tar utility for large archives
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
-              setenv BATCH_GROUP "SBATCH --account="                                    # SLURM Syntax for account name
+              setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
@@ -2209,6 +2177,7 @@ s?>>>FVLATLON<<<?$FVLATLON?g
 s?>>>HIST_GOCART<<<?$HIST_GOCART?g
 s?>>>OSTIA<<<?$OSTIA?g
 s?>>>HIST_CATCHCN<<<?$HIST_CATCHCN?g
+s?>>>GCMRUN_CATCHCN<<<?$GCMRUN_CATCHCN?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
 
@@ -2238,6 +2207,7 @@ s^@OGCM_GRIDNAME^$OGCM_GRIDNAME^g
 s^SOLAR_DT: 3600^SOLAR_DT: $SOLAR_DT^
 s^IRRAD_DT: 3600^IRRAD_DT: $IRRAD_DT^
 s^SATSIM_DT: 1800^SATSIM_DT: $SATSIM_DT^
+
 s/@GOCART_DT/$DT/g
 
 s?@IS_FCST?$IS_FCST?g
@@ -2295,7 +2265,6 @@ s/@USE_SKIN_LAYER/1/g
 s/@ANALYZE_TS/0/g
 
 s/@LSM_CHOICE/$LSM_CHOICE/g
-s/@RUN_ROUTE/$RUN_ROUTE/g
 
 s?@CPEXEC?$CPEXEC?g
 s?@TAREXEC?$TAREXEC?g
@@ -2529,14 +2498,14 @@ if( $OGCM == TRUE ) if(! -e $EXPDIR/RESTART ) mkdir -p $EXPDIR/RESTART
 
 if( $OGCM == TRUE ) /bin/mv $HOMDIR/plotocn.j       $EXPDIR/plot
 
-## Modify AGCM.rc
-## --------------
-#set file = $HOMDIR/AGCM.rc
-#
-## Add GMI timestep:
-#/bin/mv $file $HOMDIR/dummy
-#cat           $HOMDIR/dummy | sed -e "/SATSIM_DT/a GMICHEM_DT: $GMICHEM_DT" > $file
-#
+# Modify AGCM.rc
+# --------------
+set file = $HOMDIR/AGCM.rc
+
+# Add GMI timestep:
+/bin/mv $file $HOMDIR/dummy
+cat           $HOMDIR/dummy | sed -e "/SATSIM_DT/a GMICHEM_DT: $GMICHEM_DT" > $file
+
 ## Change from GF to RAS for now:
 #/bin/mv $file $HOMDIR/dummy
 #cat           $HOMDIR/dummy | sed -e "s/CONVPAR_OPTION: GF/CONVPAR_OPTION: RAS/" > $file
@@ -2552,7 +2521,7 @@ if( $OGCM == TRUE ) /bin/mv $HOMDIR/plotocn.j       $EXPDIR/plot
 ## For future:  sed commands to insert important GF flags:
 ##/CONVPAR_OPTION/a USE_TRACER_TRANSP: 1
 ##/CONVPAR_OPTION/a USE_TRACER_SCAVEN: 0
-#/bin/rm -f    $HOMDIR/dummy
+/bin/rm -f    $HOMDIR/dummy
 
 #######################################################################
 #       Modify RC Directory for LM and GOCART.data/GOCART Options     

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2647,6 +2647,11 @@ endif
     sed -e 's/doMEGANviaHEMCO: F/doMEGANviaHEMCO: T/' $EXPDIR/RC/GMI_GridComp.rc > $EXPDIR/RC/GMI_GridComp.tmp
     /bin/mv -f $EXPDIR/RC/GMI_GridComp.tmp $EXPDIR/RC/GMI_GridComp.rc
 
+    sed -e 's/#HEMCO_INTERNAL/HEMCO_INTERNAL/' $HOMDIR/AGCM.rc > $HOMDIR/AGCM.rc.tmp
+    /bin/mv -f $HOMDIR/AGCM.rc.tmp $HOMDIR/AGCM.rc
+    sed -e 's/#HEMCO_IMPORT/HEMCO_IMPORT/'     $HOMDIR/AGCM.rc > $HOMDIR/AGCM.rc.tmp
+    /bin/mv -f $HOMDIR/AGCM.rc.tmp $HOMDIR/AGCM.rc
+
   endif
 
 ##################################################################

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -710,11 +710,11 @@ if( $AGCM_IM ==  "c12" ) then
      set       DT = 900
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 12
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 2
@@ -734,10 +734,10 @@ if( $AGCM_IM ==  "72" ) then
      set       DT = 900
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000015
      set NUM_SGMT = 20
      if( $OGCM == TRUE ) then
@@ -756,11 +756,11 @@ if( $AGCM_IM ==  "c24" ) then
      set       DT = 900
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 24
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 4
@@ -780,10 +780,10 @@ if( $AGCM_IM ==  "144" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000015
      set NUM_SGMT = 20
      if( $OGCM == TRUE ) then
@@ -802,11 +802,11 @@ if( $AGCM_IM ==  "c48" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 48
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 6
@@ -824,10 +824,10 @@ if( $AGCM_IM ==  "288" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000008
      set NUM_SGMT = 5
      if( $OGCM == TRUE ) then
@@ -846,9 +846,7 @@ if( $AGCM_IM ==  "c90" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set AGCM_IM  = 90
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      if( $OGCM == TRUE ) then
@@ -861,6 +859,8 @@ if( $AGCM_IM ==  "c90" ) then
      set OCEAN_DT = $IRRAD_DT
      endif
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set HYDROSTATIC = TRUE
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -874,10 +874,10 @@ if( $AGCM_IM ==  "576" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000016
      set NUM_SGMT = 1
      if( $OGCM == TRUE ) then
@@ -896,10 +896,10 @@ if( $AGCM_IM ==  "c180" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 180
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      if( $OGCM == TRUE ) then
@@ -926,10 +926,10 @@ if( $AGCM_IM == "1152" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set JOB_SGMT = 00000005
      set NUM_SGMT = 1
      set NUM_READERS = 4
@@ -951,11 +951,11 @@ if( $AGCM_IM == "c360" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 360
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 12 
@@ -976,11 +976,11 @@ if( $AGCM_IM == "c500" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 500
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 12
@@ -1002,11 +1002,11 @@ if( $AGCM_IM == "c720" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 720
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 16
@@ -1028,11 +1028,11 @@ if( $AGCM_IM == "c1440" ) then
      set       DT = 450
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = $DT
+     set SC_SPLIT = 1
+#    set  GOCART_DT = `expr $DT \* 2`
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 30 
@@ -1055,11 +1055,11 @@ if( $AGCM_IM == "c768" ) then
      set       DT = 180
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = 900
+     set SC_SPLIT = 1
+#    set  GOCART_DT = $CHEM_DT
      set AGCM_IM  = 768
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 32
@@ -1081,11 +1081,11 @@ if( $AGCM_IM == "c1536" ) then
      set       DT = 90
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = 900
+     set SC_SPLIT = 1
+#    set  GOCART_DT = $CHEM_DT
      set AGCM_IM  = 1536
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 64
@@ -1107,11 +1107,11 @@ if( $AGCM_IM == "c3072" ) then
      set       DT = 45
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
-#    set GOCART_DT = 3600
      set SATSIM_DT = 3600
-     set SC_SPLIT = 1
      set OCEAN_DT = $IRRAD_DT
      set  CHEM_DT = 900
+     set SC_SPLIT = 1
+#    set  GOCART_DT = $CHEM_DT
      set AGCM_IM  = 3072
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 64
@@ -1214,43 +1214,12 @@ if( $LSM_BCS == "Icarus-NLv3" ) then
     endif
     if( $LSM_CHOICE == 1 ) set HIST_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set HIST_CATCHCN = ""
+    if( $LSM_CHOICE == 1 ) set GCMRUN_CATCHCN = "#DELETE"
+    if( $LSM_CHOICE == 2 ) set GCMRUN_CATCHCN = ""
 else
     set LSM_CHOICE = 1
     set HIST_CATCHCN = "#DELETE"
-endif
-
-
-# Check for Runoff Routing Model
-# ------------------------------
-RRM:
-echo "Do you wish to run ${C1} the Runoff Routing Model${CN}? (Default: ${C2}NO${CN} or ${C2}FALSE${CN})"
-set   RUNRRM  = $<
-if( .$RUNRRM == . ) then
-set   RUNRRM  = FALSE
-else
-set   RUNRRM  = `echo   $RUNRRM | tr "[:lower:]" "[:upper:]"`
-if(  $RUNRRM == "Y"     | \
-     $RUNRRM == "YES"   | \
-     $RUNRRM == "T"     | \
-     $RUNRRM == "TRUE"  ) set RUNRRM = TRUE
-if(  $RUNRRM == "N"     | \
-     $RUNRRM == "NO"    | \
-     $RUNRRM == "F"     | \
-     $RUNRRM == "FALSE" ) set RUNRRM = FALSE
-
-if( $RUNRRM != TRUE & $RUNRRM != FALSE ) then
-echo
-echo "${C1} the Runoff Routing Model${CN} must be set equal to ${C2}TRUE${CN} or ${C2}FALSE${CN}!"
-goto RRM
-else
-echo
-endif
-endif
-
-if( $RUNRRM == TRUE ) then
-    set RUN_ROUTE = 1
-else
-    set RUN_ROUTE = 0
+    set GCMRUN_CATCHCN = "#DELETE"
 endif
 
 #######################################################################
@@ -1401,7 +1370,6 @@ if( $SITE == 'NAS' ) then
               setenv CONVERT_P  "PBS -l select=${CNV_NX}:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}"    # PE Configuration for gcm_convert.j
               setenv    MOVE_P  "PBS -l select=1:ncpus=1"                                                                      # PE Configuration for gcm_moveplot.j
 
-
               setenv BCSDIR     /nobackup/gmao_SIteam/ModelData/bcs/${LSM_BCS}/${LSM_BCS}_${OCEAN_TAG}      # location of Boundary Conditions
               setenv REPLAY_ANA_EXPID    ONLY_MERRA2_SUPPORTED                                              # Default Analysis Experiment for REPLAY
               setenv REPLAY_ANA_LOCATION ONLY_MERRA2_SUPPORTED                                              # Default Analysis Location   for REPLAY
@@ -1418,7 +1386,7 @@ if( $SITE == 'NAS' ) then
               setenv TAREXEC    mtar                                                   # Tar utility for large archives
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
-              setenv BATCH_GROUP "SBATCH --account="                                    # SLURM Syntax for account name
+              setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
@@ -1448,7 +1416,7 @@ else if( $SITE == 'NCCS' ) then
               setenv    PLOT_P  "SBATCH --nodes=4 --ntasks=4"                                 # PE Configuration for gcm_plot.j
               setenv ARCHIVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_archive.j
               setenv CONVERT_P  "SBATCH --ntasks=${CNV_NPES}"                                 # PE Configuration for gcm_convert.j
-              setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j              
+              setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j
 
               setenv BCSDIR  /discover/nobackup/ltakacs/bcs/${LSM_BCS}/${LSM_BCS}_${OCEAN_TAG}  # location of Boundary Conditions
               setenv REPLAY_ANA_EXPID x0039                                                     # Default Analysis Experiment for REPLAY
@@ -1488,7 +1456,7 @@ else
               setenv    PLOT_P  NULL                                                   # PE Configuration for gcm_post.j
               setenv ARCHIVE_P  NULL                                                   # PE Configuration for gcm_archive.j
               setenv CONVERT_P  NULL                                                   # PE Configuration for gcm_convert.j
-              setenv    MOVE_P  NULL                                                   # PE Configuration for gcm_moveplot.j              
+              setenv    MOVE_P  NULL                                                   # PE Configuration for gcm_moveplot.j
 
               setenv BCSDIR     /ford1/share/gmao_SIteam/ModelData/bcs/${LSM_BCS}/${LSM_BCS}_${OCEAN_TAG}  # location of Boundary Conditions
               setenv REPLAY_ANA_EXPID    REPLAY_UNSUPPORTED                                                # Default Analysis Experiment for REPLAY
@@ -2057,6 +2025,7 @@ s?>>>FVLATLON<<<?$FVLATLON?g
 s?>>>HIST_GOCART<<<?$HIST_GOCART?g
 s?>>>OSTIA<<<?$OSTIA?g
 s?>>>HIST_CATCHCN<<<?$HIST_CATCHCN?g
+s?>>>GCMRUN_CATCHCN<<<?$GCMRUN_CATCHCN?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
 
@@ -2083,6 +2052,8 @@ s^@DYCORE^$DYCORE^g
 s^@AGCM_GRIDNAME^$AGCM_GRIDNAME^g
 s^@OGCM_GRIDNAME^$OGCM_GRIDNAME^g
 
+s/@GOCART_DT/$DT/g
+
 s?@IS_FCST?$IS_FCST?g
 s^@BOOT^YES^g
 s^@BCSRES^$BCSRES^g
@@ -2094,10 +2065,9 @@ s^@TILEBIN^$TILEBIN^g
 s/@DT/$DT/g
 s/@SOLAR_DT/$SOLAR_DT/g
 s/@IRRAD_DT/$IRRAD_DT/g
+s/@SATSIM_DT/$SATSIM_DT/g
 s/@OCEAN_DT/$OCEAN_DT/g
 s/@CHEM_DT/$CHEM_DT/g
-s/@GOCART_DT/$DT/g
-s/@SATSIM_DT/$SATSIM_DT/g
 s/@SC_SPLIT/$SC_SPLIT/g
 s/@NX/$NX/g
 s/@NY/$NY/g
@@ -2141,7 +2111,6 @@ s/@USE_SKIN_LAYER/1/g
 s/@ANALYZE_TS/0/g
 
 s/@LSM_CHOICE/$LSM_CHOICE/g
-s/@RUN_ROUTE/$RUN_ROUTE/g
 
 s?@CPEXEC?$CPEXEC?g
 s?@TAREXEC?$TAREXEC?g
@@ -2496,7 +2465,7 @@ endif
 #   Set R by providing an option to cmake :   -DSTRATCHEM_REDUCED_MECHANISM=ON
 #   This will (1) properly set the line below, and (2) compile StratChem with the appropriate option.
 
-    set R = @STRATCHEM_REDUCED_MECHANISM@
+    set R = OFF
 
     if (${R} == ON) then
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -2465,7 +2465,7 @@ endif
 #   Set R by providing an option to cmake :   -DSTRATCHEM_REDUCED_MECHANISM=ON
 #   This will (1) properly set the line below, and (2) compile StratChem with the appropriate option.
 
-    set R = OFF
+    set R = @STRATCHEM_REDUCED_MECHANISM@
 
     if (${R} == ON) then
 


### PR DESCRIPTION
Updated gmichem_setup, stratchem_setup and geoschemchem_setup, so that the resulting gcm_run.j script works with no edits required.  StratChem and GEOS-Chem are zero diff;  GMI experiments now explicitly set GMICHEM_DT, which is generally 2 * HeartBeat; in previous Git releases,  GMICHEM_DT defaulted to the HeartBeat.  Since gcm_setup has not changed, this PR is zero-diff.