### PR TITLE
Added optional PCHEM species file with prod/loss of strat water vapor

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -377,6 +377,11 @@ cat << _EOF_ > $FILE
 # ----------------------------------------------------------
 #/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.1870-2097.z_91x72.nc4 species.data
 
+# S2S pre-industrial with prod/loss of stratospheric water vapor
+# (AGCM.rc:  pchem_clim_years = 3-Years,  and  H2O_ProdLoss: 1 )
+# --------------------------------------------------------------
+#/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-6.wH2OandPL.1850s.z_91x72.nc4 species.data
+
 # MERRA-2 Ozone Data (AGCM.rc:  pchem_clim_years = 39-Years)
 # ----------------------------------------------------------
 /bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.MERRA2OX.197902-201706.z_91x72.nc4 species.data


### PR DESCRIPTION
This is zero diff.
The new file (listed in comments) has been used in pre-industrial climate simulations, and includes extra production and loss fields; code to use those fields has been added to the repo GEOSchem_GridComp (develop branch) PR # 112 , and the new species file serves as an example of what's needed.