### PR TITLE
Fixes #164. Increase job name limit

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1256,14 +1256,17 @@ endif
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
 
-              setenv     RUN_N  `echo $EXPID | cut -b1-11`_RUN                         # RUN      Job Name
-              setenv     RUN_FN `echo $EXPID | cut -b1-11`_FCST                        # Forecast Job Name
-              setenv    POST_N  `echo $EXPID | cut -b1-10`_POST                        # POST     Job Name
-              setenv    PLOT_N  `echo $EXPID | cut -b1-11`_PLT                         # PLOT     Job Name
-              setenv    MOVE_N  `echo $EXPID | cut -b1-11`_MOVE                        # MOVE     Job Name
-              setenv ARCHIVE_N  `echo $EXPID | cut -b1-10`_ARCH                        # ARCHIVE  Job Name
-              setenv REGRESS_N  `echo $EXPID | cut -b1-10`_RGRS                        # REGRESS  Job Name
-              setenv CONVERT_N  `echo $EXPID | cut -b1-11`_CNV                         # CONVERT  Job Name
+# Longer messages are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
+# and 230 with PBS. To be safe, we will limit to 200
+
+              setenv     RUN_N  `echo $EXPID | cut -b1-200`_RUN                         # RUN      Job Name
+              setenv     RUN_FN `echo $EXPID | cut -b1-200`_FCST                        # Forecast Job Name
+              setenv    POST_N  `echo $EXPID | cut -b1-199`_POST                        # POST     Job Name
+              setenv    PLOT_N  `echo $EXPID | cut -b1-200`_PLT                         # PLOT     Job Name
+              setenv    MOVE_N  `echo $EXPID | cut -b1-200`_MOVE                        # MOVE     Job Name
+              setenv ARCHIVE_N  `echo $EXPID | cut -b1-199`_ARCH                        # ARCHIVE  Job Name
+              setenv REGRESS_N  `echo $EXPID | cut -b1-199`_RGRS                        # REGRESS  Job Name
+              setenv CONVERT_N  `echo $EXPID | cut -b1-200`_CNV                         # CONVERT  Job Name
 
 # Default converter time
               setenv CONVERT_T  "0:15:00"                                              # Wallclock Time   for gcm_convert.j
@@ -2858,14 +2861,14 @@ end
 # Construct the new job ids
 # -------------------------
 
-    set RUN_N=`echo $NEWEXPID | cut -b1-11`_RUN
-   set RUN_FN=`echo $NEWEXPID | cut -b1-11`_FCST
-   set POST_N=`echo $NEWEXPID | cut -b1-10`_POST
-   set PLOT_N=`echo $NEWEXPID | cut -b1-11`_PLT
-   set MOVE_N=`echo $NEWEXPID | cut -b1-11`_MOVE
-set ARCHIVE_N=`echo $NEWEXPID | cut -b1-10`_ARCH
-set REGRESS_N=`echo $NEWEXPID | cut -b1-10`_RGRS
-set CONVERT_N=`echo $NEWEXPID | cut -b1-11`_CNV
+    set RUN_N=`echo $NEWEXPID | cut -b1-200`_RUN
+   set RUN_FN=`echo $NEWEXPID | cut -b1-200`_FCST
+   set POST_N=`echo $NEWEXPID | cut -b1-199`_POST
+   set PLOT_N=`echo $NEWEXPID | cut -b1-200`_PLT
+   set MOVE_N=`echo $NEWEXPID | cut -b1-200`_MOVE
+set ARCHIVE_N=`echo $NEWEXPID | cut -b1-199`_ARCH
+set REGRESS_N=`echo $NEWEXPID | cut -b1-199`_RGRS
+set CONVERT_N=`echo $NEWEXPID | cut -b1-200`_CNV
 
 sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$RUN_N#"     \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$RUN_N#"     $NEWHOMDIR/gcm_run.j

--- a/gcm_setup
+++ b/gcm_setup
@@ -1256,7 +1256,7 @@ endif
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
 
-# Longer messages are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
+# Longer job names are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
 # and 230 with PBS. To be safe, we will limit to 200
 
               setenv     RUN_N  `echo $EXPID | cut -b1-200`_RUN                         # RUN      Job Name

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1307,7 +1307,7 @@ endif
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
 
