### PR TITLE
Change setup scripts depending on HYDROSTATIC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ target_include_directories (GEOSgcm.x PUBLIC ${INC_ESMF})
 file (GLOB templates CONFIGURE_DEPENDS *.tmpl)
 
 set (programs
-   gcm_setup
    gcm_run.j
    gcm_regress.j
    gcm_post.j
@@ -31,12 +30,9 @@ set (programs
    gcm_forecast.setup
    gcm_emip.setup
    scm_setup
-   gmichem_setup
-   geoschemchem_setup
    gcm_quickstat.j
    scm_run.j
    )
-
 
 install (
    FILES ${templates}
@@ -53,8 +49,23 @@ install (
    DESTINATION etc
    )
 
-configure_file(stratchem_setup stratchem_setup @ONLY)
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/stratchem_setup DESTINATION bin)
+if(HYDROSTATIC)
+   set(CFG_HYDROSTATIC TRUE)
+else()
+   set(CFG_HYDROSTATIC FALSE)
+endif()
+
+set (setup_scripts
+   gcm_setup
+   gmichem_setup
+   geoschemchem_setup
+   stratchem_setup
+   )
+
+foreach (file ${setup_scripts})
+   configure_file(${file} ${file} @ONLY)
+   install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${file} DESTINATION bin)
+endforeach ()
 
 configure_file(.AGCM_VERSION .AGCM_VERSION @ONLY)
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/.AGCM_VERSION DESTINATION etc)

--- a/gcm_setup
+++ b/gcm_setup
@@ -304,16 +304,9 @@ endif
 
 ASKHYDRO:
 
-if( $HRCODE == 'c1440' | \
-	 $HRCODE == 'c768'  | \
-    $HRCODE == 'c1536' | \
-    $HRCODE == 'c3072' ) then
-    set DEFAULT_HYDROSTATIC = FALSE
-else
-	 set DEFAULT_HYDROSTATIC = TRUE
-endif
+set DEFAULT_HYDROSTATIC = @CFG_HYDROSTATIC@
 
-echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}YES${CN} or ${C2}TRUE${CN} for Grid Resolutions <= C720)"
+echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}${DEFAULT_HYDROSTATIC}${CN})"
 set   USE_HYDROSTATIC = $<
 
 if( .$USE_HYDROSTATIC == . ) then

--- a/gcm_setup
+++ b/gcm_setup
@@ -285,16 +285,16 @@ ASKMP:
 #echo "   ${C2}MG3   --  6-phase 2-moment Morrison & Gettleman${CN}"
  set   AGCM_MP = $<
 if( .$AGCM_MP == . ) then
-	set AGCM_MP = "1MOM"
+   set AGCM_MP = "1MOM"
 else
