### PR TITLE
Update gcm_run.j

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -697,7 +697,10 @@ if ( (! -e $EXPDIR/openwater_internal_rst) && (! -e $EXPDIR/seaicethermo_interna
    # -----------------------------
    /bin/rm $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
 
+ else
+   echo "Neither saltwater_internal_rst, or openwater_internal_rst and seaicethermo_internal_rst were found. Abort!"
  endif
+ 
 endif
 
 # Test Saltwater Restart for Number of tiles correctness

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -698,7 +698,8 @@ if ( (! -e $EXPDIR/openwater_internal_rst) && (! -e $EXPDIR/seaicethermo_interna
    /bin/rm $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
 
  else
-   echo "Neither saltwater_internal_rst, or openwater_internal_rst and seaicethermo_internal_rst were found. Abort!"
+   echo "Neither saltwater_internal_rst, nor openwater_internal_rst and seaicethermo_internal_rst were found. Abort!"
+   exit 6
  endif
  
 endif

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -696,7 +696,11 @@ if ( (! -e $EXPDIR/openwater_internal_rst) && (! -e $EXPDIR/seaicethermo_interna
    # Remove the decorated restarts
    # -----------------------------
    /bin/rm $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
-
+   
+   # Remove the saltwater internal restart
+   # -------------------------------------
+   /bin/rm $EXPDIR/saltwater_internal_rst
+   
  else
    echo "Neither saltwater_internal_rst, nor openwater_internal_rst and seaicethermo_internal_rst were found. Abort!"
    exit 6

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -665,7 +665,8 @@ endif
 #                Split Saltwater Restart if detected
 #######################################################################
 
-if ( ( -e $EXPDIR/saltwater_internal_rst ) && ( $counter == 1 ) ) then
+if ( (! -e $EXPDIR/openwater_internal_rst) && (! -e $EXPDIR/seaicethermo_internal_rst)) then
+ if ( ( -e $EXPDIR/saltwater_internal_rst ) && ( $counter == 1 ) ) then
 
    # The splitter script requires an OutData directory
    # -------------------------------------------------
@@ -696,6 +697,7 @@ if ( ( -e $EXPDIR/saltwater_internal_rst ) && ( $counter == 1 ) ) then
    # -----------------------------
    /bin/rm $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
 
+ endif
 endif
 
 # Test Saltwater Restart for Number of tiles correctness
@@ -713,6 +715,7 @@ if ( -x $GEOSBIN/rs_numtiles.x ) then
    endif    
 
 endif
+
 
 # Environment variables for MPI, etc
 # ----------------------------------


### PR DESCRIPTION
fixes https://github.com/GEOS-ESM/GEOSgcm_App/issues/161

Unintentionally, if one has saltwater restart, we use this logic. We need to be able to _protect_ from that _wrong_ intent!

So the intent of this PR is: 
to **add** logic to instead check for the presence of openwater and seaice thermo restarts, which the user/run is expected to have. So if indeed they are found, we SKIP, if not there, then use the saltwater restart, split it into openwater and seaice thermo.
