### PR TITLE
Remove OCEAN_PRELOAD

### DIFF
--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -284,7 +284,7 @@ cat CAP.tmp | sed -e "s?$oldstring?$newstring?g" > CAP.rc
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x
+$RUN_CMD $NPES ./GEOSgcm.x
                                                                                                                       
 
 set date = `cat cap_restart`
@@ -346,7 +346,7 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x
+$RUN_CMD $NPES ./GEOSgcm.x
 
 foreach rst ( $rst_file_names )
   /bin/rm -f  $rst
@@ -426,7 +426,7 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x
+$RUN_CMD $NPES ./GEOSgcm.x
                                                                                                                       
 set date = `cat cap_restart`
 set nymde = $date[1]

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -778,7 +778,7 @@ else
    set IOSERVER_OPTIONS = ""
 endif
 
-@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS --logging_config 'logging.yaml'
+$RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS --logging_config 'logging.yaml'
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -506,7 +506,6 @@ if( $OGCM == TRUE ) then
     set OGRIDTYP  = "TM"
     set DATAOCEAN = "#DELETE"
     set OCEAN_NAME = ""
-    set OCEAN_PRELOAD = ""
 
     # Ocean Model
     # -----------
@@ -534,12 +533,10 @@ if( $OGCM == TRUE ) then
        set OCEAN_NAME="MOM"
        set MOM5=""
        set MOM6 = "#DELETE"
-       set OCEAN_PRELOAD='env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
        set MOM6=""
        set MOM5 = "#DELETE"
-       set OCEAN_PRELOAD='env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
     endif
 
     # Coupled Ocean Resolution
@@ -736,7 +733,6 @@ else
 
     set DATAOCEAN = ""
     set OCEAN_NAME = ""
-    set OCEAN_PRELOAD = ""
     set OGCM_LM   =  34
     set COUPLED   = "#DELETE"
     set MOM5      = "#DELETE"
@@ -2040,7 +2036,6 @@ s?>>>EMIP_OLDLAND<<<?$EMIP_OLDLAND?g
 s?>>>EMIP_NEWLAND<<<?$EMIP_NEWLAND?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
-s?@OCEAN_PRELOAD?$OCEAN_PRELOAD?g
 
 s?>>>4DIAUDAS<<<?#DELETE?g
 s?>>>REGULAR_REPLAY<<<?#?g

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -506,7 +506,6 @@ if( $OGCM == TRUE ) then
     set OGRIDTYP  = "TM"
     set DATAOCEAN = "#DELETE"
     set OCEAN_NAME = ""
-    set OCEAN_PRELOAD = ""
 
     # Ocean Model
     # -----------
@@ -534,12 +533,10 @@ if( $OGCM == TRUE ) then
        set OCEAN_NAME="MOM"
        set MOM5=""
        set MOM6 = "#DELETE"
-       set OCEAN_PRELOAD='env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
        set MOM6=""
        set MOM5 = "#DELETE"
-       set OCEAN_PRELOAD='env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
     endif
 
     # Coupled Ocean Resolution
@@ -736,7 +733,6 @@ else
 
     set DATAOCEAN = ""
     set OCEAN_NAME = ""
-    set OCEAN_PRELOAD = ""
     set OGCM_LM   =  34
     set COUPLED   = "#DELETE"
     set MOM5      = "#DELETE"
@@ -2091,7 +2087,6 @@ s?>>>EMIP_OLDLAND<<<?$EMIP_OLDLAND?g
 s?>>>EMIP_NEWLAND<<<?$EMIP_NEWLAND?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
-s?@OCEAN_PRELOAD?$OCEAN_PRELOAD?g
 
 s?>>>4DIAUDAS<<<?#DELETE?g
 s?>>>REGULAR_REPLAY<<<?#?g

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -511,7 +511,6 @@ if( $OGCM == TRUE ) then
     set OGRIDTYP  = "TM"
     set DATAOCEAN = "#DELETE"
     set OCEAN_NAME = ""
-    set OCEAN_PRELOAD = ""
 
     # Ocean Model
     # -----------
@@ -539,12 +538,10 @@ if( $OGCM == TRUE ) then
        set OCEAN_NAME="MOM"
        set MOM5=""
        set MOM6 = "#DELETE"
-       set OCEAN_PRELOAD='env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
        set MOM6=""
        set MOM5 = "#DELETE"
-       set OCEAN_PRELOAD='env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
     endif
 
     # Coupled Ocean Resolution
@@ -809,7 +806,6 @@ else
 
     set DATAOCEAN = ""
     set OCEAN_NAME = ""
-    set OCEAN_PRELOAD = ""
     set OGCM_LM   =  34
     set COUPLED   = "#DELETE"
     set MOM5      = "#DELETE"
@@ -2228,7 +2224,6 @@ s?>>>EMIP_OLDLAND<<<?$EMIP_OLDLAND?g
 s?>>>EMIP_NEWLAND<<<?$EMIP_NEWLAND?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
-s?@OCEAN_PRELOAD?$OCEAN_PRELOAD?g
 
 s?>>>4DIAUDAS<<<?#DELETE?g
 s?>>>REGULAR_REPLAY<<<?#?g

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -506,7 +506,6 @@ if( $OGCM == TRUE ) then
     set OGRIDTYP  = "TM"
     set DATAOCEAN = "#DELETE"
     set OCEAN_NAME = ""
-    set OCEAN_PRELOAD = ""
 
     # Ocean Model
     # -----------
@@ -534,12 +533,10 @@ if( $OGCM == TRUE ) then
        set OCEAN_NAME="MOM"
        set MOM5=""
        set MOM6 = "#DELETE"
-       set OCEAN_PRELOAD='env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
        set MOM6=""
        set MOM5 = "#DELETE"
-       set OCEAN_PRELOAD='env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
     endif
 
     # Coupled Ocean Resolution
@@ -736,7 +733,6 @@ else
 
     set DATAOCEAN = ""
     set OCEAN_NAME = ""
-    set OCEAN_PRELOAD = ""
     set OGCM_LM   =  34
     set COUPLED   = "#DELETE"
     set MOM5      = "#DELETE"
@@ -2076,7 +2072,6 @@ s?>>>EMIP_OLDLAND<<<?$EMIP_OLDLAND?g
 s?>>>EMIP_NEWLAND<<<?$EMIP_NEWLAND?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
-s?@OCEAN_PRELOAD?$OCEAN_PRELOAD?g
 
 s?>>>4DIAUDAS<<<?#DELETE?g
 s?>>>REGULAR_REPLAY<<<?#?g


### PR DESCRIPTION
As part of the DSO work by @weiyuan-jiang, the `OCEAN_PRELOAD` business is no longer needed. So, this PR removes `OCEAN_PRELOAD`. 

Note that this is contingent on updates to FMS (https://github.com/GEOS-ESM/GEOSgcm/pull/254), MAPL (https://github.com/GEOS-ESM/MAPL/pull/701) and GEOSgcm_GridComp (https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/377) being accepted. So I've added the blocker to this.