### PR TITLE
Add MPI_LAUNCH_TIMEOUT for MPT

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1865,6 +1865,8 @@ cat > $HOMDIR/SETENV.commands << EOF
    setenv MPI_XPMEM_ENABLED yes
    unsetenv SUPPRESS_XPMEM_TRIM_THRESH
 
+   setenv MPI_LAUNCH_TIMEOUT 40
+
    # For some reason, PMI_RANK is randomly set and interferes
    # with binarytile.x and other executables.
    unsetenv PMI_RANK

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1916,6 +1916,8 @@ cat > $HOMDIR/SETENV.commands << EOF
    setenv MPI_XPMEM_ENABLED yes
    unsetenv SUPPRESS_XPMEM_TRIM_THRESH
 
+   setenv MPI_LAUNCH_TIMEOUT 40
+
    # For some reason, PMI_RANK is randomly set and interferes
    # with binarytile.x and other executables.
    unsetenv PMI_RANK

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2052,6 +2052,8 @@ cat > $HOMDIR/SETENV.commands << EOF
    setenv MPI_XPMEM_ENABLED yes
    unsetenv SUPPRESS_XPMEM_TRIM_THRESH
 
+   setenv MPI_LAUNCH_TIMEOUT 40
+
    # For some reason, PMI_RANK is randomly set and interferes
    # with binarytile.x and other executables.
    unsetenv PMI_RANK

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1901,6 +1901,8 @@ cat > $HOMDIR/SETENV.commands << EOF
    setenv MPI_XPMEM_ENABLED yes
    unsetenv SUPPRESS_XPMEM_TRIM_THRESH
 
+   setenv MPI_LAUNCH_TIMEOUT 40
+
    # For some reason, PMI_RANK is randomly set and interferes
    # with binarytile.x and other executables.
    unsetenv PMI_RANK


### PR DESCRIPTION
Recently, my GEOS regression runs at NAS have had momentary "cannot launch MPT" issues. NAS has a [help page](https://www.nas.nasa.gov/hecc/support/kb/mpt-startup-failures-workarounds_526.html) about this and one of the suggestions is to add `MPI_LAUNCH_TIMEOUT=40`. So, this PR adds that as a new variable if using MPT.

I'm going to look at adding the file system mounts as well, but that can't really be put in `gcm_setup`, et al., so it'll be in my nightly scripting scripts.

As for `several_tries`, it seems overkill for now for all GEOS runs, but if I get complaints I'll look at adding it as well (maybe by default at high-res??)

