### PR TITLE
Update GAAS Replay fix

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -2395,7 +2395,7 @@ endif
 # Remove FVWORK/EXPID syntax from GAAS_GridComp.rc for use in REPLAY
 # ------------------------------------------------------------------
     /bin/mv $EXPDIR/RC/GAAS_GridComp.rc $EXPDIR/RC/GAAS_GridComp.tmp
-    cat $EXPDIR/RC/GAAS_GridComp.tmp | sed -e 's?${FVWORK}/${EXPID}.??g' > $EXPDIR/RC/GAAS_GridComp.rc
+    cat $EXPDIR/RC/GAAS_GridComp.tmp | sed -e 's?${FVWORK}/${EXPID}.?aod/Y%y4/M%m2/@ANA_EXPID.?g' > $EXPDIR/RC/GAAS_GridComp.rc
 
 
 # Turn on RATS_PROVIDER


### PR DESCRIPTION
Per @lltakacs, we are missing an update to gcm_setup for the GAAS ana aod replay files. This change is in CVS (say, `GEOSadas-5_27_1_p3`) but got missed on the way to Git.

It's zero-diff trivially for an AMIP, but if this isn't quite right, GAAS might not work as expected...