### PR TITLE
Fix for setup scripts

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -45,7 +45,7 @@ set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 
 # Test if GEOSgcm.x is here which means you are in install directory
-if (! -x GEOSgcm.x) then
+if (! -x ${BINDIR}/GEOSgcm.x) then
    echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
    echo "This is no longer supported. Please run from the bin/ directory"
    echo "in your installation"

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -45,7 +45,7 @@ set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 
 # Test if GEOSgcm.x is here which means you are in install directory
-if (! -x GEOSgcm.x) then
+if (! -x ${BINDIR}/GEOSgcm.x) then
    echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
    echo "This is no longer supported. Please run from the bin/ directory"
    echo "in your installation"

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -45,7 +45,7 @@ set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 
 # Test if GEOSgcm.x is here which means you are in install directory
-if (! -x GEOSgcm.x) then
+if (! -x ${BINDIR}/GEOSgcm.x) then
    echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
    echo "This is no longer supported. Please run from the bin/ directory"
    echo "in your installation"

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -45,7 +45,7 @@ set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 
 # Test if GEOSgcm.x is here which means you are in install directory
-if (! -x GEOSgcm.x) then
+if (! -x ${BINDIR}/GEOSgcm.x) then
    echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
    echo "This is no longer supported. Please run from the bin/ directory"
    echo "in your installation"


### PR DESCRIPTION
This fixes a dumb bug found by @AgilentGCMS . Namely, if you try to run `install/bin/gcm_setup` from anywhere *but* `install/bin` it fails. And with a weirdly dumb message:
```console
$ cd ~
$ /discover/swdev/mathomp4/Models/GEOSgcm-RegridUpdate/GEOSgcm/install-Release/bin/gcm_setup
You are trying to run /discover/swdev/mathomp4/Models/GEOSgcm-RegridUpdate/GEOSgcm/install-Release/bin/gcm_setup in the Applications/GEOSgcm_App directory
This is no longer supported. Please run from the bin/ directory
in your installation
```
The intent was to make sure people didn't run the `gcm_setup` in the `src/Applications/GEOSgcm_App` directory, but it doesn't mean you can't run the "real" `gcm_setup` from other directories as long as you give the right path.