### PR TITLE
Fixes for C12 MOM6

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -571,8 +571,14 @@ if( $OGCM == TRUE ) then
     set   OGCM_LM = 50
     endif
 
-    set OGCM_NX = 36
-    set OGCM_NY = 10
+    # At the moment c12 MOM6 is default 3x2 ocean (and 1x6 atmos)
+    if( $AGCM_IM ==  "c12" ) then
+       set OGCM_NX = 3
+       set OGCM_NY = 2
+    else
+       set OGCM_NX = 36
+       set OGCM_NY = 10
+    endif
     @   OGCM_NPROCS = $OGCM_NX * $OGCM_NY
     set OGCM_GRID_TYPE = Tripolar
     set LATLON_OGCM = ""
@@ -755,7 +761,12 @@ if( $AGCM_IM ==  "c12" ) then
      set  CHEM_DT = $DT
      set AGCM_IM  = 12
      set AGCM_JM  = `expr $AGCM_IM \* 6`
+     # C12 MOM6 should be 1x6 to match the default 3x2 ocean layout
+     if ( $OCEAN_NAME == "MOM6") then
+     set       NX = 1
+     else
      set       NX = 2
+     endif
      set       NY = `expr $NX \* 6`
      set   HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`

--- a/gcm_setup
+++ b/gcm_setup
@@ -537,14 +537,25 @@ if( $OGCM == TRUE ) then
           goto CORSLV
        endif
     endif
+
     set IMO = ${OGCM_IM}
+    if( $IMO < 10 ) then
+       set IMO = 000$IMO
+    else if($IMO < 100) then
+       set IMO = 00$IMO
+    else if($IMO < 1000) then
+       set IMO = 0$IMO
+    endif
+
     set JMO = ${OGCM_JM}
-    if( $IMO < 10   ) set IMO = 000$IMO
-    if( $IMO < 100  ) set IMO =  00$IMO
-    if( $IMO < 1000 ) set IMO =   0$IMO
-    if( $JMO < 10   ) set JMO = 000$JMO
-    if( $JMO < 100  ) set JMO =  00$JMO
-    if( $JMO < 1000 ) set JMO =   0$JMO
+    if( $JMO < 10 ) then
+       set JMO = 000$JMO
+    else if($JMO < 100) then
+       set JMO = 00$JMO
+    else if($JMO < 1000) then
+       set JMO = 0$JMO
+    endif
+
     set OCEAN_RES = TM${IMO}xTM${JMO}
     set OCEAN_TAG  = Reynolds
     set SSTNAME  = "#DELETE"


### PR DESCRIPTION
This PR updates the setup scripts for the C12 MOM6 setup that @sanAkel and @yvikhlya have developed. It includes:

- Fixes some csh logic for making the tile names
- Default C12 MOM6 as 1x6 atmos/3x2 ocean. Note that C12 data ocean will still be 2x12 by default