### PR TITLE
Edits to run GEOSgcm.x from install directory

### DIFF
--- a/gcm_convert.j
+++ b/gcm_convert.j
@@ -387,10 +387,8 @@ sed -r -i -e "/VEGDYN_INTERNAL_RESTART_TYPE:/ s/$fromtype/binary/" AGCM.rc
 #endif
 
 #######################################################################
-#                    Get Executable and RESTARTS 
+#                    Get RESTARTS 
 #######################################################################
-
-@CPEXEC $EXPDIR/GEOSgcm.x .
 
 set rst_files      = `cat AGCM.rc | grep "RESTART_FILE"    | grep -v VEGDYN | grep -v "#" | cut -d ":" -f1 | cut -d "_" -f1-2`
 set rst_file_names = `cat AGCM.rc | grep "RESTART_FILE"    | grep -v VEGDYN | grep -v "#" | cut -d ":" -f2`
@@ -499,7 +497,18 @@ set LOGFILE = "$CNVDIR/GEOSgcm.log"
 # Assume gcm_setup set these properly for the local platform
 /bin/rm -f EGRESS
 @SETENVS
-$RUN_CMD $NPES ./GEOSgcm.x >& $LOGFILE
+
+# If there is a GEOSgcm.x in the experiment directory, use it,
+# otherwise, use the one in the install directory
+if (-x $EXPDIR/GEOSgcm.x) then
+   @CPEXEC $EXPDIR/GEOSgcm.x .
+   set GEOSGCM_EXECUTABLE = ./GEOSgcm.x
+else
+   set GEOSGCM_EXECUTABLE = $GEOSBIN/GEOSgcm.x
+endif
+
+$RUN_CMD $NPES ${GEOSGCM_EXECUTABLE} >& $LOGFILE
+
 if( -e EGRESS ) then
    set rc = 0
 else

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -68,8 +68,16 @@ cd $HOMDIR
     end
 cd $EXPDIR/regress
 
