### PR TITLE
Fix for GOCART.data

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1217,10 +1217,7 @@ if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
-
-# GOCART.data was using the MERRA2OX species file, so by
-# default we set this value to that
-set PCHEM_CLIM_YEARS = 39
+set PCHEM_CLIM_YEARS = ""
 
 if( $GOKART == TRUE ) then
 
@@ -1287,6 +1284,10 @@ set  AERO_PROVIDER   = GOCART.data
 set  EMISSIONS       = ""
 set  GOCART          = "#"
 set  HIST_GOCART     = "#DELETE"
+
+# GOCART.data uses MERRA2OX currently
+set MERRA2OX_SPECIES = ""
+set PCHEM_CLIM_YEARS = 39
 
 endif
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -1217,7 +1217,10 @@ if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
-set PCHEM_CLIM_YEARS = ""
+
+# GOCART.data was using the MERRA2OX species file, so by
+# default we set this value to that
+set PCHEM_CLIM_YEARS = 39
 
 if( $GOKART == TRUE ) then
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -1217,6 +1217,7 @@ if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
+set PCHEM_CLIM_YEARS = ""
 
 if( $GOKART == TRUE ) then
 

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1253,10 +1253,7 @@ if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
-
-# GOCART.data was using the MERRA2OX species file, so by
-# default we set this value to that
-set PCHEM_CLIM_YEARS = 39
+set PCHEM_CLIM_YEARS = ""
 
 if( $GOKART == TRUE ) then
 
@@ -1323,6 +1320,10 @@ set  AERO_PROVIDER   = GOCART.data
 set  EMISSIONS       = ""
 set  GOCART          = "#"
 set  HIST_GOCART     = "#DELETE"
+
+# GOCART.data uses MERRA2OX currently
+set MERRA2OX_SPECIES = ""
+set PCHEM_CLIM_YEARS = 39
 
 endif
 

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1253,7 +1253,10 @@ if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
-set PCHEM_CLIM_YEARS = ""
+
+# GOCART.data was using the MERRA2OX species file, so by
+# default we set this value to that
+set PCHEM_CLIM_YEARS = 39
 
 if( $GOKART == TRUE ) then
 

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1253,6 +1253,7 @@ if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
+set PCHEM_CLIM_YEARS = ""
 
 if( $GOKART == TRUE ) then
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1358,6 +1358,7 @@ endif
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
+set PCHEM_CLIM_YEARS = ""
 
 if( $GOKART == TRUE ) then
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1358,7 +1358,10 @@ endif
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
-set PCHEM_CLIM_YEARS = ""
+
+# GOCART.data was using the MERRA2OX species file, so by
+# default we set this value to that
+set PCHEM_CLIM_YEARS = 39
 
 if( $GOKART == TRUE ) then
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1336,7 +1336,6 @@ set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
 set PCHEM_CLIM_YEARS = ""
 
-
 if($APNum == 1) then
  set GOKART = TRUE
  set GOKARTDATA = FALSE
@@ -1352,7 +1351,7 @@ if($APNum == 2) then
  set  HIST_GOCART     = "#DELETE"
  set AERO_PROVIDER = GOCART.data
 
- # We need to set these values for GOCART.data
+ # GOCART.data uses MERRA2OX currently
  set MERRA2OX_SPECIES = ""
  set PCHEM_CLIM_YEARS = 39
 endif

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1330,6 +1330,13 @@ endif
 
 set  EMISSIONS       = ""
 
+# Default setup for linkbcs emissions
+set OPS_SPECIES      = "#"
+set CMIP_SPECIES     = "#"
+set MERRA2OX_SPECIES = "#"
+set PCHEM_CLIM_YEARS = ""
+
+
 if($APNum == 1) then
  set GOKART = TRUE
  set GOKARTDATA = FALSE
@@ -1344,6 +1351,10 @@ if($APNum == 2) then
  set  GOCART          = "#"
  set  HIST_GOCART     = "#DELETE"
  set AERO_PROVIDER = GOCART.data
+
+ # We need to set these values for GOCART.data
+ set MERRA2OX_SPECIES = ""
+ set PCHEM_CLIM_YEARS = 39
 endif
 
 if($APNum == 3) then
@@ -1353,15 +1364,6 @@ if($APNum == 3) then
  set  HIST_GOCART     = "#DELETE"
  set AERO_PROVIDER = GMICHEM
 endif
-
-# Default setup for linkbcs emissions
-set OPS_SPECIES      = "#"
-set CMIP_SPECIES     = "#"
-set MERRA2OX_SPECIES = "#"
-
-# GOCART.data was using the MERRA2OX species file, so by
-# default we set this value to that
-set PCHEM_CLIM_YEARS = 39
 
 if( $GOKART == TRUE ) then
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1253,10 +1253,7 @@ if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
-
-# GOCART.data was using the MERRA2OX species file, so by
-# default we set this value to that
-set PCHEM_CLIM_YEARS = 39
+set PCHEM_CLIM_YEARS = ""
 
 if( $GOKART == TRUE ) then
 
@@ -1323,6 +1320,10 @@ set  AERO_PROVIDER   = GOCART.data
 set  EMISSIONS       = ""
 set  GOCART          = "#"
 set  HIST_GOCART     = "#DELETE"
+
+# GOCART.data uses MERRA2OX currently
+set MERRA2OX_SPECIES = ""
+set PCHEM_CLIM_YEARS = 39
 
 endif
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1253,7 +1253,10 @@ if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
-set PCHEM_CLIM_YEARS = ""
+
+# GOCART.data was using the MERRA2OX species file, so by
+# default we set this value to that
+set PCHEM_CLIM_YEARS = 39
 
 if( $GOKART == TRUE ) then
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1253,6 +1253,7 @@ if(  $GOKART == "C" ) set GOKART = FALSE   # Use Climatological Aerosols
 set OPS_SPECIES      = "#"
 set CMIP_SPECIES     = "#"
 set MERRA2OX_SPECIES = "#"
+set PCHEM_CLIM_YEARS = ""
 
 if( $GOKART == TRUE ) then
 


### PR DESCRIPTION
This PR fixes a missed path from #233. Forgot to test GOCART.data. As `PCHEM_CLIM_YEARS` was never set in that path, GOCART.data experiments could not be made.

In order to keep things "the same" with GOCART.data, we set the "default" `PCHEM_CLIM_YEARS` to 39 as before GOCART.data was using the 39-year MERRA2OX species file.