-# Longer messages are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
+# Longer job names are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
 # and 230 with PBS. To be safe, we will limit to 200
 
               setenv     RUN_N  `echo $EXPID | cut -b1-200`_RUN                         # RUN      Job Name

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1307,14 +1307,17 @@ endif
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
 
-              setenv     RUN_N  `echo $EXPID | cut -b1-11`_RUN                         # RUN      Job Name
-              setenv     RUN_FN `echo $EXPID | cut -b1-11`_FCST                        # Forecast Job Name
-              setenv    POST_N  `echo $EXPID | cut -b1-10`_POST                        # POST     Job Name
-              setenv    PLOT_N  `echo $EXPID | cut -b1-11`_PLT                         # PLOT     Job Name
-              setenv    MOVE_N  `echo $EXPID | cut -b1-11`_MOVE                        # MOVE     Job Name
-              setenv ARCHIVE_N  `echo $EXPID | cut -b1-10`_ARCH                        # ARCHIVE  Job Name
-              setenv REGRESS_N  `echo $EXPID | cut -b1-10`_RGRS                        # REGRESS  Job Name
-              setenv CONVERT_N  `echo $EXPID | cut -b1-11`_CNV                         # CONVERT  Job Name
+# Longer messages are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
+# and 230 with PBS. To be safe, we will limit to 200
+
+              setenv     RUN_N  `echo $EXPID | cut -b1-200`_RUN                         # RUN      Job Name
+              setenv     RUN_FN `echo $EXPID | cut -b1-200`_FCST                        # Forecast Job Name
+              setenv    POST_N  `echo $EXPID | cut -b1-199`_POST                        # POST     Job Name
+              setenv    PLOT_N  `echo $EXPID | cut -b1-200`_PLT                         # PLOT     Job Name
+              setenv    MOVE_N  `echo $EXPID | cut -b1-200`_MOVE                        # MOVE     Job Name
+              setenv ARCHIVE_N  `echo $EXPID | cut -b1-199`_ARCH                        # ARCHIVE  Job Name
+              setenv REGRESS_N  `echo $EXPID | cut -b1-199`_RGRS                        # REGRESS  Job Name
+              setenv CONVERT_N  `echo $EXPID | cut -b1-200`_CNV                         # CONVERT  Job Name
 
 # Default converter time
               setenv CONVERT_T  "0:15:00"                                              # Wallclock Time   for gcm_convert.j
@@ -3087,14 +3090,14 @@ end
 # Construct the new job ids
 # -------------------------
 
-    set RUN_N=`echo $NEWEXPID | cut -b1-11`_RUN
-   set RUN_FN=`echo $NEWEXPID | cut -b1-11`_FCST
-   set POST_N=`echo $NEWEXPID | cut -b1-10`_POST
-   set PLOT_N=`echo $NEWEXPID | cut -b1-11`_PLT
-   set MOVE_N=`echo $NEWEXPID | cut -b1-11`_MOVE
-set ARCHIVE_N=`echo $NEWEXPID | cut -b1-10`_ARCH
-set REGRESS_N=`echo $NEWEXPID | cut -b1-10`_RGRS
-set CONVERT_N=`echo $NEWEXPID | cut -b1-11`_CNV
+    set RUN_N=`echo $NEWEXPID | cut -b1-200`_RUN
+   set RUN_FN=`echo $NEWEXPID | cut -b1-200`_FCST
+   set POST_N=`echo $NEWEXPID | cut -b1-199`_POST
+   set PLOT_N=`echo $NEWEXPID | cut -b1-200`_PLT
+   set MOVE_N=`echo $NEWEXPID | cut -b1-200`_MOVE
+set ARCHIVE_N=`echo $NEWEXPID | cut -b1-199`_ARCH
+set REGRESS_N=`echo $NEWEXPID | cut -b1-199`_RGRS
+set CONVERT_N=`echo $NEWEXPID | cut -b1-200`_CNV
 
 sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$RUN_N#"     \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$RUN_N#"     $NEWHOMDIR/gcm_run.j

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1435,7 +1435,7 @@ endif
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
 
