### PR TITLE
Fixes #194. Update the PBS Batch handling at NAS

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -9,6 +9,7 @@
 #@BATCH_JOBNAME@RUN_N
 #@RUN_Q
 #@BATCH_GROUP
+#@BATCH_JOINOUTERR
 #@BATCH_NAME -o gcm_run.o@RSTDATE
 
 #######################################################################
@@ -743,15 +744,6 @@ endif
 #---------------------
 python bundleParser.py
 
-# Test if at NAS and if BATCH
-# ---------------------------
-set NAS_BATCH = FALSE
-if ($SITE == NAS) then
-   if ($PBS_ENVIRONMENT == PBS_BATCH) then
-      set NAS_BATCH = TRUE
-   endif
-endif
-
 # If REPLAY, link necessary forcing files
 # ---------------------------------------
 set  REPLAY_MODE = `grep REPLAY_MODE: AGCM.rc | grep -v '#' | cut -d: -f2`
@@ -786,11 +778,7 @@ else
    set IOSERVER_OPTIONS = ""
 endif
 
-if( $NAS_BATCH == TRUE ) then
-   @OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS --logging_config 'logging.yaml' >& $HOMDIR/gcm_run.$PBS_JOBID.$nymdc.out
-else
-   @OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS --logging_config 'logging.yaml'
-endif
+@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS --logging_config 'logging.yaml'
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh
 
 @GPUEND

--- a/gcm_setup
+++ b/gcm_setup
@@ -1277,7 +1277,7 @@ if( $SITE == 'NAS' ) then
               setenv BATCH_TIME "PBS -l walltime="    # PBS Syntax for walltime
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
-              setenv BATCH_JOINOUTERR "PBS -j oe "    # PBS Syntax for joining output and error
+              setenv BATCH_JOINOUTERR "PBS -j oe -k oed"    # PBS Syntax for joining output and error
               setenv     RUN_FT "6:00:00"             # Wallclock Time   for gcm_forecast.j
               setenv     RUN_T  "8:00:00"             # Wallclock Time   for gcm_run.j
               setenv    POST_T  "8:00:00"             # Wallclock Time   for gcm_post.j

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1328,7 +1328,7 @@ if( $SITE == 'NAS' ) then
               setenv BATCH_TIME "PBS -l walltime="    # PBS Syntax for walltime
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
-              setenv BATCH_JOINOUTERR "PBS -j oe "    # PBS Syntax for joining output and error
+              setenv BATCH_JOINOUTERR "PBS -j oe -k oed "    # PBS Syntax for joining output and error
               setenv     RUN_FT "6:00:00"             # Wallclock Time   for gcm_forecast.j
               setenv     RUN_T  "8:00:00"             # Wallclock Time   for gcm_run.j
               setenv    POST_T  "8:00:00"             # Wallclock Time   for gcm_post.j

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1456,7 +1456,7 @@ if( $SITE == 'NAS' ) then
               setenv BATCH_TIME "PBS -l walltime="    # PBS Syntax for walltime
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
-              setenv BATCH_JOINOUTERR "PBS -j oe "    # PBS Syntax for joining output and error
+              setenv BATCH_JOINOUTERR "PBS -j oe -k oed "    # PBS Syntax for joining output and error
               setenv     RUN_FT "6:00:00"             # Wallclock Time   for gcm_forecast.j
               setenv     RUN_T  "8:00:00"             # Wallclock Time   for gcm_run.j
               setenv    POST_T  "8:00:00"             # Wallclock Time   for gcm_post.j

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1313,7 +1313,7 @@ if( $SITE == 'NAS' ) then
               setenv BATCH_TIME "PBS -l walltime="    # PBS Syntax for walltime
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
-              setenv BATCH_JOINOUTERR "PBS -j oe "    # PBS Syntax for joining output and error
+              setenv BATCH_JOINOUTERR "PBS -j oe -k oed "    # PBS Syntax for joining output and error
               setenv     RUN_FT "6:00:00"             # Wallclock Time   for gcm_forecast.j
               setenv     RUN_T  "8:00:00"             # Wallclock Time   for gcm_run.j
               setenv    POST_T  "8:00:00"             # Wallclock Time   for gcm_post.j


### PR DESCRIPTION
This is an update to the PBS stdout/stderr handling at NAS. To wit, before, if run under batch, a job would produce three files:
```
stock-gcm-2021Jan19-1day-c24-BATCH_RUN.e10442444
stock-gcm-2021Jan19-1day-c24-BATCH_RUN.o10442444
gcm_run.10442444.pbspl1.nas.nasa.gov.20000414.out
```
The first two were the bits of stderr and stdout from PBS but the third was the direct output from GEOS. This made NAS unlike NCCS where SLURM puts all our output in the `slurm-42018658.out` file, say. This was done because the only way to monitor a job at NAS was to go to the head node of the compute allocation and tail the files in `/PBS/spool`

With this PR, we join stderr and stdout `-j oe`, and then use `-k oed` to now produce one file:
```
updatePBS-gcm-2021Jan19-1day-c24-BATCH_RUN.o10442667
```
that is updated as the job runs...just like SLURM!