### PR TITLE
Fix option: _dual_ocean_ since it applies to MOM5

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -799,15 +799,15 @@ USE_SATSIM_MISR:  @MISR_SATSIM
 >>>COUPLED<<<steady_state_ocean: 0
 >>>COUPLED<<<OCEAN_PICE_SCALING: 0.0
 
-# For running coupled model in dual ocean mode, uncomment three lines below, 
+# For running MOM5 coupled model in dual ocean mode, uncomment three lines below, 
 # make sure that regular replay is enabled, proper PRECIP_FILE is chosen,
 # sst.data and fraci.data are pointing to read forcing files on tripolar grid,
 # the run starts at 21z/03z/09z/15z, 
 # HISTORY.rc collections have proper ref_time field
 # ---------------------------------------------------------------------------
-#DUAL_OCEAN: 1
-#DATA_SST_FILE: sst.data
-#DATA_FRT_FILE: fraci.data
+>>>MOM5<<<#DUAL_OCEAN: 1
+>>>MOM5<<<#DATA_SST_FILE: sst.data
+>>>MOM5<<<#DATA_FRT_FILE: fraci.data
 
 >>>COUPLED<<<
 >>>COUPLED<<<# Section for CICE 


### PR DESCRIPTION
The option to run coupled model in with the `DUAL_OCEAN:1` only works with MOM5 ocean model. 
It does not and can not work with MOM6 ocean model, [see for more details](https://github.com/GEOS-ESM/GEOSgcm_GridComp/issues/322).

Fixing the `AGCM.rc.tmpl` is essential to avoid any confusion about this option and its functionality.