-# Longer messages are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
+# Longer job names are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
 # and 230 with PBS. To be safe, we will limit to 200
 
               setenv     RUN_N  `echo $EXPID | cut -b1-200`_RUN                         # RUN      Job Name

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1435,14 +1435,17 @@ endif
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
 
-              setenv     RUN_N  `echo $EXPID | cut -b1-11`_RUN                         # RUN      Job Name
-              setenv     RUN_FN `echo $EXPID | cut -b1-11`_FCST                        # Forecast Job Name
-              setenv    POST_N  `echo $EXPID | cut -b1-10`_POST                        # POST     Job Name
-              setenv    PLOT_N  `echo $EXPID | cut -b1-11`_PLT                         # PLOT     Job Name
-              setenv    MOVE_N  `echo $EXPID | cut -b1-11`_MOVE                        # MOVE     Job Name
-              setenv ARCHIVE_N  `echo $EXPID | cut -b1-10`_ARCH                        # ARCHIVE  Job Name
-              setenv REGRESS_N  `echo $EXPID | cut -b1-10`_RGRS                        # REGRESS  Job Name
-              setenv CONVERT_N  `echo $EXPID | cut -b1-11`_CNV                         # CONVERT  Job Name
+# Longer messages are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
+# and 230 with PBS. To be safe, we will limit to 200
+
+              setenv     RUN_N  `echo $EXPID | cut -b1-200`_RUN                         # RUN      Job Name
+              setenv     RUN_FN `echo $EXPID | cut -b1-200`_FCST                        # Forecast Job Name
+              setenv    POST_N  `echo $EXPID | cut -b1-199`_POST                        # POST     Job Name
+              setenv    PLOT_N  `echo $EXPID | cut -b1-200`_PLT                         # PLOT     Job Name
+              setenv    MOVE_N  `echo $EXPID | cut -b1-200`_MOVE                        # MOVE     Job Name
+              setenv ARCHIVE_N  `echo $EXPID | cut -b1-199`_ARCH                        # ARCHIVE  Job Name
+              setenv REGRESS_N  `echo $EXPID | cut -b1-199`_RGRS                        # REGRESS  Job Name
+              setenv CONVERT_N  `echo $EXPID | cut -b1-200`_CNV                         # CONVERT  Job Name
 
 # Default converter time
               setenv CONVERT_T  "0:15:00"                                              # Wallclock Time   for gcm_convert.j
@@ -3191,14 +3194,14 @@ end
 # Construct the new job ids
 # -------------------------
 
-    set RUN_N=`echo $NEWEXPID | cut -b1-11`_RUN
-   set RUN_FN=`echo $NEWEXPID | cut -b1-11`_FCST
-   set POST_N=`echo $NEWEXPID | cut -b1-10`_POST
-   set PLOT_N=`echo $NEWEXPID | cut -b1-11`_PLT
-   set MOVE_N=`echo $NEWEXPID | cut -b1-11`_MOVE
-set ARCHIVE_N=`echo $NEWEXPID | cut -b1-10`_ARCH
-set REGRESS_N=`echo $NEWEXPID | cut -b1-10`_RGRS
-set CONVERT_N=`echo $NEWEXPID | cut -b1-11`_CNV
+    set RUN_N=`echo $NEWEXPID | cut -b1-200`_RUN
+   set RUN_FN=`echo $NEWEXPID | cut -b1-200`_FCST
+   set POST_N=`echo $NEWEXPID | cut -b1-199`_POST
+   set PLOT_N=`echo $NEWEXPID | cut -b1-200`_PLT
+   set MOVE_N=`echo $NEWEXPID | cut -b1-200`_MOVE
+set ARCHIVE_N=`echo $NEWEXPID | cut -b1-199`_ARCH
+set REGRESS_N=`echo $NEWEXPID | cut -b1-199`_RGRS
+set CONVERT_N=`echo $NEWEXPID | cut -b1-200`_CNV
 
 sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$RUN_N#"     \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$RUN_N#"     $NEWHOMDIR/gcm_run.j

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1292,14 +1292,17 @@ endif
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
 
