### PR TITLE
Update MPI Settings

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -108,9 +108,12 @@ PRINTRC: 1
 # Set the number of parallel I/O processes to use when
 # RESTART_TYPE and or CHECKPOINT_TYPE are set to pbinary or pnc4
 #---------------------------------------------------------------
-PARALLEL_READFORCING: 1
+PARALLEL_READFORCING: 0
 NUM_READERS: @NUM_READERS
 NUM_WRITERS: 1
+
+# Write restarts by oserver (Default: NO)
+WRITE_RESTART_BY_OSERVER: @RESTART_BY_OSERVER
 
 # Active observer when desired
 # ----------------------------
@@ -142,7 +145,7 @@ RECORD_REF_TIME: >>>REFTIME<<< >>>FCSTIME<<<
 ####         For these cases, only the CORRECTOR step is employed and is, therefore, as        ####
 ####         efficient as a stand-alone model run.                                             ####
 ####                                                                                           ####
-####         In order to guarentee reproducibility, the model and its BUILD parameters         ####
+####         In order to guarantee reproducibility, the model and its BUILD parameters         ####
 ####         (Compilers and Options) as well as all INPUT data must be identical to the        ####
 ####         original DAS experiment.  This type of REPLAY is useful when producing            ####
 ####         additional passive, diagnostic data, or when the original data is lost.           ####
@@ -215,7 +218,7 @@ RECORD_REF_TIME: >>>REFTIME<<< >>>FCSTIME<<<
 ####   ----------------------                                                                  ####
 ####        The current 4D-EnVar system, as previously noted, produces 7 hourly Analyses:      ####
 ####        (-03z, -02z, -01z, 00z, +01z, +02z, +03z) for each 6-hour assimilation window      ####
-####        centered around the 4 synpotic times of 00z, 06z, 12z, and 18z.  We see that the   ####
+####        centered around the 4 synoptic times of 00z, 06z, 12z, and 18z.  We see that the   ####
 ####        last Analysis (+03z) associated with each synoptic time will be over-ridden by     ####
 ####        the first Analyiss (-03z) associated with synoptic time of the next assimilation   ####
 ####        window. To prevent these over-ridden files from being lost, the GEOS-5 DAS         ####
@@ -225,7 +228,7 @@ RECORD_REF_TIME: >>>REFTIME<<< >>>FCSTIME<<<
 ####        used for this purpose, and is only utilized if the REPLAY configuration warrants.  ####
 ####                                                                                           ####
 ####                                                                                           ####
-####   Regualr Replay Time Interpolation:                                                      ####
+####   Regular Replay Time Interpolation:                                                      ####
 ####   ----------------------------------                                                      ####
 ####        In some instances the USER might wish to create IAU Increments at a frequency      ####
 ####        greater than the frequency of the target analysis.  For those cases additional     ####

--- a/gcm_setup
+++ b/gcm_setup
@@ -219,6 +219,8 @@ echo "Enter the ${C1}Atmospheric Horizontal Resolution${CN} code:"
 echo "--------------------------------------"
 echo "            Cubed-Sphere"
 echo "--------------------------------------"
+echo "   ${C2}c12  --  8   deg ${CN}"
+echo "   ${C2}c24  --  4   deg ${CN}"
 echo "   ${C2}c48  --  2   deg ${CN}"
 echo "   ${C2}c90  --  1   deg ${CN}"
 echo "   ${C2}c180 -- 1/2  deg (${C1}56-km${C2}) ${CN}"
@@ -1718,12 +1720,19 @@ else
 endif
 
 #######################################################################
-#                      Create SETENV Commands
+#               Set Recommended MPI Stack Settings
 #######################################################################
+
+# By default do not write restarts by oserver
+set RESTART_BY_OSERVER = NO
 
 /bin/rm -f $HOMDIR/SETENV.commands
 
 if( $MPI == openmpi ) then
+
+# Open MPI and GEOS has issues with restart writing. Having the
+# oserver write them can be orders of magnitude faster
+set RESTART_BY_OSERVER = YES
 
 # This turns off an annoying warning when running
 # Open MPI on a system where TMPDIRs are on a networked
@@ -1795,7 +1804,25 @@ cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
 setenv I_MPI_ADJUST_GATHERV 3
+
+# This flag prints out the Intel MPI state. Uncomment if needed
+#setenv I_MPI_DEBUG 9
 EOF
+
+# These are options determined to be useful at NCCS
+# Not setting generally as they are more fabric/cluster
+# specific compared to the above adjustments
+if ( $SITE == 'NCCS' ) then
+
+cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_SHM_HEAP_VSIZE 512
+setenv PSM2_MEMORY large
+setenv I_MPI_EXTRA_FILESYSTEM 1
+setenv I_MPI_EXTRA_FILESYSTEM_FORCE gpfs
+setenv ROMIO_FSTYPE_FORCE "gpfs:"
+EOF
+
+endif # if NCCS
 
 endif # if mpi
 
