### PR TITLE
Update comments in line with CTM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,14 +49,13 @@ install (
    DESTINATION etc
    )
 
-# Did we build with Hydrostatic?
 if(HYDROSTATIC)
    set(CFG_HYDROSTATIC TRUE)
 else()
    set(CFG_HYDROSTATIC FALSE)
 endif()
 
-# Did we build on Rome?
+# Did we build for AMD Rome hardware (aka EPYC)?
 cmake_host_system_information(RESULT proc_decription QUERY PROCESSOR_DESCRIPTION)
 if (${proc_decription} MATCHES "EPYC")
   set(CFG_BUILT_ON_ROME TRUE)

--- a/gcm_convert.j
+++ b/gcm_convert.j
@@ -20,8 +20,8 @@ limit stacksize unlimited
 
 @SETENVS
 
-# Set OMP_NUM_THREADS
-# -------------------
+# Establish safe default number of OpenMP threads
+# -----------------------------------------------
 setenv OMP_NUM_THREADS 1
 
 #######################################################################

--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -689,8 +689,8 @@ if( $REPLAY_MODE == 'Exact' | $REPLAY_MODE == 'Regular' ) then
 
 endif
 
-# Set OMP_NUM_THREADS
-# -------------------
+# Establish safe default number of OpenMP threads
+# -----------------------------------------------
 setenv OMP_NUM_THREADS 1
 
 # Run GEOSgcm.x

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -20,8 +20,8 @@ limit stacksize unlimited
 
 @SETENVS
 
-# Set OMP_NUM_THREADS
-# -------------------
+# Establish safe default number of OpenMP threads
+# -----------------------------------------------
 setenv OMP_NUM_THREADS 1
 
 @GPUSTART

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -788,8 +788,8 @@ if( $REPLAY_MODE == 'Exact' | $REPLAY_MODE == 'Regular' ) then
 
 endif
 
-# Set OMP_NUM_THREADS
-# -------------------
+# Establish safe default number of OpenMP threads
+# -----------------------------------------------
 setenv OMP_NUM_THREADS 1
 
 # Run GEOSgcm.x


### PR DESCRIPTION
@tclune requested some changes to comments on a PR syncing the CTM to GEOSgcm v10.19.3 (https://github.com/GEOS-ESM/GEOSctm/pull/34).

This PR pulls those changes back into the GCM so we can keep both in sync. (Not often we go CTM → GCM!)