### PR TITLE
Use CONFIGURE_DEPENDS with GLOB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries (GEOSgcm.x ${OpenMP_Fortran_LIBRARIES})
 set_target_properties(GEOSgcm.x PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
 target_include_directories (GEOSgcm.x PUBLIC ${INC_ESMF})
 
-file (GLOB templates *.tmpl)
+file (GLOB templates CONFIGURE_DEPENDS *.tmpl)
 
 set (programs
    gcm_setup


### PR DESCRIPTION
When a `GLOB` is used in CMake, the CMake system doesn't check to see if files in the `GLOB` change when re-running `cmake`. Thus if someone adds/removes a file that the `GLOB` would pick up, say, CMake might not see there is a change and things go a bit pear-shaped. But there is [a `CONFIGURE_DEPENDS` flag](https://cmake.org/cmake/help/latest/command/file.html#glob):

> If the CONFIGURE_DEPENDS flag is specified, CMake will add logic to the main build system check target to rerun the flagged GLOB commands at build time. If any of the outputs change, CMake will regenerate the build system.

While CMake prefers no `GLOB` at all (as `CONFIGURE_DEPENDS` isn't supported for all generators), for now this is a possible partial solution until the CMake could be rewritten to explicitly list all files. 