+# If there is a GEOSgcm.x in the experiment directory, use it,
+# otherwise, use the one in the install directory
+if (-x $EXPDIR/GEOSgcm.x) then
+   @CPEXEC $EXPDIR/GEOSgcm.x $EXPDIR/regress
+   set GEOSGCM_EXECUTABLE = ./GEOSgcm.x
+else
+   set GEOSGCM_EXECUTABLE = $GEOSBIN/GEOSgcm.x
+endif
+
 /bin/ln -s $EXPDIR/RC/*.rc  $EXPDIR/regress
-@CPEXEC $EXPDIR/GEOSgcm.x   $EXPDIR/regress
 @CPEXEC $EXPDIR/linkbcs     $EXPDIR/regress
 @CPEXEC $HOMDIR/*.yaml      $EXPDIR/regress
 >>>COUPLED<<<@CPEXEC $HOMDIR/*.nml       $EXPDIR/regress
@@ -288,7 +296,7 @@ cat CAP.tmp | sed -e "s?$oldstring?$newstring?g" > CAP.rc
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-$RUN_CMD $NPES ./GEOSgcm.x
+$RUN_CMD $NPES $GEOSGCM_EXECUTABLE
                                                                                                                       
 
 set date = `cat cap_restart`
@@ -351,7 +359,7 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-$RUN_CMD $NPES ./GEOSgcm.x
+$RUN_CMD $NPES $GEOSGCM_EXECUTABLE
 
 foreach rst ( $rst_file_names )
   /bin/rm -f  $rst
@@ -431,7 +439,7 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-$RUN_CMD $NPES ./GEOSgcm.x
+$RUN_CMD $NPES $GEOSGCM_EXECUTABLE
                                                                                                                       
 set date = `cat cap_restart`
 set nymde = $date[1]

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -429,10 +429,8 @@ chmod +x linkbcs
 @CPEXEC  linkbcs $EXPDIR
 
 #######################################################################
-#                    Get Executable and RESTARTS 
+#                    Get RESTARTS 
 #######################################################################
-
-@CPEXEC $EXPDIR/GEOSgcm.x .
 
 set rst_files      = `cat AGCM.rc | grep "RESTART_FILE"    | grep -v VEGDYN | grep -v "#" | cut -d ":" -f1 | cut -d "_" -f1-2`
 set rst_file_names = `cat AGCM.rc | grep "RESTART_FILE"    | grep -v VEGDYN | grep -v "#" | cut -d ":" -f2`
@@ -798,7 +796,16 @@ else
    set IOSERVER_EXTRA = ""
 endif
 
-$RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
+# If there is a GEOSgcm.x in the experiment directory, use it,
+# otherwise, use the one in the install directory
+if (-x $EXPDIR/GEOSgcm.x) then
+   @CPEXEC $EXPDIR/GEOSgcm.x .
+   set GEOSGCM_EXECUTABLE = ./GEOSgcm.x
+else
+   set GEOSGCM_EXECUTABLE = $GEOSBIN/GEOSgcm.x
+endif
+
+$RUN_CMD $NPES $GEOSGCM_EXECUTABLE $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -46,7 +46,7 @@ set ETCDIR   = ${GEOSDEF}/etc
 
 # Test if GEOSgcm.x is here which means you are in install directory
 if (! -x GEOSgcm.x) then
-   echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
+   echo "You are trying to run $0 in the GEOSgcm_App directory"
    echo "This is no longer supported. Please run from the bin/ directory"
    echo "in your installation"
    exit 1
@@ -59,7 +59,6 @@ endif
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
-set LINKX = FALSE
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -81,11 +80,6 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
-         breaksw
-
-      # Symlink GEOSgcm.x
-      case --link:
-         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1748,12 +1742,6 @@ echo $GROUP > $HOME/.GROUProot
      set EMISSIONS = g5chem
   endif
 
-if ( $LINKX == "TRUE" ) then
-  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
-else
-  if ( -e $GEOSBIN/GEOSgcm.x ) rsync -avx $GEOSBIN/GEOSgcm.x $EXPDIR
-endif
-
 #######################################################################
 #               Set Recommended MPI Stack Settings
 #######################################################################
@@ -2232,6 +2220,7 @@ endif
 /bin/rm -f $TMPHIST
 
 echo $HOMDIR > $EXPDIR/.HOMDIR
+echo $GEOSDIR > $EXPDIR/.GEOSDIR
 echo " "
 
 #######################################################################
@@ -2438,20 +2427,14 @@ endif
 echo "Done!"
 echo "-----"
 echo " "
-echo "Build Directory: ${C2}${GEOSDIR}${CN}"
-echo "----------------"
+echo "Install Directory: ${C2}${GEOSDIR}${CN}"
+echo "-----------------"
 echo " "
 if ( ! -e $GEOSBIN/GEOSgcm.x ) then
      echo " "
-     echo "Note:  Build directory does not contain ${C1}GEOSgcm.x${CN} !"
+     echo "Note:  Install directory does not contain ${C1}GEOSgcm.x${CN} !"
      echo "       You will need to put a copy of ${C1}GEOSgcm.x${CN} in your Experiment directory"
      echo "----------------------------------------------------------------------------"
-     echo " "
-else
-     echo " "
-     echo "The following executable has been placed in your Experiment Directory:"
-     echo "----------------------------------------------------------------------"
-     echo "${C2}$GEOSBIN/GEOSgcm.x${CN}"
      echo " "
 endif
 echo " "
@@ -2854,7 +2837,6 @@ sh $COPYSCRIPT
 # ----------------------------------------------------
 
 echo "$NEWHOMDIR" >> $NEWEXPDIR/.HOMDIR
-/bin/cp $OLDEXPDIR/GEOSgcm.x $NEWEXPDIR
 /bin/cp -a $OLDEXPDIR/RC $NEWEXPDIR/RC
 
 # -----------------------------------------------------

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -46,7 +46,7 @@ set ETCDIR   = ${GEOSDEF}/etc
 
 # Test if GEOSgcm.x is here which means you are in install directory
 if (! -x GEOSgcm.x) then
-   echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
+   echo "You are trying to run $0 in the GEOSgcm_App directory"
    echo "This is no longer supported. Please run from the bin/ directory"
    echo "in your installation"
    exit 1
@@ -59,7 +59,6 @@ endif
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
-set LINKX = FALSE
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -81,11 +80,6 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
-         breaksw
-
-      # Symlink GEOSgcm.x
-      case --link:
-         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1799,12 +1793,6 @@ echo $GROUP > $HOME/.GROUProot
      set EMISSIONS = g5chem
   endif
 
-if ( $LINKX == "TRUE" ) then
-  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
-else
-  if ( -e $GEOSBIN/GEOSgcm.x ) rsync -avx $GEOSBIN/GEOSgcm.x $EXPDIR
-endif
-
 #######################################################################
 #               Set Recommended MPI Stack Settings
 #######################################################################
@@ -2366,6 +2354,7 @@ else
 endif
 
 echo $HOMDIR > $EXPDIR/.HOMDIR
+echo $GEOSDIR > $EXPDIR/.GEOSDIR
 echo " "
 
 #######################################################################
@@ -2651,33 +2640,16 @@ endif
 echo "Done!"
 echo "-----"
 echo " "
-echo "Build Directory: ${C2}${GEOSDIR}${CN}"
-echo "----------------"
+echo "Install Directory: ${C2}${GEOSDIR}${CN}"
+echo "-----------------"
 echo " "
 if ( ! -e $GEOSBIN/GEOSgcm.x ) then
      echo " "
-     echo "Note:  Build directory does not contain ${C1}GEOSgcm.x${CN} !"
+     echo "Note:  Install directory does not contain ${C1}GEOSgcm.x${CN} !"
      echo "       You will need to put a copy of ${C1}GEOSgcm.x${CN} in your Experiment directory"
      echo "----------------------------------------------------------------------------"
      echo " "
-else
-     echo " "
-     echo "The following executable has been placed in your Experiment Directory:"
-     echo "----------------------------------------------------------------------"
-     echo "${C2}$GEOSBIN/GEOSgcm.x${CN}"
-     echo " "
 endif
-echo " "
-echo "If these files are not required, move or rename them (in RC/): "
-echo "-------------------------------------------------------------- "
-echo "  CARMAchem_GridComp_ExtData.rc"
-echo "  CFC_GridComp_ExtData.rc"
-echo "  CH4_GridComp_ExtData.rc"
-echo "  DNA_ExtData.rc"
-echo "  GEOSachem_ExtData.rc"
-echo "  MAM7_ExtData.rc"
-echo "  O3_GridComp_ExtData.rc"
-echo "  Rn_GridComp_ExtData.rc"
 echo " "
 echo "You must now copy your ${C1}Initial Conditions${CN} into: "
 echo "----------------------------------------------- "
@@ -3084,7 +3056,6 @@ sh $COPYSCRIPT
 # ----------------------------------------------------
 
 echo "$NEWHOMDIR" >> $NEWEXPDIR/.HOMDIR
-/bin/cp $OLDEXPDIR/GEOSgcm.x $NEWEXPDIR
 /bin/cp -a $OLDEXPDIR/RC $NEWEXPDIR/RC
 
 # -----------------------------------------------------

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -46,7 +46,7 @@ set ETCDIR   = ${GEOSDEF}/etc
 
 # Test if GEOSgcm.x is here which means you are in install directory
 if (! -x GEOSgcm.x) then
-   echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
+   echo "You are trying to run $0 in the GEOSgcm_App directory"
    echo "This is no longer supported. Please run from the bin/ directory"
    echo "in your installation"
    exit 1
@@ -59,7 +59,6 @@ endif
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
-set LINKX = FALSE
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -81,11 +80,6 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
-         breaksw
-
-      # Symlink GEOSgcm.x
-      case --link:
-         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1936,12 +1930,6 @@ echo $GROUP > $HOME/.GROUProot
         /bin/cp $GEOSDIR/etc/$GMIEXP/chemistry_files/*.rc $EXPDIR/RC
   endif
 
-if ( $LINKX == "TRUE" ) then
-  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
-else
-  if ( -e $GEOSBIN/GEOSgcm.x ) rsync -avx $GEOSBIN/GEOSgcm.x $EXPDIR
-endif
-
 #######################################################################
 #               Set Recommended MPI Stack Settings
 #######################################################################
@@ -2426,6 +2414,7 @@ endif
 /bin/rm -f $TMPHIST
 
 echo $HOMDIR > $EXPDIR/.HOMDIR
+echo $GEOSDIR > $EXPDIR/.GEOSDIR
 echo " "
 
 #######################################################################
@@ -2772,20 +2761,14 @@ mkdir $HOMDIR/extra
 echo "Done!"
 echo "-----"
 echo " "
-echo "Build Directory: ${C2}${GEOSDIR}${CN}"
-echo "----------------"
+echo "Install Directory: ${C2}${GEOSDIR}${CN}"
+echo "-----------------"
 echo " "
 if ( ! -e $GEOSBIN/GEOSgcm.x ) then
      echo " "
-     echo "Note:  Build directory does not contain ${C1}GEOSgcm.x${CN} !"
+     echo "Note:  Install directory does not contain ${C1}GEOSgcm.x${CN} !"
      echo "       You will need to put a copy of ${C1}GEOSgcm.x${CN} in your Experiment directory"
      echo "----------------------------------------------------------------------------"
-     echo " "
-else
-     echo " "
-     echo "The following executable has been placed in your Experiment Directory:"
-     echo "----------------------------------------------------------------------"
-     echo "${C2}$GEOSBIN/GEOSgcm.x${CN}"
      echo " "
 endif
 echo " "
@@ -3188,7 +3171,6 @@ sh $COPYSCRIPT
 # ----------------------------------------------------
 
 echo "$NEWHOMDIR" >> $NEWEXPDIR/.HOMDIR
-/bin/cp $OLDEXPDIR/GEOSgcm.x $NEWEXPDIR
 /bin/cp -a $OLDEXPDIR/RC $NEWEXPDIR/RC
 
 # -----------------------------------------------------

--- a/scm_run.j
+++ b/scm_run.j
@@ -26,4 +26,4 @@ setenv EXPDIR  @EXPDIR
 
 cd $EXPDIR
 
-$RUN_CMD 1 ./GEOSgcm.x
+$RUN_CMD 1 ${GEOSBIN}/GEOSgcm.x

--- a/scm_setup
+++ b/scm_setup
@@ -380,8 +380,6 @@ SOURCEDIR=$SCMDIR$selected_case
 
 mkdir -p $expdir
 
-/bin/cp $INSTALLDIR/bin/GEOSgcm.x $expdir
-
 /bin/cp $SOURCEDIR/$DATFILE $expdir
 /bin/cp $SOURCEDIR/topo_dynave.data $expdir
 /bin/cp $SOURCEDIR/fraci.data $expdir

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -46,7 +46,7 @@ set ETCDIR   = ${GEOSDEF}/etc
 
 # Test if GEOSgcm.x is here which means you are in install directory
 if (! -x GEOSgcm.x) then
-   echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
+   echo "You are trying to run $0 in the GEOSgcm_App directory"
    echo "This is no longer supported. Please run from the bin/ directory"
    echo "in your installation"
    exit 1
@@ -59,7 +59,6 @@ endif
 # Set default behavior of switches
 set NOCVS = TRUE
 set GPU   = FALSE
-set LINKX = FALSE
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -81,11 +80,6 @@ while ( $#argv > 0 )
       # Do not archive the source
       case --nocvs:
          set NOCVS = TRUE
-         breaksw
-
-      # Symlink GEOSgcm.x
-      case --link:
-         set LINKX = TRUE
          breaksw
 
       # Here any string not above will trigger USAGE
@@ -1784,12 +1778,6 @@ echo $GROUP > $HOME/.GROUProot
      set EMISSIONS = g5chem
   endif
 
-if ( $LINKX == "TRUE" ) then
-  if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
-else
-  if ( -e $GEOSBIN/GEOSgcm.x ) rsync -avx $GEOSBIN/GEOSgcm.x $EXPDIR
-endif
-
 #######################################################################
 #               Set Recommended MPI Stack Settings
 #######################################################################
@@ -2272,6 +2260,7 @@ endif
 /bin/rm -f $TMPHIST
 
 echo $HOMDIR > $EXPDIR/.HOMDIR
+echo $GEOSDIR > $EXPDIR/.GEOSDIR
 echo " "
 
 #######################################################################
@@ -2602,20 +2591,14 @@ endif
 echo "Done!"
 echo "-----"
 echo " "
-echo "Build Directory: ${C2}${GEOSDIR}${CN}"
-echo "----------------"
+echo "Install Directory: ${C2}${GEOSDIR}${CN}"
+echo "-----------------"
 echo " "
 if ( ! -e $GEOSBIN/GEOSgcm.x ) then
      echo " "
-     echo "Note:  Build directory does not contain ${C1}GEOSgcm.x${CN} !"
+     echo "Note:  Install directory does not contain ${C1}GEOSgcm.x${CN} !"
      echo "       You will need to put a copy of ${C1}GEOSgcm.x${CN} in your Experiment directory"
      echo "----------------------------------------------------------------------------"
-     echo " "
-else
-     echo " "
-     echo "The following executable has been placed in your Experiment Directory:"
-     echo "----------------------------------------------------------------------"
-     echo "${C2}$GEOSBIN/GEOSgcm.x${CN}"
      echo " "
 endif
 echo " "
@@ -3018,7 +3001,6 @@ sh $COPYSCRIPT
 # ----------------------------------------------------
 
 echo "$NEWHOMDIR" >> $NEWEXPDIR/.HOMDIR
-/bin/cp $OLDEXPDIR/GEOSgcm.x $NEWEXPDIR
 /bin/cp -a $OLDEXPDIR/RC $NEWEXPDIR/RC
 
 # -----------------------------------------------------


### PR DESCRIPTION
This is part of an effort to primarily run `GEOSgcm.x` from the install directory, unless a GEOSgcm.x is explicitly in the experiment directory.