-	set AGCM_MP = `echo $AGCM_MP | tr "[:lower:]" "[:upper:]"`
-	if( "$AGCM_MP" != "1MOM" & \
+   set AGCM_MP = `echo $AGCM_MP | tr "[:lower:]" "[:upper:]"`
+   if( "$AGCM_MP" != "1MOM" & \
        "$AGCM_MP" != "GFDL" & \
        "$AGCM_MP" != "MG1"  ) then
        echo
        echo "${C1}Microphysics${CN} must be one of the options below!"
        goto ASKMP
-	endif
+   endif
 endif
 
 
@@ -310,10 +310,10 @@ echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}${DEFAULT_HYDROSTATIC
 set   USE_HYDROSTATIC = $<
 
 if( .$USE_HYDROSTATIC == . ) then
-	set USE_HYDROSTATIC = $DEFAULT_HYDROSTATIC
+   set USE_HYDROSTATIC = $DEFAULT_HYDROSTATIC
 else
-	set USE_HYDROSTATIC = `echo $USE_HYDROSTATIC | tr "[:lower:]" "[:upper:]"`
-	if(  $USE_HYDROSTATIC == "Y"     | \
+   set USE_HYDROSTATIC = `echo $USE_HYDROSTATIC | tr "[:lower:]" "[:upper:]"`
+   if(  $USE_HYDROSTATIC == "Y"     | \
         $USE_HYDROSTATIC == "YES"   | \
         $USE_HYDROSTATIC == "T"     | \
         $USE_HYDROSTATIC == "TRUE"  ) set USE_HYDROSTATIC = TRUE
@@ -1067,34 +1067,43 @@ set JOB_SGMT = "$JOB_SGMT 000000"
 # For chevronned lines in AGCM.rc.tmpl
 set GFDL_HYDRO = FALSE
 if ( "$AGCM_MP" == "GFDL" ) then
-	set MP_GFDL = ""
+   set MP_GFDL = ""
 else
-	set MP_GFDL = "# "
+   set MP_GFDL = "# "
 endif
 if ( "$AGCM_MP" == "MG1" ) then
-	set MP_MG1 = ""
+   set MP_MG1 = ""
 else
-	set MP_MG1 = "# "
+   set MP_MG1 = "# "
 endif
 
 # Settings for fvcore_layout.rc
 set FV_NWAT    = ""
 set FV_ZTRACER = "z_tracer    = .T."
 if ( "$USE_HYDROSTATIC" == "TRUE" ) then
-	set FV_MAKENH     = "Make_NH     = .F."
-	set FV_HYDRO      = "hydrostatic = .T."
-	set FV_SATADJ     = "do_sat_adj  = .F."
+   set FV_MAKENH     = "Make_NH     = .F."
+   set FV_HYDRO      = "hydrostatic = .T."
+   set FV_SATADJ     = "do_sat_adj  = .F."
 else
-	set FV_MAKENH     = "Make_NH     = .T."
-	set FV_HYDRO      = "hydrostatic = .F."
-	if ( "$AGCM_MP" == "1MOM" | "$AGCM_MP" == "MG1" ) then
-		set FV_SATADJ  = "do_sat_adj = .F."
-		set FV_NWAT    = "nwat       =  3 "
-	else if ( "$AGCM_MP" == "GFDL" ) then
-		set FV_SATADJ  = "do_sat_adj = .T."
-		set FV_NWAT    = "nwat       =  6 "
-		set GFDL_HYDRO = TRUE
-	endif
+   # Logic for NH runs based on build type
+   if ( "$DEFAULT_HYDROSTATIC" == "TRUE") then
+      # If you built for hydrostatic, but want an NH run, run make_nh
+      set FV_MAKENH     = "Make_NH     = .T."
+   else
+      # If you built for non-hydrostatic and want an NH run, do not run
+      # NOTE: If you run regrid.pl it will make restarts that should trigger
+      #       make_nh automatically in FV3
+      set FV_MAKENH     = "Make_NH     = .F."
+   endif
+   set FV_HYDRO      = "hydrostatic = .F."
+   if ( "$AGCM_MP" == "1MOM" | "$AGCM_MP" == "MG1" ) then
+      set FV_SATADJ  = "do_sat_adj = .F."
+      set FV_NWAT    = "nwat       =  3 "
+   else if ( "$AGCM_MP" == "GFDL" ) then
+      set FV_SATADJ  = "do_sat_adj = .T."
+      set FV_NWAT    = "nwat       =  6 "
+      set GFDL_HYDRO = TRUE
+   endif
 endif
 
 

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -304,16 +304,9 @@ endif
 
 ASKHYDRO:
 
-if( $HRCODE == 'c1440' | \
-	 $HRCODE == 'c768'  | \
-    $HRCODE == 'c1536' | \
-    $HRCODE == 'c3072' ) then
-    set DEFAULT_HYDROSTATIC = FALSE
-else
-	 set DEFAULT_HYDROSTATIC = TRUE
-endif
+set DEFAULT_HYDROSTATIC = @CFG_HYDROSTATIC@
 
-echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}YES${CN} or ${C2}TRUE${CN} for Grid Resolutions <= C720)"
+echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}${DEFAULT_HYDROSTATIC}${CN})"
 set   USE_HYDROSTATIC = $<
 
 if( .$USE_HYDROSTATIC == . ) then

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -285,16 +285,16 @@ ASKMP:
 #echo "   ${C2}MG3   --  6-phase 2-moment Morrison & Gettleman${CN}"
  set   AGCM_MP = $<
 if( .$AGCM_MP == . ) then
