### PR TITLE
Fixes for IOSERVER on Rome

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -772,13 +772,33 @@ setenv OMP_NUM_THREADS 1
 # -------------
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 
-if( $USE_IOSERVER == 1) then
+if( $USE_IOSERVER == 1 ) then
    set IOSERVER_OPTIONS = "--npes_model $MODEL_NPES --nodes_output_server $IOS_NODES"
+   set IOSERVER_EXTRA = ""
+
+   # Rome requires some extra bits for IOSERVER as it requires
+   # multigroup server with less PEs per backend node
+   if ( -x /usr/local/bin/nas_info ) then
+      set PROCTYPE=`/usr/local/bin/nas_info --nasmodel`
+      if ( $PROCTYPE == rom ) then
+         # Per Weiyuan Jiang, the ideal number of backend PEs is based on the
+         # number of HISTORY collections and number of IO nodes
+
+         # First we figure out the number of collections in the HISTORY.rc (this is not perfect, but is close to right)
+         set NUM_HIST_COLS = `cat HISTORY.rc | sed -n '/^COLLECTIONS:/,/^ *::$/{p;/^ *::$/q}' | grep -v '^ *#' | wc -l`
+
+         # Now we divide that number of collections by the ioserver nodes
+         set NUM_BACKEND_PES = `echo "scale=1;(($NUM_HIST_COLS - 1) / $IOS_NODES)" | bc | awk '{print int($1 + 0.5)}'`
+
+         set IOSERVER_EXTRA = "--oserver_type multigroup --npes_backend_pernode $NUM_BACKEND_PES"
+      endif
+   endif
 else
    set IOSERVER_OPTIONS = ""
+   set IOSERVER_EXTRA = ""
 endif
 
-$RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS --logging_config 'logging.yaml'
+$RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 


### PR DESCRIPTION
We know on the Romes that using the MAPL IOSERVER "out of the box" doesn't quite work well. Probably has to do with the number of cores on the Rome being stupid high and...doing things wrong? Dunno.

But, working with @weiyuan-jiang, it was found that the Romes work better if we use the MultiGroup server version of IOSERVER. So this PR tries to "automate" what @weiyuan-jiang said is the best way to set up the MultiGroup server. To wit, he says the best number of backend PEs is the number of history collections divided by the number of ioserver nodes.

This change tries to do that. First, using some `sed` we try to calculate the number of history collections active. I tried my best but I'm guessing somewhere out there is a HISTORY.rc that will break this, but it works with the `HISTORY.AGCM.rc.tmpl` so that's something. 

Once we get that number, we then remove one from it (for the `::` line), and then divide by the number of ionodes. I try to do some ugly `bc` and `awk` to "round up".

Note, it's possible eventually we'd want GEOS to *always* use the MultiGroup server? I'll leave that determination to @bena-nasa, @aoloso, @tclune, and @weiyuan-jiang. Good thing is, we have the code here for it, and we can just make it "everywhere" instead of "just Rome".