### PR TITLE
Do not run binarytile.x with MPI

### DIFF
--- a/gcm_convert.j
+++ b/gcm_convert.j
@@ -270,7 +270,7 @@ chmod +x linkbcs
 #######################################################################
 
 if (! -e tile.bin) then
-$RUN_CMD 1 $GEOSBIN/binarytile.x tile.data tile.bin
+$GEOSBIN/binarytile.x tile.data tile.bin
 endif
 
 #######################################################################

--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -535,7 +535,7 @@ setenv YEAR $year
 ./linkbcs
 
 if (! -e tile.bin) then
-$RUN_CMD 1 $GEOSBIN/binarytile.x tile.data tile.bin
+$GEOSBIN/binarytile.x tile.data tile.bin
 endif
 
 #######################################################################

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -119,7 +119,7 @@ end
 
 setenv YEAR `cat cap_restart | cut -c1-4`
 ./linkbcs
-if(! -e tile.bin) $RUN_CMD 1 $GEOSBIN/binarytile.x tile.data tile.bin
+if(! -e tile.bin) $GEOSBIN/binarytile.x tile.data tile.bin
 
 #######################################################################
 #                Split Saltwater Restart if detected

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -651,8 +651,8 @@ setenv YEAR $yearc
 ./linkbcs
 
 if (! -e tile.bin) then
-$RUN_CMD 1 $GEOSBIN/binarytile.x tile.data tile.bin
->>>MOM5<<<$RUN_CMD 1 $GEOSBIN/binarytile.x tile_hist.data tile_hist.bin
+$GEOSBIN/binarytile.x tile.data tile.bin
+>>>MOM5<<<$GEOSBIN/binarytile.x tile_hist.data tile_hist.bin
 endif
 
 # If running in dual ocean mode, link sst and fraci data here


### PR DESCRIPTION
Under CMake, `binarytile.x` isn't compiled with MPI. For unknown reasons, Intel MPI 19.1.2 sometimes has issues running it with `mpirun`. It shouldn't, but...

Still, as it isn't even compiled with MPI, there is no need to run with MPI.