-              setenv     RUN_N  `echo $EXPID | cut -b1-11`_RUN                         # RUN      Job Name
-              setenv     RUN_FN `echo $EXPID | cut -b1-11`_FCST                        # Forecast Job Name
-              setenv    POST_N  `echo $EXPID | cut -b1-10`_POST                        # POST     Job Name
-              setenv    PLOT_N  `echo $EXPID | cut -b1-11`_PLT                         # PLOT     Job Name
-              setenv    MOVE_N  `echo $EXPID | cut -b1-11`_MOVE                        # MOVE     Job Name
-              setenv ARCHIVE_N  `echo $EXPID | cut -b1-10`_ARCH                        # ARCHIVE  Job Name
-              setenv REGRESS_N  `echo $EXPID | cut -b1-10`_RGRS                        # REGRESS  Job Name
-              setenv CONVERT_N  `echo $EXPID | cut -b1-11`_CNV                         # CONVERT  Job Name
+# Longer messages are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
+# and 230 with PBS. To be safe, we will limit to 200
+
+              setenv     RUN_N  `echo $EXPID | cut -b1-200`_RUN                         # RUN      Job Name
+              setenv     RUN_FN `echo $EXPID | cut -b1-200`_FCST                        # Forecast Job Name
+              setenv    POST_N  `echo $EXPID | cut -b1-199`_POST                        # POST     Job Name
+              setenv    PLOT_N  `echo $EXPID | cut -b1-200`_PLT                         # PLOT     Job Name
+              setenv    MOVE_N  `echo $EXPID | cut -b1-200`_MOVE                        # MOVE     Job Name
+              setenv ARCHIVE_N  `echo $EXPID | cut -b1-199`_ARCH                        # ARCHIVE  Job Name
+              setenv REGRESS_N  `echo $EXPID | cut -b1-199`_RGRS                        # REGRESS  Job Name
+              setenv CONVERT_N  `echo $EXPID | cut -b1-200`_CNV                         # CONVERT  Job Name
 
 # Default converter time
               setenv CONVERT_T  "0:15:00"                                              # Wallclock Time   for gcm_convert.j
@@ -3021,14 +3024,14 @@ end
 # Construct the new job ids
 # -------------------------
 
-    set RUN_N=`echo $NEWEXPID | cut -b1-11`_RUN
-   set RUN_FN=`echo $NEWEXPID | cut -b1-11`_FCST
-   set POST_N=`echo $NEWEXPID | cut -b1-10`_POST
-   set PLOT_N=`echo $NEWEXPID | cut -b1-11`_PLT
-   set MOVE_N=`echo $NEWEXPID | cut -b1-11`_MOVE
-set ARCHIVE_N=`echo $NEWEXPID | cut -b1-10`_ARCH
-set REGRESS_N=`echo $NEWEXPID | cut -b1-10`_RGRS
-set CONVERT_N=`echo $NEWEXPID | cut -b1-11`_CNV
+    set RUN_N=`echo $NEWEXPID | cut -b1-200`_RUN
+   set RUN_FN=`echo $NEWEXPID | cut -b1-200`_FCST
+   set POST_N=`echo $NEWEXPID | cut -b1-199`_POST
+   set PLOT_N=`echo $NEWEXPID | cut -b1-200`_PLT
+   set MOVE_N=`echo $NEWEXPID | cut -b1-200`_MOVE
+set ARCHIVE_N=`echo $NEWEXPID | cut -b1-199`_ARCH
+set REGRESS_N=`echo $NEWEXPID | cut -b1-199`_RGRS
+set CONVERT_N=`echo $NEWEXPID | cut -b1-200`_CNV
 
 sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$RUN_N#"     \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$RUN_N#"     $NEWHOMDIR/gcm_run.j

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1292,7 +1292,7 @@ endif
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
 
-# Longer messages are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
+# Longer job names are now supported with SLURM and PBS. Limits seem to be 1024 characters with SLURM
 # and 230 with PBS. To be safe, we will limit to 200
 
               setenv     RUN_N  `echo $EXPID | cut -b1-200`_RUN                         # RUN      Job Name


### PR DESCRIPTION
This should increase the job name limit that is in the `_setup` scripts. Back in ye olde days, PBS could only handle 16 character. Now SLURM can handle 1024 and PBS at NAS can do 230. This update puts the limit at 200...which is good for almost anything!