### PR TITLE
Make species consistent with emissions choice

### DIFF
--- a/gcm_convert.j
+++ b/gcm_convert.j
@@ -222,15 +222,20 @@ cat << _EOF_ > $FILE
 
 # DAS or REPLAY Mode (AGCM.rc:  pchem_clim_years = 1-Year Climatology)
 # --------------------------------------------------------------------
-#/bin/ln -sf $BCSDIR/Shared/pchem.species.Clim_Prod_Loss.z_721x72.nc4 species.data
+@OPS_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.Clim_Prod_Loss.z_721x72.nc4 species.data
 
 # CMIP-5 Ozone Data (AGCM.rc:  pchem_clim_years = 228-Years)
 # ----------------------------------------------------------
-#bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.1870-2097.z_91x72.nc4 species.data
+@CMIP_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.1870-2097.z_91x72.nc4 species.data
+
+# S2S pre-industrial with prod/loss of stratospheric water vapor
+# (AGCM.rc:  pchem_clim_years = 3-Years,  and  H2O_ProdLoss: 1 )
+# --------------------------------------------------------------
+#/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-6.wH2OandPL.1850s.z_91x72.nc4 species.data
 
 # MERRA-2 Ozone Data (AGCM.rc:  pchem_clim_years = 39-Years)
 # ----------------------------------------------------------
