### PR TITLE
Add gwd_import to checkpoint/restart

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -528,6 +528,10 @@ AIAU_IMPORT_RESTART_FILE:               aiau_import_rst
 AIAU_IMPORT_CHECKPOINT_FILE:            aiau_import_checkpoint
 AIAU_IMPORT_CHECKPOINT_TYPE:            @CHECKPOINT_TYPE
 
+GWD_IMPORT_RESTART_FILE:                gwd_import_rst
+GWD_IMPORT_CHECKPOINT_FILE:             gwd_import_checkpoint
+GWD_IMPORT_CHECKPOINT_TYPE:             @CHECKPOINT_TYPE
+
 MOIST_IMPORT_RESTART_FILE:              moist_import_rst
 MOIST_IMPORT_CHECKPOINT_FILE:           moist_import_checkpoint
 MOIST_IMPORT_CHECKPOINT_TYPE:           @CHECKPOINT_TYPE


### PR DESCRIPTION
This is in combination with https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/312 to allow the new NCAR GWD to pass stop-start regression. We need `DTDTCN` to be saved so GWD can restart correctly.

Note I'm labeling this both 0-diff and non-0-diff as it is zero-diff in the sense that the results are the same, but non-zero-diff in that new restart appears.

@sdrabenh can remove a label as he sees fit :)