@@ -2019,6 +2046,7 @@ s/@NY/$NY/g
 s/@USE_SHMEM/$USE_SHMEM/g
 s/@USE_IOSERVER/$USE_IOSERVER/g
 s/@IOS_NDS/$IOS_NDS/g
+s/@RESTART_BY_OSERVER/$RESTART_BY_OSERVER/g
 s/@NCPUS_PER_NODE/$NCPUS_PER_NODE/g
 s/@NUM_READERS/$NUM_READERS/g
 s/@NUM_WRITERS/$NUM_WRITERS/g

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -219,6 +219,8 @@ echo "Enter the ${C1}Atmospheric Horizontal Resolution${CN} code:"
 echo "--------------------------------------"
 echo "            Cubed-Sphere"
 echo "--------------------------------------"
+echo "   ${C2}c12  --  8   deg ${CN}"
+echo "   ${C2}c24  --  4   deg ${CN}"
 echo "   ${C2}c48  --  2   deg ${CN}"
 echo "   ${C2}c90  --  1   deg ${CN}"
 echo "   ${C2}c180 -- 1/2  deg (${C1}56-km${C2}) ${CN}"
@@ -1784,12 +1786,19 @@ else
 endif
 
 #######################################################################
-#                      Create SETENV Commands
+#               Set Recommended MPI Stack Settings
 #######################################################################
+
+# By default do not write restarts by oserver
+set RESTART_BY_OSERVER = NO
 
 /bin/rm -f $HOMDIR/SETENV.commands
 
 if( $MPI == openmpi ) then
+
+# Open MPI and GEOS has issues with restart writing. Having the
+# oserver write them can be orders of magnitude faster
+set RESTART_BY_OSERVER = YES
 
 # This turns off an annoying warning when running
 # Open MPI on a system where TMPDIRs are on a networked
@@ -1861,7 +1870,25 @@ cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
 setenv I_MPI_ADJUST_GATHERV 3
+
+# This flag prints out the Intel MPI state. Uncomment if needed
+#setenv I_MPI_DEBUG 9
 EOF
+
+# These are options determined to be useful at NCCS
+# Not setting generally as they are more fabric/cluster
+# specific compared to the above adjustments
+if ( $SITE == 'NCCS' ) then
+
+cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_SHM_HEAP_VSIZE 512
+setenv PSM2_MEMORY large
+setenv I_MPI_EXTRA_FILESYSTEM 1
+setenv I_MPI_EXTRA_FILESYSTEM_FORCE gpfs
+setenv ROMIO_FSTYPE_FORCE "gpfs:"
+EOF
+
+endif # if NCCS
 
 endif # if mpi
 
@@ -2088,6 +2115,7 @@ s/@NY/$NY/g
 s/@USE_SHMEM/$USE_SHMEM/g
 s/@USE_IOSERVER/$USE_IOSERVER/g
 s/@IOS_NDS/$IOS_NDS/g
+s/@RESTART_BY_OSERVER/$RESTART_BY_OSERVER/g
 s/@NCPUS_PER_NODE/$NCPUS_PER_NODE/g
 s/@NUM_READERS/$NUM_READERS/g
 s/@NUM_WRITERS/$NUM_WRITERS/g

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -219,6 +219,8 @@ echo "Enter the ${C1}Atmospheric Horizontal Resolution${CN} code:"
 echo "--------------------------------------"
 echo "            Cubed-Sphere"
 echo "--------------------------------------"
+echo "   ${C2}c12  --  8   deg ${CN}"
+echo "   ${C2}c24  --  4   deg ${CN}"
 echo "   ${C2}c48  --  2   deg ${CN}"
 echo "   ${C2}c90  --  1   deg ${CN}"
 echo "   ${C2}c180 -- 1/2  deg (${C1}56-km${C2}) ${CN}"
@@ -1921,12 +1923,19 @@ else
 endif
 
 #######################################################################
-#                      Create SETENV Commands
+#               Set Recommended MPI Stack Settings
 #######################################################################
+
+# By default do not write restarts by oserver
+set RESTART_BY_OSERVER = NO
 
 /bin/rm -f $HOMDIR/SETENV.commands
 
 if( $MPI == openmpi ) then
+
+# Open MPI and GEOS has issues with restart writing. Having the
+# oserver write them can be orders of magnitude faster
+set RESTART_BY_OSERVER = YES
 
 # This turns off an annoying warning when running
 # Open MPI on a system where TMPDIRs are on a networked
@@ -1998,7 +2007,25 @@ cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
 setenv I_MPI_ADJUST_GATHERV 3