-	set AGCM_MP = "1MOM"
+   set AGCM_MP = "1MOM"
 else
-	set AGCM_MP = `echo $AGCM_MP | tr "[:lower:]" "[:upper:]"`
-	if( "$AGCM_MP" != "1MOM" & \
+   set AGCM_MP = `echo $AGCM_MP | tr "[:lower:]" "[:upper:]"`
+   if( "$AGCM_MP" != "1MOM" & \
        "$AGCM_MP" != "GFDL" & \
        "$AGCM_MP" != "MG1"  ) then
        echo
        echo "${C1}Microphysics${CN} must be one of the options below!"
        goto ASKMP
-	endif
+   endif
 endif
 
 
@@ -310,10 +310,10 @@ echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}${DEFAULT_HYDROSTATIC
 set   USE_HYDROSTATIC = $<
 
 if( .$USE_HYDROSTATIC == . ) then
-	set USE_HYDROSTATIC = $DEFAULT_HYDROSTATIC
+   set USE_HYDROSTATIC = $DEFAULT_HYDROSTATIC
 else
-	set USE_HYDROSTATIC = `echo $USE_HYDROSTATIC | tr "[:lower:]" "[:upper:]"`
-	if(  $USE_HYDROSTATIC == "Y"     | \
+   set USE_HYDROSTATIC = `echo $USE_HYDROSTATIC | tr "[:lower:]" "[:upper:]"`
+   if(  $USE_HYDROSTATIC == "Y"     | \
         $USE_HYDROSTATIC == "YES"   | \
         $USE_HYDROSTATIC == "T"     | \
         $USE_HYDROSTATIC == "TRUE"  ) set USE_HYDROSTATIC = TRUE
@@ -1103,34 +1103,43 @@ set JOB_SGMT = "$JOB_SGMT 000000"
 # For chevronned lines in AGCM.rc.tmpl
 set GFDL_HYDRO = FALSE
 if ( "$AGCM_MP" == "GFDL" ) then
-	set MP_GFDL = ""
+   set MP_GFDL = ""
 else
-	set MP_GFDL = "# "
+   set MP_GFDL = "# "
 endif
 if ( "$AGCM_MP" == "MG1" ) then
-	set MP_MG1 = ""
+   set MP_MG1 = ""
 else
-	set MP_MG1 = "# "
+   set MP_MG1 = "# "
 endif
 
 # Settings for fvcore_layout.rc
 set FV_NWAT    = ""
 set FV_ZTRACER = "z_tracer    = .T."
 if ( "$USE_HYDROSTATIC" == "TRUE" ) then
-	set FV_MAKENH     = "Make_NH     = .F."
-	set FV_HYDRO      = "hydrostatic = .T."
-	set FV_SATADJ     = "do_sat_adj  = .F."
+   set FV_MAKENH     = "Make_NH     = .F."
+   set FV_HYDRO      = "hydrostatic = .T."
+   set FV_SATADJ     = "do_sat_adj  = .F."
 else
-	set FV_MAKENH     = "Make_NH     = .T."
-	set FV_HYDRO      = "hydrostatic = .F."
-	if ( "$AGCM_MP" == "1MOM" | "$AGCM_MP" == "MG1" ) then
-		set FV_SATADJ  = "do_sat_adj = .F."
-		set FV_NWAT    = "nwat       =  3 "
-	else if ( "$AGCM_MP" == "GFDL" ) then
-		set FV_SATADJ  = "do_sat_adj = .T."
-		set FV_NWAT    = "nwat       =  6 "
-		set GFDL_HYDRO = TRUE
-	endif
+   # Logic for NH runs based on build type
+   if ( "$DEFAULT_HYDROSTATIC" == "TRUE") then
+      # If you built for hydrostatic, but want an NH run, run make_nh
+      set FV_MAKENH     = "Make_NH     = .T."
+   else
+      # If you built for non-hydrostatic and want an NH run, do not run
+      # NOTE: If you run regrid.pl it will make restarts that should trigger
+      #       make_nh automatically in FV3
+      set FV_MAKENH     = "Make_NH     = .F."
+   endif
+   set FV_HYDRO      = "hydrostatic = .F."
+   if ( "$AGCM_MP" == "1MOM" | "$AGCM_MP" == "MG1" ) then
+      set FV_SATADJ  = "do_sat_adj = .F."
+      set FV_NWAT    = "nwat       =  3 "
+   else if ( "$AGCM_MP" == "GFDL" ) then
+      set FV_SATADJ  = "do_sat_adj = .T."
+      set FV_NWAT    = "nwat       =  6 "
+      set GFDL_HYDRO = TRUE
+   endif
 endif
 
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -304,16 +304,9 @@ endif
 
 ASKHYDRO:
 
-if( $HRCODE == 'c1440' | \
-	 $HRCODE == 'c768'  | \
-    $HRCODE == 'c1536' | \
-    $HRCODE == 'c3072' ) then
-    set DEFAULT_HYDROSTATIC = FALSE
-else
-	 set DEFAULT_HYDROSTATIC = TRUE
-endif
+set DEFAULT_HYDROSTATIC = @CFG_HYDROSTATIC@
 
-echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}YES${CN} or ${C2}TRUE${CN} for Grid Resolutions <= C720)"
+echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}${DEFAULT_HYDROSTATIC}${CN})"
 set   USE_HYDROSTATIC = $<
 
 if( .$USE_HYDROSTATIC == . ) then

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -285,16 +285,16 @@ ASKMP:
 #echo "   ${C2}MG3   --  6-phase 2-moment Morrison & Gettleman${CN}"
  set   AGCM_MP = $<
 if( .$AGCM_MP == . ) then
