### PR TITLE
Updates for Cascade Lake at NCCS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,7 @@ ecbuild_add_executable (
 
 set (CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_FLAGS_VECT}")
 
-#link_directories (${MKL_LIBRARIES})
-target_link_libraries (GEOSgcm.x ${OpenMP_Fortran_LIBRARIES})
-set_target_properties(GEOSgcm.x PROPERTIES LINK_FLAGS "${OpenMP_Fortran_FLAGS}")
+target_link_libraries (GEOSgcm.x OpenMP::OpenMP_Fortran)
 target_include_directories (GEOSgcm.x PUBLIC ${INC_ESMF})
 
 file (GLOB templates CONFIGURE_DEPENDS *.tmpl)

--- a/gcm_setup
+++ b/gcm_setup
@@ -393,7 +393,7 @@ if ( $SITE == 'NCCS' ) then
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
    if ( .$MODEL == .) then
-      set MODEL = 'hasw'
+      set MODEL = 'sky'
    endif
 
    if( $MODEL != 'hasw' & \

--- a/gcm_setup
+++ b/gcm_setup
@@ -392,12 +392,13 @@ if ( $SITE == 'NCCS' ) then
    echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
    echo "   ${C2}hasw (Haswell)${CN} (default)"
    echo "   ${C2}sky  (Skylake)${CN}"
-   echo "   ${C2}cas  (Cascade Lake)${CN}"
+   # Keep Cascade Lake hidden until in general use
+   #echo "   ${C2}cas  (Cascade Lake)${CN}"
    echo " "
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
    if ( .$MODEL == .) then
-      set MODEL = 'sky'
+      set MODEL = 'hasw'
    endif
 
    if( $MODEL != 'hasw' & \

--- a/gcm_setup
+++ b/gcm_setup
@@ -387,9 +387,8 @@ ASKPROC:
 if ( $SITE == 'NCCS' ) then
    echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
    echo "   ${C2}hasw (Haswell)${CN} (default)"
-   if (-e /etc/os-release) then
-      echo "   ${C2}sky  (Skylake)${CN}"
-   endif
+   echo "   ${C2}sky  (Skylake)${CN}"
+   echo "   ${C2}cas  (Cascade Lake)${CN}"
    echo " "
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
@@ -398,12 +397,15 @@ if ( $SITE == 'NCCS' ) then
    endif
 
    if( $MODEL != 'hasw' & \
-       $MODEL != 'sky' ) goto ASKPROC
+       $MODEL != 'sky'  & \
+       $MODEL != 'cas' ) goto ASKPROC
 
    if (     $MODEL == 'hasw') then
       set NCPUS_PER_NODE = 28
    else if ($MODEL == 'sky') then
       set NCPUS_PER_NODE = 40
+   else if ($MODEL == 'cas') then
+      set NCPUS_PER_NODE = 48
    endif
 
 else if ( $SITE == 'NAS' ) then

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -393,7 +393,7 @@ if ( $SITE == 'NCCS' ) then
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
    if ( .$MODEL == .) then
-      set MODEL = 'hasw'
+      set MODEL = 'sky'
    endif
 
    if( $MODEL != 'hasw' & \

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -392,12 +392,13 @@ if ( $SITE == 'NCCS' ) then
    echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
    echo "   ${C2}hasw (Haswell)${CN} (default)"
    echo "   ${C2}sky  (Skylake)${CN}"
-   echo "   ${C2}cas  (Cascade Lake)${CN}"
+   # Keep Cascade Lake hidden until in general use
+   #echo "   ${C2}cas  (Cascade Lake)${CN}"
    echo " "
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
    if ( .$MODEL == .) then
-      set MODEL = 'sky'
+      set MODEL = 'hasw'
    endif
 
    if( $MODEL != 'hasw' & \

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -387,9 +387,8 @@ ASKPROC:
 if ( $SITE == 'NCCS' ) then
    echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
    echo "   ${C2}hasw (Haswell)${CN} (default)"
-   if (-e /etc/os-release) then
-      echo "   ${C2}sky  (Skylake)${CN}"
-   endif
+   echo "   ${C2}sky  (Skylake)${CN}"
+   echo "   ${C2}cas  (Cascade Lake)${CN}"
    echo " "
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
@@ -398,12 +397,15 @@ if ( $SITE == 'NCCS' ) then
    endif
 
    if( $MODEL != 'hasw' & \
-       $MODEL != 'sky' ) goto ASKPROC
+       $MODEL != 'sky'  & \
+       $MODEL != 'cas' ) goto ASKPROC
 
    if (     $MODEL == 'hasw') then
       set NCPUS_PER_NODE = 28
    else if ($MODEL == 'sky') then
       set NCPUS_PER_NODE = 40
+   else if ($MODEL == 'cas') then
+      set NCPUS_PER_NODE = 48
    endif
 
 else if ( $SITE == 'NAS' ) then

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -393,7 +393,7 @@ if ( $SITE == 'NCCS' ) then
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
    if ( .$MODEL == .) then
-      set MODEL = 'hasw'
+      set MODEL = 'sky'
    endif
 
    if( $MODEL != 'hasw' & \

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -392,12 +392,13 @@ if ( $SITE == 'NCCS' ) then
    echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
    echo "   ${C2}hasw (Haswell)${CN} (default)"
    echo "   ${C2}sky  (Skylake)${CN}"
-   echo "   ${C2}cas  (Cascade Lake)${CN}"
+   # Keep Cascade Lake hidden until in general use
+   #echo "   ${C2}cas  (Cascade Lake)${CN}"
    echo " "
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
    if ( .$MODEL == .) then
-      set MODEL = 'sky'
+      set MODEL = 'hasw'
    endif
 
    if( $MODEL != 'hasw' & \

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -387,9 +387,8 @@ ASKPROC:
 if ( $SITE == 'NCCS' ) then
    echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
    echo "   ${C2}hasw (Haswell)${CN} (default)"
-   if (-e /etc/os-release) then
-      echo "   ${C2}sky  (Skylake)${CN}"
-   endif
+   echo "   ${C2}sky  (Skylake)${CN}"
+   echo "   ${C2}cas  (Cascade Lake)${CN}"
    echo " "
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
@@ -398,12 +397,15 @@ if ( $SITE == 'NCCS' ) then
    endif
 
    if( $MODEL != 'hasw' & \
-       $MODEL != 'sky' ) goto ASKPROC
+       $MODEL != 'sky'  & \
+       $MODEL != 'cas' ) goto ASKPROC
 
    if (     $MODEL == 'hasw') then
       set NCPUS_PER_NODE = 28
    else if ($MODEL == 'sky') then
       set NCPUS_PER_NODE = 40
+   else if ($MODEL == 'cas') then
+      set NCPUS_PER_NODE = 48
    endif
 
 else if ( $SITE == 'NAS' ) then

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -393,7 +393,7 @@ if ( $SITE == 'NCCS' ) then
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
    if ( .$MODEL == .) then
-      set MODEL = 'hasw'
+      set MODEL = 'sky'
    endif
 
    if( $MODEL != 'hasw' & \

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -392,12 +392,13 @@ if ( $SITE == 'NCCS' ) then
    echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
    echo "   ${C2}hasw (Haswell)${CN} (default)"
    echo "   ${C2}sky  (Skylake)${CN}"
-   echo "   ${C2}cas  (Cascade Lake)${CN}"
+   # Keep Cascade Lake hidden until in general use
+   #echo "   ${C2}cas  (Cascade Lake)${CN}"
    echo " "
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
    if ( .$MODEL == .) then
-      set MODEL = 'sky'
+      set MODEL = 'hasw'
    endif
 
    if( $MODEL != 'hasw' & \

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -387,9 +387,8 @@ ASKPROC:
 if ( $SITE == 'NCCS' ) then
    echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
    echo "   ${C2}hasw (Haswell)${CN} (default)"
-   if (-e /etc/os-release) then
-      echo "   ${C2}sky  (Skylake)${CN}"
-   endif
+   echo "   ${C2}sky  (Skylake)${CN}"
+   echo "   ${C2}cas  (Cascade Lake)${CN}"
    echo " "
    set MODEL = `echo $<`
    set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
@@ -398,12 +397,15 @@ if ( $SITE == 'NCCS' ) then
    endif
 
    if( $MODEL != 'hasw' & \
-       $MODEL != 'sky' ) goto ASKPROC
+       $MODEL != 'sky'  & \
+       $MODEL != 'cas' ) goto ASKPROC
 
    if (     $MODEL == 'hasw') then
       set NCPUS_PER_NODE = 28
    else if ($MODEL == 'sky') then
       set NCPUS_PER_NODE = 40
+   else if ($MODEL == 'cas') then
+      set NCPUS_PER_NODE = 48
    endif
 
 else if ( $SITE == 'NAS' ) then


### PR DESCRIPTION
Adds a hidden option for Cascade Lake cores at NCCS. This will at least let people with access get good IOSERVER, etc. setups.

NOTE: Cascade Lake requires Intel 2021.2 or later. I'll probably recommend 2021.3 as that's available at NAS too...but it's also a non-zero-diff compiler. 😞 