+
+# This flag prints out the Intel MPI state. Uncomment if needed
+#setenv I_MPI_DEBUG 9
 EOF
+
+# These are options determined to be useful at NCCS
+# Not setting generally as they are more fabric/cluster
+# specific compared to the above adjustments
+if ( $SITE == 'NCCS' ) then
+
+cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_SHM_HEAP_VSIZE 512
+setenv PSM2_MEMORY large
+setenv I_MPI_EXTRA_FILESYSTEM 1
+setenv I_MPI_EXTRA_FILESYSTEM_FORCE gpfs
+setenv ROMIO_FSTYPE_FORCE "gpfs:"
+EOF
+
+endif # if NCCS
 
 endif # if mpi
 
@@ -2228,6 +2255,7 @@ s/@NY/$NY/g
 s/@USE_SHMEM/$USE_SHMEM/g
 s/@USE_IOSERVER/$USE_IOSERVER/g
 s/@IOS_NDS/$IOS_NDS/g
+s/@RESTART_BY_OSERVER/$RESTART_BY_OSERVER/g
 s/@NCPUS_PER_NODE/$NCPUS_PER_NODE/g
 s/@NUM_READERS/$NUM_READERS/g
 s/@NUM_WRITERS/$NUM_WRITERS/g

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -219,6 +219,8 @@ echo "Enter the ${C1}Atmospheric Horizontal Resolution${CN} code:"
 echo "--------------------------------------"
 echo "            Cubed-Sphere"
 echo "--------------------------------------"
+echo "   ${C2}c12  --  8   deg ${CN}"
+echo "   ${C2}c24  --  4   deg ${CN}"
 echo "   ${C2}c48  --  2   deg ${CN}"
 echo "   ${C2}c90  --  1   deg ${CN}"
 echo "   ${C2}c180 -- 1/2  deg (${C1}56-km${C2}) ${CN}"
@@ -1769,12 +1771,19 @@ else
 endif
 
 #######################################################################
-#                      Create SETENV Commands
+#               Set Recommended MPI Stack Settings
 #######################################################################
+
+# By default do not write restarts by oserver
+set RESTART_BY_OSERVER = NO
 
 /bin/rm -f $HOMDIR/SETENV.commands
 
 if( $MPI == openmpi ) then
+
+# Open MPI and GEOS has issues with restart writing. Having the
+# oserver write them can be orders of magnitude faster
+set RESTART_BY_OSERVER = YES
 
 # This turns off an annoying warning when running
 # Open MPI on a system where TMPDIRs are on a networked
@@ -1846,7 +1855,25 @@ cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_DAPL_UD enable
 setenv I_MPI_ADJUST_ALLREDUCE 12
 setenv I_MPI_ADJUST_GATHERV 3
+
+# This flag prints out the Intel MPI state. Uncomment if needed
+#setenv I_MPI_DEBUG 9
 EOF
+
+# These are options determined to be useful at NCCS
+# Not setting generally as they are more fabric/cluster
+# specific compared to the above adjustments
+if ( $SITE == 'NCCS' ) then
+
+cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_SHM_HEAP_VSIZE 512
+setenv PSM2_MEMORY large
+setenv I_MPI_EXTRA_FILESYSTEM 1
+setenv I_MPI_EXTRA_FILESYSTEM_FORCE gpfs
+setenv ROMIO_FSTYPE_FORCE "gpfs:"
+EOF
+
+endif # if NCCS
 
 endif # if mpi
 
@@ -2074,6 +2101,7 @@ s/@NY/$NY/g
 s/@USE_SHMEM/$USE_SHMEM/g
 s/@USE_IOSERVER/$USE_IOSERVER/g
 s/@IOS_NDS/$IOS_NDS/g
+s/@RESTART_BY_OSERVER/$RESTART_BY_OSERVER/g
 s/@NCPUS_PER_NODE/$NCPUS_PER_NODE/g
 s/@NUM_READERS/$NUM_READERS/g
 s/@NUM_WRITERS/$NUM_WRITERS/g


### PR DESCRIPTION
This PR updates a few things:

* For Intel MPI at NCCS, it sets a few settings that have proven useful by @wmputman and @sdrabenh 
* For Open MPI, it turns on `WRITE_RESTART_BY_OSERVER: YES` (the default `NO` is kept for all other MPI stacks). This is needed because there is some weird issue with Open MPI and GEOS where writing restarts at even, say, c90 can take hours without this. This needs a line added to `AGCM.rc.tmpl`
* Set `PARALLEL_READFORCING` to 0. This is from @atrayano who says this should be the default period. No matter what.
* Fix some spelling issues I saw when reading `AGCM.rc.tmpl`
* Add in `c12` and `c24` to the "what resolution" print of the `_setup` scripts. I know of a few people I've told to try c24 and then they are confused since it's a "hidden" option.