-/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.MERRA2OX.197902-201706.z_91x72.nc4 species.data
+@MERRA2OX_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.MERRA2OX.197902-201706.z_91x72.nc4 species.data
 
 /bin/ln -sf $BCSDIR/Shared/*bin .
 /bin/ln -sf $BCSDIR/Shared/*c2l*.nc4 .

--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -418,15 +418,20 @@ cat << _EOF_ > $FILE
 
 # DAS or REPLAY Mode (AGCM.rc:  pchem_clim_years = 1-Year Climatology)
 # --------------------------------------------------------------------
-/bin/ln -sf $BCSDIR/Shared/pchem.species.Clim_Prod_Loss.z_721x72.nc4 species.data
+@OPS_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.Clim_Prod_Loss.z_721x72.nc4 species.data
 
 # CMIP-5 Ozone Data (228-Years)
 # -----------------------------
-#/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.1870-2097.z_91x72.nc4 species.data
+@CMIP_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.1870-2097.z_91x72.nc4 species.data
+
+# S2S pre-industrial with prod/loss of stratospheric water vapor
+# (AGCM.rc:  pchem_clim_years = 3-Years,  and  H2O_ProdLoss: 1 )
+# --------------------------------------------------------------
+#/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-6.wH2OandPL.1850s.z_91x72.nc4 species.data
 
 # MERRA-2 Ozone Data (39-Years)
 # -----------------------------
-#/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.MERRA2OX.197902-201706.z_91x72.nc4 species.data
+@MERRA2OX_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.MERRA2OX.197902-201706.z_91x72.nc4 species.data
 
 /bin/ln -sf $BCSDIR/Shared/*bin .
 /bin/ln -sf $BCSDIR/Shared/*c2l*.nc4 .

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -371,11 +371,11 @@ cat << _EOF_ > $FILE
 
 # DAS or REPLAY Mode (AGCM.rc:  pchem_clim_years = 1-Year Climatology)
 # --------------------------------------------------------------------
-#/bin/ln -sf $BCSDIR/Shared/pchem.species.Clim_Prod_Loss.z_721x72.nc4 species.data
+@OPS_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.Clim_Prod_Loss.z_721x72.nc4 species.data
 
 # CMIP-5 Ozone Data (AGCM.rc:  pchem_clim_years = 228-Years)
 # ----------------------------------------------------------
-#/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.1870-2097.z_91x72.nc4 species.data
+@CMIP_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.1870-2097.z_91x72.nc4 species.data
 
 # S2S pre-industrial with prod/loss of stratospheric water vapor
 # (AGCM.rc:  pchem_clim_years = 3-Years,  and  H2O_ProdLoss: 1 )
@@ -384,7 +384,7 @@ cat << _EOF_ > $FILE
 
 # MERRA-2 Ozone Data (AGCM.rc:  pchem_clim_years = 39-Years)
 # ----------------------------------------------------------
-/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.MERRA2OX.197902-201706.z_91x72.nc4 species.data
+@MERRA2OX_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.MERRA2OX.197902-201706.z_91x72.nc4 species.data
 
 /bin/ln -sf $BCSDIR/Shared/*bin .
 /bin/ln -sf $BCSDIR/Shared/*c2l*.nc4 .

--- a/gcm_setup
+++ b/gcm_setup
@@ -1188,6 +1188,10 @@ endif
 if(  $GOKART == "A" ) set GOKART = TRUE    # Use Actual         Aerosols
 if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 
+# Default setup for linkbcs emissions
+set OPS_SPECIES      = "#"
+set CMIP_SPECIES     = "#"
+set MERRA2OX_SPECIES = "#"
 
 if( $GOKART == TRUE ) then
 
@@ -1214,6 +1218,19 @@ EMISSIONS:
      endif
      endif
      if(  $EMISSIONS == OPS ) set EMISSIONS = ''
+
+     # Fix up the linkbcs species.data
+     # NOTE: If OPS is selected, EMISSIONS is blanked
+     if(  $EMISSIONS == '' ) then
+        set OPS_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 1
+     else if(  $EMISSIONS == CMIP ) then
+        set CMIP_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 228
+     else
+        set MERRA2OX_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 39
+     endif
 
 # AERO Provider
 # -------------
@@ -2034,6 +2051,9 @@ s?>>>MOM5<<<?$MOM5?g
 s?>>>MOM6<<<?$MOM6?g
 s?>>>DATAOCEAN<<<?$DATAOCEAN?g
 s?>>>GOCART<<<?$GOCART?g
+s?@OPS_SPECIES?$OPS_SPECIES?g
+s?@CMIP_SPECIES?$CMIP_SPECIES?g
+s?@MERRA2OX_SPECIES?$MERRA2OX_SPECIES?g
 s?>>>FVCUBED<<<?$FVCUBED?g
 s?>>>HIST_GOCART<<<?$HIST_GOCART?g
 s?>>>OSTIA<<<?$OSTIA?g
@@ -2056,8 +2076,7 @@ s?@REPLAY_ANA_LOCATION?$REPLAY_ANA_LOCATION?g
 s?@M2_REPLAY_ANA_LOCATION?$M2_REPLAY_ANA_LOCATION?g
 
 s?@OX_RELAXTIME?259200.?g
-#s?@PCHEM_CLIM_YEARS?228?g
-s?@PCHEM_CLIM_YEARS?39?g
+s?@PCHEM_CLIM_YEARS?$PCHEM_CLIM_YEARS?g
 
 s?@RATS_PROVIDER?$RATS_PROVIDER?g
 s?@AERO_PROVIDER?$AERO_PROVIDER?g

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1224,6 +1224,10 @@ endif
 if(  $GOKART == "A" ) set GOKART = TRUE    # Use Actual         Aerosols
 if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 
+# Default setup for linkbcs emissions
+set OPS_SPECIES      = "#"
+set CMIP_SPECIES     = "#"
+set MERRA2OX_SPECIES = "#"
 
 if( $GOKART == TRUE ) then
 
@@ -1250,6 +1254,19 @@ EMISSIONS:
      endif
      endif
      if(  $EMISSIONS == OPS ) set EMISSIONS = ''
+
+     # Fix up the linkbcs species.data
+     # NOTE: If OPS is selected, EMISSIONS is blanked
+     if(  $EMISSIONS == '' ) then
+        set OPS_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 1
+     else if(  $EMISSIONS == CMIP ) then
+        set CMIP_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 228
+     else
+        set MERRA2OX_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 39
+     endif
 
 # AERO Provider
 # -------------
@@ -2085,6 +2102,9 @@ s?>>>MOM5<<<?$MOM5?g
 s?>>>MOM6<<<?$MOM6?g
 s?>>>DATAOCEAN<<<?$DATAOCEAN?g
 s?>>>GOCART<<<?$GOCART?g
+s?@OPS_SPECIES?$OPS_SPECIES?g
+s?@CMIP_SPECIES?$CMIP_SPECIES?g
+s?@MERRA2OX_SPECIES?$MERRA2OX_SPECIES?g
 s?>>>FVCUBED<<<?$FVCUBED?g
 s?>>>HIST_GOCART<<<?$HIST_GOCART?g
 s?>>>OSTIA<<<?$OSTIA?g
@@ -2107,8 +2127,7 @@ s?@REPLAY_ANA_LOCATION?$REPLAY_ANA_LOCATION?g
 s?@M2_REPLAY_ANA_LOCATION?$M2_REPLAY_ANA_LOCATION?g
 
 s?@OX_RELAXTIME?259200.?g
-#s?@PCHEM_CLIM_YEARS?228?g
-s?@PCHEM_CLIM_YEARS?39?g
+s?@PCHEM_CLIM_YEARS?$PCHEM_CLIM_YEARS?g
 
 s?@RATS_PROVIDER?$RATS_PROVIDER?g
 s?@AERO_PROVIDER?$AERO_PROVIDER?g

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1329,6 +1329,10 @@ if($APNum == 3) then
  set AERO_PROVIDER = GMICHEM
 endif
 
+# Default setup for linkbcs emissions
+set OPS_SPECIES      = "#"
+set CMIP_SPECIES     = "#"
+set MERRA2OX_SPECIES = "#"
 
 if( $GOKART == TRUE ) then
 
@@ -1371,6 +1375,18 @@ EMISSIONS:
      endif
      if(  $EMISSIONS == OPS ) set EMISSIONS = ''
 
+     # Fix up the linkbcs species.data
+     # NOTE: If OPS is selected, EMISSIONS is blanked
+     if(  $EMISSIONS == '' ) then
+        set OPS_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 1
+     else if(  $EMISSIONS == CMIP ) then
+        set CMIP_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 228
+     else
+        set MERRA2OX_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 39
+     endif
 endif
 
 # GMI past experiment settings
@@ -2222,6 +2238,9 @@ s?>>>MOM5<<<?$MOM5?g
 s?>>>MOM6<<<?$MOM6?g
 s?>>>DATAOCEAN<<<?$DATAOCEAN?g
 s?>>>GOCART<<<?$GOCART?g
+s?@OPS_SPECIES?$OPS_SPECIES?g
+s?@CMIP_SPECIES?$CMIP_SPECIES?g
+s?@MERRA2OX_SPECIES?$MERRA2OX_SPECIES?g
 s?>>>FVCUBED<<<?$FVCUBED?g
 s?>>>HIST_GOCART<<<?$HIST_GOCART?g
 s?>>>OSTIA<<<?$OSTIA?g
@@ -2244,8 +2263,7 @@ s?@REPLAY_ANA_LOCATION?$REPLAY_ANA_LOCATION?g
 s?@M2_REPLAY_ANA_LOCATION?$M2_REPLAY_ANA_LOCATION?g
 
 s?@OX_RELAXTIME?259200.?g
-#s?@PCHEM_CLIM_YEARS?228?g
-s?@PCHEM_CLIM_YEARS?39?g
+s?@PCHEM_CLIM_YEARS?$PCHEM_CLIM_YEARS?g
 
 s?@RATS_PROVIDER?$RATS_PROVIDER?g
 s?@AERO_PROVIDER?$AERO_PROVIDER?g

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1224,6 +1224,10 @@ endif
 if(  $GOKART == "A" ) set GOKART = TRUE    # Use Actual         Aerosols
 if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 
+# Default setup for linkbcs emissions
+set OPS_SPECIES      = "#"
+set CMIP_SPECIES     = "#"
+set MERRA2OX_SPECIES = "#"
 
 if( $GOKART == TRUE ) then
 
@@ -1250,6 +1254,19 @@ EMISSIONS:
      endif
      endif
      if(  $EMISSIONS == OPS ) set EMISSIONS = ''
+
+     # Fix up the linkbcs species.data
+     # NOTE: If OPS is selected, EMISSIONS is blanked
+     if(  $EMISSIONS == '' ) then
+        set OPS_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 1
+     else if(  $EMISSIONS == CMIP ) then
+        set CMIP_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 228
+     else
+        set MERRA2OX_SPECIES = ''
+        set PCHEM_CLIM_YEARS = 39
+     endif
 
 # AERO Provider
 # -------------
@@ -2070,6 +2087,9 @@ s?>>>MOM5<<<?$MOM5?g
 s?>>>MOM6<<<?$MOM6?g
 s?>>>DATAOCEAN<<<?$DATAOCEAN?g
 s?>>>GOCART<<<?$GOCART?g
+s?@OPS_SPECIES?$OPS_SPECIES?g
+s?@CMIP_SPECIES?$CMIP_SPECIES?g
+s?@MERRA2OX_SPECIES?$MERRA2OX_SPECIES?g
 s?>>>FVCUBED<<<?$FVCUBED?g
 s?>>>HIST_GOCART<<<?$HIST_GOCART?g
 s?>>>OSTIA<<<?$OSTIA?g
@@ -2092,8 +2112,7 @@ s?@REPLAY_ANA_LOCATION?$REPLAY_ANA_LOCATION?g
 s?@M2_REPLAY_ANA_LOCATION?$M2_REPLAY_ANA_LOCATION?g
 
 s?@OX_RELAXTIME?259200.?g
-#s?@PCHEM_CLIM_YEARS?228?g
-s?@PCHEM_CLIM_YEARS?39?g
+s?@PCHEM_CLIM_YEARS?$PCHEM_CLIM_YEARS?g
 
 s?@RATS_PROVIDER?$RATS_PROVIDER?g
 s?@AERO_PROVIDER?$AERO_PROVIDER?g


### PR DESCRIPTION
Per a discussion between @sdrabenh and myself, it seems "right" that if you select OPS emissions in `gcm_setup`, you should also use the OPS species file (prod/loss). If not, sometimes you get the "MERRA2OX Crash" a la #218 and #233 .

What this PR does is try and say:

- If you choose OPS emissions, use the OPS prod/loss species, `pchem_clim_years: 1`
- If you choose CMIP emissions, use the CMIP species, `pchem_clim_years: 228`
- ELSE, use the MERRA2OX species (aka the default behavior from before), `pchem_clim_years: 39`

Now, I think I got this right for `gcm_setup` and I *tried* to get it right in the other setups, but `gmichem_setup` is fancy. As such, I now ping @mmanyin to see if he thinks I got it correct. (The `stratchem_setup` and `geoschemchem_setup` seemed pretty easy to change as they are `gcm_setup`-like in this area.)

I'll draft this until @mmanyin can weigh in 😄 