### PR TITLE
Update MAPL logger

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -87,8 +87,8 @@ loggers:
        
    MAPL:
        handlers: [mpi_shared]
-       level: INFO
-       root_level: DEBUG
+       level: WARNING
+       root_level: INFO
 
   # Note: When enabling another logger, make sure
   #       indentation matches that of the above 


### PR DESCRIPTION
In https://github.com/GEOS-ESM/MAPL/pull/801 I've added some debug pFlogger messages for the NRL Sun code. While this doesn't hurt anything, the default level of logging for MAPL is currently `DEBUG` on root. So, once https://github.com/GEOS-ESM/MAPL/pull/801 goes in, the NRL sun code will get noisy in logging, e.g.,:
```
0000: MAPL.SUN: DEBUG: Off the end of table, moving into last complete cycle
0000: MAPL.SUN: DEBUG:   Original Year-Mon-Day to Find: 2021-02-15
0000: MAPL.SUN: DEBUG:   Original Day of Year: 46
0000: MAPL.SUN: DEBUG:   New Year-Mon-Day to Find: 2010-02-16
0000: MAPL.SUN: DEBUG:   New Day of Year: 47
0000: MAPL.SUN: DEBUG:   First DOY to Find:      47
0000: MAPL.SUN: DEBUG:     file_index for date:  46798
0000: MAPL.SUN: DEBUG:     yearTable(date):     2010
0000: MAPL.SUN: DEBUG:     doyTable(date):       47
0000: MAPL.SUN: DEBUG:     tsi(date):           1360.960
0000: MAPL.SUN: DEBUG:     mgindex(date):       0.153700
0000: MAPL.SUN: DEBUG:     sbindex(date):        124.7500
0000: MAPL.SUN: DEBUG:   Second DOY to Find:     48
0000: MAPL.SUN: DEBUG:     file_index for date:  46799
0000: MAPL.SUN: DEBUG:     yearTable(date):     2010
0000: MAPL.SUN: DEBUG:     doyTable(date):       48
0000: MAPL.SUN: DEBUG:     tsi(date):           1360.963
0000: MAPL.SUN: DEBUG:     mgindex(date):       0.153800
0000: MAPL.SUN: DEBUG:     sbindex(date):        144.0400
0000: MAPL.SUN: DEBUG:   Interpolation Factor:  0.625000
```
So, instead, we move the MAPL logger to be `WARNING` on all PEs and `INFO` on root (per consultation with @tclune ). Then, if @dr0cloud, say, wants to debug the code, he can change the `logging.yaml` to use `DEBUG` and see these prints. 