### PR TITLE
changed the component name specification for CICEDyna

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -653,13 +653,13 @@ SEAICETHERMO_INTERNAL_RESTART_FILE:     seaicethermo_internal_rst
 SEAICETHERMO_INTERNAL_CHECKPOINT_FILE:  seaicethermo_internal_checkpoint
 SEAICETHERMO_INTERNAL_CHECKPOINT_TYPE:  @CHECKPOINT_TYPE
 
->>>COUPLED<<<SEAICE_IMPORT_RESTART_FILE:             seaice_import_rst
->>>COUPLED<<<SEAICE_IMPORT_CHECKPOINT_FILE:          seaice_import_checkpoint
->>>COUPLED<<<SEAICE_IMPORT_CHECKPOINT_TYPE:          @CHECKPOINT_TYPE
+>>>COUPLED<<<CICE4_IMPORT_RESTART_FILE:             seaice_import_rst
+>>>COUPLED<<<CICE4_IMPORT_CHECKPOINT_FILE:          seaice_import_checkpoint
+>>>COUPLED<<<CICE4_IMPORT_CHECKPOINT_TYPE:          @CHECKPOINT_TYPE
 
->>>COUPLED<<<SEAICE_INTERNAL_RESTART_FILE:           seaice_internal_rst
->>>COUPLED<<<SEAICE_INTERNAL_CHECKPOINT_FILE:        seaice_internal_checkpoint
->>>COUPLED<<<SEAICE_INTERNAL_CHECKPOINT_TYPE:        @CHECKPOINT_TYPE
+>>>COUPLED<<<CICE4_INTERNAL_RESTART_FILE:           seaice_internal_rst
+>>>COUPLED<<<CICE4_INTERNAL_CHECKPOINT_FILE:        seaice_internal_checkpoint
+>>>COUPLED<<<CICE4_INTERNAL_CHECKPOINT_TYPE:        @CHECKPOINT_TYPE
 
 >>>COUPLED<<<OCEAN_INTERNAL_RESTART_FILE:               ocean_internal_rst
 >>>COUPLED<<<OCEAN_INTERNAL_CHECKPOINT_FILE:            ocean_internal_checkpoint


### PR DESCRIPTION
This PR changed the component name specification in `AGCM.rc.tmpl` for `CICEDyna` grid comp from `SEAICE` to `CICE4`. It is required by the newly introduced `GEOS_SeaIceGridComp`.

It is continent on https://github.com/GEOS-ESM/GEOSgcm_GridComp/issues/424