-	set AGCM_MP = "1MOM"
+   set AGCM_MP = "1MOM"
 else
-	set AGCM_MP = `echo $AGCM_MP | tr "[:lower:]" "[:upper:]"`
-	if( "$AGCM_MP" != "1MOM" & \
+   set AGCM_MP = `echo $AGCM_MP | tr "[:lower:]" "[:upper:]"`
+   if( "$AGCM_MP" != "1MOM" & \
        "$AGCM_MP" != "GFDL" & \
        "$AGCM_MP" != "MG1"  ) then
        echo
        echo "${C1}Microphysics${CN} must be one of the options below!"
        goto ASKMP
-	endif
+   endif
 endif
 
 
@@ -310,10 +310,10 @@ echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}${DEFAULT_HYDROSTATIC
 set   USE_HYDROSTATIC = $<
 
 if( .$USE_HYDROSTATIC == . ) then
-	set USE_HYDROSTATIC = $DEFAULT_HYDROSTATIC
+   set USE_HYDROSTATIC = $DEFAULT_HYDROSTATIC
 else
-	set USE_HYDROSTATIC = `echo $USE_HYDROSTATIC | tr "[:lower:]" "[:upper:]"`
-	if(  $USE_HYDROSTATIC == "Y"     | \
+   set USE_HYDROSTATIC = `echo $USE_HYDROSTATIC | tr "[:lower:]" "[:upper:]"`
+   if(  $USE_HYDROSTATIC == "Y"     | \
         $USE_HYDROSTATIC == "YES"   | \
         $USE_HYDROSTATIC == "T"     | \
         $USE_HYDROSTATIC == "TRUE"  ) set USE_HYDROSTATIC = TRUE
@@ -1176,34 +1176,43 @@ set JOB_SGMT = "$JOB_SGMT 000000"
 # For chevronned lines in AGCM.rc.tmpl
 set GFDL_HYDRO = FALSE
 if ( "$AGCM_MP" == "GFDL" ) then
-	set MP_GFDL = ""
+   set MP_GFDL = ""
 else
-	set MP_GFDL = "# "
+   set MP_GFDL = "# "
 endif
 if ( "$AGCM_MP" == "MG1" ) then
-	set MP_MG1 = ""
+   set MP_MG1 = ""
 else
-	set MP_MG1 = "# "
+   set MP_MG1 = "# "
 endif
 
 # Settings for fvcore_layout.rc
 set FV_NWAT    = ""
 set FV_ZTRACER = "z_tracer    = .T."
 if ( "$USE_HYDROSTATIC" == "TRUE" ) then
-	set FV_MAKENH     = "Make_NH     = .F."
-	set FV_HYDRO      = "hydrostatic = .T."
-	set FV_SATADJ     = "do_sat_adj  = .F."
+   set FV_MAKENH     = "Make_NH     = .F."
+   set FV_HYDRO      = "hydrostatic = .T."
+   set FV_SATADJ     = "do_sat_adj  = .F."
 else
-	set FV_MAKENH     = "Make_NH     = .T."
-	set FV_HYDRO      = "hydrostatic = .F."
-	if ( "$AGCM_MP" == "1MOM" | "$AGCM_MP" == "MG1" ) then
-		set FV_SATADJ  = "do_sat_adj = .F."
-		set FV_NWAT    = "nwat       =  3 "
-	else if ( "$AGCM_MP" == "GFDL" ) then
-		set FV_SATADJ  = "do_sat_adj = .T."
-		set FV_NWAT    = "nwat       =  6 "
-		set GFDL_HYDRO = TRUE
-	endif
+   # Logic for NH runs based on build type
+   if ( "$DEFAULT_HYDROSTATIC" == "TRUE") then
+      # If you built for hydrostatic, but want an NH run, run make_nh
+      set FV_MAKENH     = "Make_NH     = .T."
+   else
+      # If you built for non-hydrostatic and want an NH run, do not run
+      # NOTE: If you run regrid.pl it will make restarts that should trigger
+      #       make_nh automatically in FV3
+      set FV_MAKENH     = "Make_NH     = .F."
+   endif
+   set FV_HYDRO      = "hydrostatic = .F."
+   if ( "$AGCM_MP" == "1MOM" | "$AGCM_MP" == "MG1" ) then
+      set FV_SATADJ  = "do_sat_adj = .F."
+      set FV_NWAT    = "nwat       =  3 "
+   else if ( "$AGCM_MP" == "GFDL" ) then
+      set FV_SATADJ  = "do_sat_adj = .T."
+      set FV_NWAT    = "nwat       =  6 "
+      set GFDL_HYDRO = TRUE
+   endif
 endif
 
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -304,16 +304,9 @@ endif
 
 ASKHYDRO:
 
-if( $HRCODE == 'c1440' | \
-	 $HRCODE == 'c768'  | \
-    $HRCODE == 'c1536' | \
-    $HRCODE == 'c3072' ) then
-    set DEFAULT_HYDROSTATIC = FALSE
-else
-	 set DEFAULT_HYDROSTATIC = TRUE
-endif
+set DEFAULT_HYDROSTATIC = @CFG_HYDROSTATIC@
 
-echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}YES${CN} or ${C2}TRUE${CN} for Grid Resolutions <= C720)"
+echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}${DEFAULT_HYDROSTATIC}${CN})"
 set   USE_HYDROSTATIC = $<
 
 if( .$USE_HYDROSTATIC == . ) then

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -285,16 +285,16 @@ ASKMP:
 #echo "   ${C2}MG3   --  6-phase 2-moment Morrison & Gettleman${CN}"
  set   AGCM_MP = $<
 if( .$AGCM_MP == . ) then
