### PR TITLE
Clean up OpenMP in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,7 @@ ecbuild_add_executable (
 
 set (CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_FLAGS_VECT}")
 
-#link_directories (${MKL_LIBRARIES})
-target_link_libraries (GEOSgcm.x ${OpenMP_Fortran_LIBRARIES})
-set_target_properties(GEOSgcm.x PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
+target_link_libraries (GEOSgcm.x OpenMP::OpenMP_Fortran)
 target_include_directories (GEOSgcm.x PUBLIC ${INC_ESMF})
 
 file (GLOB templates CONFIGURE_DEPENDS *.tmpl)


### PR DESCRIPTION
This is just cosmetic. We know how to do OpenMP in CMake better now, so we should!