### PR TITLE
Use 45 cores per node with SCU16 per NCCS

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -409,7 +409,13 @@ if ( $SITE == 'NCCS' ) then
    else if ($MODEL == 'sky') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'cas') then
-      set NCPUS_PER_NODE = 48
+      # NCCS currently recommends that users do not run with
+      # 48 cores per node on SCU16 due to OS issues and 
+      # recommends that CPU-intensive works run with 46 or less
+      # cores. As 45 is a multiple of 3, it's the best value
+      # that doesn't waste too much
+      #set NCPUS_PER_NODE = 48
+      set NCPUS_PER_NODE = 45
    endif
 
 else if ( $SITE == 'NAS' ) then

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -409,7 +409,13 @@ if ( $SITE == 'NCCS' ) then
    else if ($MODEL == 'sky') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'cas') then
-      set NCPUS_PER_NODE = 48
+      # NCCS currently recommends that users do not run with
+      # 48 cores per node on SCU16 due to OS issues and 
+      # recommends that CPU-intensive works run with 46 or less
+      # cores. As 45 is a multiple of 3, it's the best value
+      # that doesn't waste too much
+      #set NCPUS_PER_NODE = 48
+      set NCPUS_PER_NODE = 45
    endif
 
 else if ( $SITE == 'NAS' ) then

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -409,7 +409,13 @@ if ( $SITE == 'NCCS' ) then
    else if ($MODEL == 'sky') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'cas') then
-      set NCPUS_PER_NODE = 48
+      # NCCS currently recommends that users do not run with
+      # 48 cores per node on SCU16 due to OS issues and 
+      # recommends that CPU-intensive works run with 46 or less
+      # cores. As 45 is a multiple of 3, it's the best value
+      # that doesn't waste too much
+      #set NCPUS_PER_NODE = 48
+      set NCPUS_PER_NODE = 45
    endif
 
 else if ( $SITE == 'NAS' ) then

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -409,7 +409,13 @@ if ( $SITE == 'NCCS' ) then
    else if ($MODEL == 'sky') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'cas') then
-      set NCPUS_PER_NODE = 48
+      # NCCS currently recommends that users do not run with
+      # 48 cores per node on SCU16 due to OS issues and 
+      # recommends that CPU-intensive works run with 46 or less
+      # cores. As 45 is a multiple of 3, it's the best value
+      # that doesn't waste too much
+      #set NCPUS_PER_NODE = 48
+      set NCPUS_PER_NODE = 45
    endif
 
 else if ( $SITE == 'NAS' ) then


### PR DESCRIPTION
NCCS is recommending not to run on all 48 cores of the Cascade Lake nodes in SCU16. They recommend CPU intensive codes use 46 or less cores. We choose 45 as that is at least a multiple of 3 so with an even number of nodes, we can get good divisible-by-6 whole nodes. 