-	set AGCM_MP = "1MOM"
+   set AGCM_MP = "1MOM"
 else
-	set AGCM_MP = `echo $AGCM_MP | tr "[:lower:]" "[:upper:]"`
-	if( "$AGCM_MP" != "1MOM" & \
+   set AGCM_MP = `echo $AGCM_MP | tr "[:lower:]" "[:upper:]"`
+   if( "$AGCM_MP" != "1MOM" & \
        "$AGCM_MP" != "GFDL" & \
        "$AGCM_MP" != "MG1"  ) then
        echo
        echo "${C1}Microphysics${CN} must be one of the options below!"
        goto ASKMP
-	endif
+   endif
 endif
 
 
@@ -310,10 +310,10 @@ echo "Use ${C1}Hydrostatic Atmosphere${CN}? (Default: ${C2}${DEFAULT_HYDROSTATIC
 set   USE_HYDROSTATIC = $<
 
 if( .$USE_HYDROSTATIC == . ) then
-	set USE_HYDROSTATIC = $DEFAULT_HYDROSTATIC
+   set USE_HYDROSTATIC = $DEFAULT_HYDROSTATIC
 else
-	set USE_HYDROSTATIC = `echo $USE_HYDROSTATIC | tr "[:lower:]" "[:upper:]"`
-	if(  $USE_HYDROSTATIC == "Y"     | \
+   set USE_HYDROSTATIC = `echo $USE_HYDROSTATIC | tr "[:lower:]" "[:upper:]"`
+   if(  $USE_HYDROSTATIC == "Y"     | \
         $USE_HYDROSTATIC == "YES"   | \
         $USE_HYDROSTATIC == "T"     | \
         $USE_HYDROSTATIC == "TRUE"  ) set USE_HYDROSTATIC = TRUE
@@ -1103,34 +1103,43 @@ set JOB_SGMT = "$JOB_SGMT 000000"
 # For chevronned lines in AGCM.rc.tmpl
 set GFDL_HYDRO = FALSE
 if ( "$AGCM_MP" == "GFDL" ) then
-	set MP_GFDL = ""
+   set MP_GFDL = ""
 else
-	set MP_GFDL = "# "
+   set MP_GFDL = "# "
 endif
 if ( "$AGCM_MP" == "MG1" ) then
-	set MP_MG1 = ""
+   set MP_MG1 = ""
 else
-	set MP_MG1 = "# "
+   set MP_MG1 = "# "
 endif
 
 # Settings for fvcore_layout.rc
 set FV_NWAT    = ""
 set FV_ZTRACER = "z_tracer    = .T."
 if ( "$USE_HYDROSTATIC" == "TRUE" ) then
-	set FV_MAKENH     = "Make_NH     = .F."
-	set FV_HYDRO      = "hydrostatic = .T."
-	set FV_SATADJ     = "do_sat_adj  = .F."
+   set FV_MAKENH     = "Make_NH     = .F."
+   set FV_HYDRO      = "hydrostatic = .T."
+   set FV_SATADJ     = "do_sat_adj  = .F."
 else
-	set FV_MAKENH     = "Make_NH     = .T."
-	set FV_HYDRO      = "hydrostatic = .F."
-	if ( "$AGCM_MP" == "1MOM" | "$AGCM_MP" == "MG1" ) then
-		set FV_SATADJ  = "do_sat_adj = .F."
-		set FV_NWAT    = "nwat       =  3 "
-	else if ( "$AGCM_MP" == "GFDL" ) then
-		set FV_SATADJ  = "do_sat_adj = .T."
-		set FV_NWAT    = "nwat       =  6 "
-		set GFDL_HYDRO = TRUE
-	endif
+   # Logic for NH runs based on build type
+   if ( "$DEFAULT_HYDROSTATIC" == "TRUE") then
+      # If you built for hydrostatic, but want an NH run, run make_nh
+      set FV_MAKENH     = "Make_NH     = .T."
+   else
+      # If you built for non-hydrostatic and want an NH run, do not run
+      # NOTE: If you run regrid.pl it will make restarts that should trigger
+      #       make_nh automatically in FV3
+      set FV_MAKENH     = "Make_NH     = .F."
+   endif
+   set FV_HYDRO      = "hydrostatic = .F."
+   if ( "$AGCM_MP" == "1MOM" | "$AGCM_MP" == "MG1" ) then
+      set FV_SATADJ  = "do_sat_adj = .F."
+      set FV_NWAT    = "nwat       =  3 "
+   else if ( "$AGCM_MP" == "GFDL" ) then
+      set FV_SATADJ  = "do_sat_adj = .T."
+      set FV_NWAT    = "nwat       =  6 "
+      set GFDL_HYDRO = TRUE
+   endif
 endif
 
 


### PR DESCRIPTION
This PR will change setup scripts depending on what `-DHYDROSTATIC` option was supplied to CMake. So if you provide `-DHYDROSTATIC=ON` then it will assume you want to use hydrostatic dynamics options and vice versa.

Note: This requires fvdycore v1.1.5 (see https://github.com/GEOS-ESM/GEOSgcm/pull/273)