### PR TITLE
Genericize NCAR GWD Beres file location

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -67,6 +67,15 @@ CLOSURE_DEEP:0
 CLOSURE_SHALLOW:7
 CLOSURE_CONGESTUS:3
 
+# GWD Parameterization
+# --------------------
+
+# if .FALSE., use GEOS GWD code (default); .TRUE., use new NCAR GWD code
+USE_NCAR_GWD: .FALSE.
+
+# This is only used if USE_NCAR_GWD is .TRUE.
+BERES_GWD_FILE: ExtData/g5gcm/gwd/newmfspectra40_dc25.nc
+
 # Ocean Model Configuration Parameters
 # ------------------------------------
       OGCM.GRID_TYPE: @OGCM_GRID_TYPE

--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -74,7 +74,7 @@ CLOSURE_CONGESTUS:3
 USE_NCAR_GWD: .FALSE.
 
 # This is only used if USE_NCAR_GWD is .TRUE.
-BERES_GWD_FILE: ExtData/g5gcm/gwd/newmfspectra40_dc25.nc
+BERES_FILE_NAME: ExtData/g5gcm/gwd/newmfspectra40_dc25.nc
 
 # Ocean Model Configuration Parameters
 # ------------------------------------


### PR DESCRIPTION
Removes hardcoded BERES_FILE_NAME and makes it an ExtData file from AGCM.rc

Should be taken in concert with https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/341