### PR TITLE
Update for NAS Runs

### DIFF
--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -178,10 +178,10 @@ endif
 #######################################################################
 
                              /bin/ln -sf $EXPDIR/RC/* .
-                             @CPEXEC -f  $HOMDIR/*.rc .
-                             @CPEXEC -f  $HOMDIR/*.nml .
-                             @CPEXEC -f  $HOMDIR/*.yaml .
-                             @CPEXEC     $GEOSBIN/bundleParser.py .
+                             cp -f  $HOMDIR/*.rc .
+                             cp -f  $HOMDIR/*.nml .
+                             cp -f  $HOMDIR/*.yaml .
+                             cp     $GEOSBIN/bundleParser.py .
 
                              cat fvcore_layout.rc >> input.nml
 
@@ -189,7 +189,7 @@ echo $nymd0 $nhms0 > cap_restart
 
 # Collapse whitespace like the strip utility
 # --------------------------------------
-@CPEXEC AGCM.rc AGCM.rc.orig
+cp AGCM.rc AGCM.rc.orig
 awk '{$1=$1};1' < AGCM.rc.orig > AGCM.rc
 
 
@@ -475,8 +475,8 @@ cat << _EOF_ > $FILE
 >>>FVCUBED<<</bin/ln -sf $BCSDIR/$BCRSLV/Gnomonic_$BCRSLV.dat .
 >>>FVCUBED<<<endif
 
-@COUPLED @CPEXEC $HOMDIR/*_table .
-@COUPLED @CPEXEC $GRIDDIR/INPUT/* INPUT
+@COUPLED cp $HOMDIR/*_table .
+@COUPLED cp $GRIDDIR/INPUT/* INPUT
 @COUPLED /bin/ln -sf $GRIDDIR/cice/kmt_cice.bin .
 @COUPLED /bin/ln -sf $GRIDDIR/cice/grid_cice.bin .
 
@@ -487,13 +487,13 @@ _EOF_
 @DATAOCEAN echo "/bin/ln -sf $SSTDIR"'/@KPARFILE SEAWIFS_KPAR_mon_clim.data' >> $FILE
 
 chmod +x linkbcs
-@CPEXEC  linkbcs $EXPDIR
+cp  linkbcs $EXPDIR
 
 #######################################################################
 #                    Get Executable and RESTARTS
 #######################################################################
 
-@CPEXEC $EXPDIR/GEOSgcm.x .
+cp $EXPDIR/GEOSgcm.x .
 
 set rst_files      = `grep "RESTART_FILE"    AGCM.rc | grep -v VEGDYN | grep -v "#" | cut -d ":" -f1 | cut -d "_" -f1-2`
 set rst_file_names = `grep "RESTART_FILE"    AGCM.rc | grep -v VEGDYN | grep -v "#" | cut -d ":" -f2`
@@ -530,7 +530,7 @@ end
 
      else if( $FCST_TYPE == 'Exact' | $FCST_TYPE == 'Regular' ) then
           /bin/ln -s ${ANA_LOCATION}/rs/Y$year/M$month/${ANA_EXPID}.rst.${nymd0}_${hour}z.tar  .
-          @TAREXEC xf ${ANA_EXPID}.rst.${nymd0}_${hour}z.tar
+          tar xf ${ANA_EXPID}.rst.${nymd0}_${hour}z.tar
           if( $FCST_TYPE == 'Exact' ) /bin/ln -s ${ANA_LOCATION}/rs/Y$year/M*/${ANA_EXPID}.agcm_import_rst.*  .
           $GEOSBIN/stripname ${ANA_EXPID}.
           $GEOSBIN/stripname .${nymd0}_${hour}z.bin
@@ -543,7 +543,7 @@ endif
 
 # Re-Create Proper CAP.rc
 # -----------------------
-@CPEXEC CAP.rc CAP.rc.orig
+cp CAP.rc CAP.rc.orig
 awk '{$1=$1};1' < CAP.rc.orig > CAP.rc
 
 # Re-Create Proper CAP.rc
@@ -620,13 +620,13 @@ if( ${EMISSIONS} == MERRA2 | \
     endif
 
     if( $AGCM_LM == 72 ) then
-        @CPEXEC --remove-destination ${MERRA2_EMISSIONS_DIRECTORY}/*.rc .
+        cp --remove-destination ${MERRA2_EMISSIONS_DIRECTORY}/*.rc .
     else
         set files =      `/bin/ls -1 ${MERRA2_EMISSIONS_DIRECTORY}/*.rc`
         foreach file ($files)
           /bin/rm -f   `basename $file`
           /bin/rm -f    dummy
-          @CPEXEC $file dummy
+          cp $file dummy
               cat       dummy | sed -e "s|/L72/|/L${AGCM_LM}/|g" | sed -e "s|z72|z${AGCM_LM}|g" > `basename $file`
         end
     endif
@@ -703,7 +703,7 @@ else
 
    # Run the script
    # --------------
-   $RUN_CMD 1 $GEOSBIN/SaltIntSplitter tile.data $SCRDIR/saltwater_internal_rst
+   @SEVERAL_TRIES $RUN_CMD 1 $GEOSBIN/SaltIntSplitter tile.data $SCRDIR/saltwater_internal_rst
 
    # Move restarts
    # -------------
@@ -715,12 +715,12 @@ else
 
    # Make decorated copies for restarts tarball
    # ------------------------------------------
-   @CPEXEC openwater_internal_rst    $EXPID.openwater_internal_rst.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
-   @CPEXEC seaicethermo_internal_rst $EXPID.seaicethermo_internal_rst.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
+   cp openwater_internal_rst    $EXPID.openwater_internal_rst.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
+   cp seaicethermo_internal_rst $EXPID.seaicethermo_internal_rst.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
 
    # Inject decorated copies into restarts tarball
    # ---------------------------------------------
-   @TAREXEC rf $EXPDIR/restarts/restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
+   tar rf $EXPDIR/restarts/restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
 
    # Remove the decorated restarts
    # -----------------------------
@@ -812,7 +812,7 @@ else
    set IOSERVER_EXTRA = ""
 endif
 
-$RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
+@SEVERAL_TRIES $RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 
@@ -874,7 +874,7 @@ set nymd = $date[1]
 @ n = $n + 1
 end
 
-$RUN_CMD 1 $GEOSUTIL/bin/stats.x -fcst $fcst_files \
+@SEVERAL_TRIES $RUN_CMD 1 $GEOSUTIL/bin/stats.x -fcst $fcst_files \
                                   -ana   $ana_files \
                                   -cli $SHARE/gmao_ops/verification/stats/MERRA-2.inst3_3d_asm_Np.198501_201412.clim_00z.576x361.data.nc4 \
                                        $SHARE/gmao_ops/verification/stats/MERRA-2.inst3_3d_asm_Np.198501_201412.clim_06z.576x361.data.nc4 \

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -64,17 +64,17 @@ cd $HOMDIR
     set files = `ls -1 *.rc`
     foreach file ($files)
             set fname = `echo $file | cut -d "." -f1`
-           @CPEXEC $fname.rc $EXPDIR/regress
+           cp $fname.rc $EXPDIR/regress
     end
 cd $EXPDIR/regress
 
 /bin/ln -s $EXPDIR/RC/*.rc  $EXPDIR/regress
-@CPEXEC $EXPDIR/GEOSgcm.x   $EXPDIR/regress
-@CPEXEC $EXPDIR/linkbcs     $EXPDIR/regress
-@CPEXEC $HOMDIR/*.yaml      $EXPDIR/regress
-@COUPLED @CPEXEC $HOMDIR/*.nml       $EXPDIR/regress
-@MOM6@CPEXEC $HOMDIR/MOM_input   $EXPDIR/regress
-@MOM6@CPEXEC $HOMDIR/MOM_override $EXPDIR/regress
+cp $EXPDIR/GEOSgcm.x   $EXPDIR/regress
+cp $EXPDIR/linkbcs     $EXPDIR/regress
+cp $HOMDIR/*.yaml      $EXPDIR/regress
+@COUPLED cp $HOMDIR/*.nml       $EXPDIR/regress
+@MOM6cp $HOMDIR/MOM_input   $EXPDIR/regress
+@MOM6cp $HOMDIR/MOM_override $EXPDIR/regress
 
 cat fvcore_layout.rc >> input.nml
 
@@ -114,12 +114,12 @@ end
 # Copy Restarts to Regress directory
 # ----------------------------------
 foreach rst ( $rst_file_names )
-       @CPEXEC $EXPDIR/$rst $EXPDIR/regress
+       cp $EXPDIR/$rst $EXPDIR/regress
 end
-@CPEXEC $EXPDIR/cap_restart $EXPDIR/regress
+cp $EXPDIR/cap_restart $EXPDIR/regress
 
 @COUPLED /bin/mkdir INPUT
-@COUPLED @CPEXEC $EXPDIR/RESTART/* INPUT
+@COUPLED cp $EXPDIR/RESTART/* INPUT
 
 setenv YEAR `cat cap_restart | cut -c1-4`
 ./linkbcs
@@ -140,7 +140,7 @@ else
 
    # Run the script
    # --------------
-   $RUN_CMD 1 $GEOSBIN/SaltIntSplitter tile.data $EXPDIR/regress/saltwater_internal_rst
+   @SEVERAL_TRIES $RUN_CMD 1 $GEOSBIN/SaltIntSplitter tile.data $EXPDIR/regress/saltwater_internal_rst
 
    # Move restarts
    # -------------
@@ -222,13 +222,13 @@ if( @EMISSIONS =~ MERRA2* ) then
     endif
 
     if( $LM == 72 ) then
-        @CPEXEC --remove-destination ${MERRA2_EMISSIONS_DIRECTORY}/*.rc .
+        cp --remove-destination ${MERRA2_EMISSIONS_DIRECTORY}/*.rc .
     else
         set files =      `/bin/ls -1 ${MERRA2_EMISSIONS_DIRECTORY}/*.rc`
         foreach file ($files)
           /bin/rm -f   `basename $file`
           /bin/rm -f    dummy
-          @CPEXEC $file dummy
+          cp $file dummy
               cat       dummy | sed -e "s|/L72/|/L${LM}/|g" | sed -e "s|z72|z${LM}|g" > `basename $file`
         end
     endif
@@ -275,9 +275,9 @@ endif
 
 set test_duration = 240000
 
-@CPEXEC     CAP.rc      CAP.rc.orig
-@CPEXEC    AGCM.rc     AGCM.rc.orig
-@CPEXEC HISTORY.rc0 HISTORY.rc
+cp     CAP.rc      CAP.rc.orig
+cp    AGCM.rc     AGCM.rc.orig
+cp HISTORY.rc0 HISTORY.rc
 
 set           NX0 = `grep "^ *NX:" AGCM.rc.orig | cut -d':' -f2`
 set           NY0 = `grep "^ *NY:" AGCM.rc.orig | cut -d':' -f2`
@@ -294,7 +294,7 @@ cat CAP.tmp | sed -e "s?$oldstring?$newstring?g" > CAP.rc
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-$RUN_CMD $NPES ./GEOSgcm.x
+@SEVERAL_TRIES $RUN_CMD $NPES ./GEOSgcm.x
                                                                                                                       
 
 set date = `cat cap_restart`
@@ -332,9 +332,9 @@ set test_duration = 180000
 /bin/rm              cap_restart
 echo $nymd0 $nhms0 > cap_restart
 
-@CPEXEC     CAP.rc.orig  CAP.rc
-@CPEXEC    AGCM.rc.orig AGCM.rc
-@CPEXEC HISTORY.rc0  HISTORY.rc
+cp     CAP.rc.orig  CAP.rc
+cp    AGCM.rc.orig AGCM.rc
+cp HISTORY.rc0  HISTORY.rc
 
 ./strip CAP.rc
 set oldstring =  `cat CAP.rc | grep JOB_SGMT:`
@@ -357,7 +357,7 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-$RUN_CMD $NPES ./GEOSgcm.x
+@SEVERAL_TRIES $RUN_CMD $NPES ./GEOSgcm.x
 
 foreach rst ( $rst_file_names )
   /bin/rm -f  $rst
@@ -385,7 +385,7 @@ while ( $n <= $numchk )
 @ n = $n + 1
 end
 
-@COUPLED @CPEXEC RESTART/* INPUT
+@COUPLED cp RESTART/* INPUT
 
 ##################################################################
 ######
@@ -437,7 +437,7 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-$RUN_CMD $NPES ./GEOSgcm.x
+@SEVERAL_TRIES $RUN_CMD $NPES ./GEOSgcm.x
                                                                                                                       
 set date = `cat cap_restart`
 set nymde = $date[1]

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -166,7 +166,7 @@ if( $GCMEMIP == TRUE & ! -e $EXPDIR/restarts/$RSTDATE/cap_restart ) then
 
 cd $EXPDIR/restarts/$RSTDATE
 
-@CPEXEC $HOMDIR/CAP.rc CAP.rc.orig
+cp $HOMDIR/CAP.rc CAP.rc.orig
 awk '{$1=$1};1' < CAP.rc.orig > CAP.rc
 
 set year  = `echo $RSTDATE | cut -d_ -f1 | cut -b1-4`
@@ -176,8 +176,8 @@ set month = `echo $RSTDATE | cut -d_ -f1 | cut -b5-6`
 >>>EMIP_OLDLAND<<<# ---------------------
 >>>EMIP_NEWLAND<<<# Copy Jason-3_4 REPLAY MERRA-2 NewLand Restarts
 >>>EMIP_NEWLAND<<<# ----------------------------------------------
-@CPEXEC /discover/nobackup/projects/gmao/g6dev/ltakacs/@EMIP_MERRA2/restarts/AMIP/M${month}/restarts.${year}${month}.tar .
-@TAREXEC xf  restarts.${year}${month}.tar
+cp /discover/nobackup/projects/gmao/g6dev/ltakacs/@EMIP_MERRA2/restarts/AMIP/M${month}/restarts.${year}${month}.tar .
+tar xf  restarts.${year}${month}.tar
 /bin/rm restarts.${year}${month}.tar
 >>>EMIP_OLDLAND<<</bin/rm MERRA2*bin
 
@@ -244,20 +244,20 @@ endif
 cd $SCRDIR
 /bin/rm -rf *
                              /bin/ln -sf $EXPDIR/RC/* .
-                             @CPEXEC     $EXPDIR/cap_restart .
-                             @CPEXEC -f  $HOMDIR/*.rc .
-                             @CPEXEC -f  $HOMDIR/*.nml .
-                             @CPEXEC -f  $HOMDIR/*.yaml .
-                             @CPEXEC     $GEOSBIN/bundleParser.py .
+                             cp     $EXPDIR/cap_restart .
+                             cp -f  $HOMDIR/*.rc .
+                             cp -f  $HOMDIR/*.nml .
+                             cp -f  $HOMDIR/*.yaml .
+                             cp     $GEOSBIN/bundleParser.py .
 
                              cat fvcore_layout.rc >> input.nml
 
-			    @MOM6@CPEXEC -f  $HOMDIR/MOM_input .
-			    @MOM6@CPEXEC -f  $HOMDIR/MOM_override .
+                             @MOM6cp -f  $HOMDIR/MOM_input .
+                             @MOM6cp -f  $HOMDIR/MOM_override .
 
 if( $GCMEMIP == TRUE ) then
-    @CPEXEC -f  $EXPDIR/restarts/$RSTDATE/cap_restart .
-    @CPEXEC -f  $EXPDIR/restarts/$RSTDATE/CAP.rc .
+    cp -f  $EXPDIR/restarts/$RSTDATE/cap_restart .
+    cp -f  $EXPDIR/restarts/$RSTDATE/CAP.rc .
 endif
 
 set END_DATE  = `grep '^\s*END_DATE:'     CAP.rc | cut -d: -f2`
@@ -384,8 +384,8 @@ cat << _EOF_ > $FILE
 >>>FVCUBED<<</bin/ln -sf $BCSDIR/$BCRSLV/Gnomonic_$BCRSLV.dat .
 >>>FVCUBED<<<endif
 
-@COUPLED @CPEXEC $HOMDIR/*_table .
-@COUPLED @CPEXEC $GRIDDIR/INPUT/* INPUT
+@COUPLED cp $HOMDIR/*_table .
+@COUPLED cp $GRIDDIR/INPUT/* INPUT
 @COUPLED /bin/ln -sf $GRIDDIR/cice/kmt_cice.bin .
 @COUPLED /bin/ln -sf $GRIDDIR/cice/grid_cice.bin .
 
@@ -401,13 +401,13 @@ _EOF_
 @DATAOCEAN echo "/bin/ln -sf $SSTDIR"'/@KPARFILE SEAWIFS_KPAR_mon_clim.data' >> $FILE
 
 chmod +x linkbcs
-@CPEXEC  linkbcs $EXPDIR
+cp  linkbcs $EXPDIR
 
 #######################################################################
 #                    Get Executable and RESTARTS
 #######################################################################
 
-@CPEXEC $EXPDIR/GEOSgcm.x .
+cp $EXPDIR/GEOSgcm.x .
 
 set rst_files      = `grep "RESTART_FILE"    AGCM.rc | grep -v VEGDYN | grep -v "#" | cut -d ":" -f1 | cut -d "_" -f1-2`
 set rst_file_names = `grep "RESTART_FILE"    AGCM.rc | grep -v VEGDYN | grep -v "#" | cut -d ":" -f2`
@@ -431,17 +431,17 @@ end
 # ----------------------------------
 if( $GCMEMIP == TRUE ) then
     foreach rst ( $rst_file_names )
-      if(-e $EXPDIR/restarts/$RSTDATE/$rst ) @CPEXEC $EXPDIR/restarts/$RSTDATE/$rst . &
+      if(-e $EXPDIR/restarts/$RSTDATE/$rst ) cp $EXPDIR/restarts/$RSTDATE/$rst . &
     end
 else
     foreach rst ( $rst_file_names )
-      if(-e $EXPDIR/$rst ) @CPEXEC $EXPDIR/$rst . &
+      if(-e $EXPDIR/$rst ) cp $EXPDIR/$rst . &
     end
 endif
 wait
 
 @COUPLED /bin/mkdir INPUT
-@COUPLED @CPEXEC $EXPDIR/RESTART/* INPUT
+@COUPLED cp $EXPDIR/RESTART/* INPUT
 
 # Copy and Tar Initial Restarts to Restarts Directory
 # ---------------------------------------------------
@@ -450,14 +450,14 @@ set numrs = `/bin/ls -1 ${EXPDIR}/restarts/*${edate}* | wc -l`
 if($numrs == 0) then
    foreach rst ( $rst_file_names )
       if( -e $rst & ! -e ${EXPDIR}/restarts/$EXPID.${rst}.${edate}.${GCMVER}.${BCTAG}_${BCRSLV} ) then
-            @CPEXEC $rst ${EXPDIR}/restarts/$EXPID.${rst}.${edate}.${GCMVER}.${BCTAG}_${BCRSLV} &
+            cp $rst ${EXPDIR}/restarts/$EXPID.${rst}.${edate}.${GCMVER}.${BCTAG}_${BCRSLV} &
       endif
    end
    wait
-@COUPLED    @CPEXEC -r $EXPDIR/RESTART ${EXPDIR}/restarts/RESTART.${edate}
+@COUPLED    cp -r $EXPDIR/RESTART ${EXPDIR}/restarts/RESTART.${edate}
    cd $EXPDIR/restarts
-      @DATAOCEAN @TAREXEC cf  restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
-      @COUPLED @TAREXEC cvf  restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV} RESTART.${edate}
+      @DATAOCEAN tar cf  restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
+      @COUPLED tar cvf  restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV} RESTART.${edate}
      /bin/rm -rf `/bin/ls -d -1     $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}`
      @COUPLED /bin/rm -rf RESTART.${edate}
    cd $SCRDIR
@@ -497,9 +497,9 @@ while ( $counter <= ${NUM_SGMT} )
 /bin/rm -f  EGRESS
 
 if( $GCMEMIP == TRUE ) then
-    @CPEXEC -f  $EXPDIR/restarts/$RSTDATE/CAP.rc .
+    cp -f  $EXPDIR/restarts/$RSTDATE/CAP.rc .
 else
-    @CPEXEC -f $HOMDIR/CAP.rc .
+    cp -f $HOMDIR/CAP.rc .
 endif
 
 /bin/mv CAP.rc CAP.rc.orig
@@ -583,13 +583,13 @@ if( ${EMISSIONS} == MERRA2 | \
     endif
 
     if( $AGCM_LM == 72 ) then
-        @CPEXEC --remove-destination ${MERRA2_EMISSIONS_DIRECTORY}/*.rc .
+        cp --remove-destination ${MERRA2_EMISSIONS_DIRECTORY}/*.rc .
     else
         set files =      `/bin/ls -1 ${MERRA2_EMISSIONS_DIRECTORY}/*.rc`
         foreach file ($files)
           /bin/rm -f   `basename $file`
           /bin/rm -f    dummy
-          @CPEXEC $file dummy
+          cp $file dummy
               cat       dummy | sed -e "s|/L72/|/L${AGCM_LM}/|g" | sed -e "s|z72|z${AGCM_LM}|g" > `basename $file`
         end
     endif
@@ -662,7 +662,7 @@ else
 
    # Run the script
    # --------------
-   $RUN_CMD 1 $GEOSBIN/SaltIntSplitter tile.data $SCRDIR/saltwater_internal_rst
+   @SEVERAL_TRIES $RUN_CMD 1 $GEOSBIN/SaltIntSplitter tile.data $SCRDIR/saltwater_internal_rst
 
    # Move restarts
    # -------------
@@ -674,12 +674,12 @@ else
 
    # Make decorated copies for restarts tarball
    # ------------------------------------------
-   @CPEXEC openwater_internal_rst    $EXPID.openwater_internal_rst.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
-   @CPEXEC seaicethermo_internal_rst $EXPID.seaicethermo_internal_rst.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
+   cp openwater_internal_rst    $EXPID.openwater_internal_rst.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
+   cp seaicethermo_internal_rst $EXPID.seaicethermo_internal_rst.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
 
    # Inject decorated copies into restarts tarball
    # ---------------------------------------------
-   @TAREXEC rf $EXPDIR/restarts/restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
+   tar rf $EXPDIR/restarts/restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
 
    # Remove the decorated restarts
    # -----------------------------
@@ -700,7 +700,7 @@ endif
 if ( -x $GEOSBIN/rs_numtiles.x ) then
 
    set N_OPENW_TILES_EXPECTED = `grep '^\s*0' tile.data | wc -l`
-   set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $GEOSBIN/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
+   set N_OPENW_TILES_FOUND = `@SEVERAL_TRIES $RUN_CMD 1 $GEOSBIN/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
          
    if ( $N_OPENW_TILES_EXPECTED != $N_OPENW_TILES_FOUND ) then
       echo "Error! Found $N_OPENW_TILES_FOUND tiles in openwater. Expect to find $N_OPENW_TILES_EXPECTED tiles."
@@ -806,7 +806,7 @@ else
    set IOSERVER_EXTRA = ""
 endif
 
-$RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
+@SEVERAL_TRIES $RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 
@@ -826,8 +826,8 @@ echo GEOSgcm Run Status: $rc
 
 set edate  = e`awk '{print $1}' cap_restart`_`awk '{print $2}' cap_restart | cut -c1-2`z
 
-@COUPLED @CPEXEC -r RESTART ${EXPDIR}/restarts/RESTART.${edate}
-@COUPLED @CPEXEC RESTART/* INPUT
+@COUPLED cp -r RESTART ${EXPDIR}/restarts/RESTART.${edate}
+@COUPLED cp RESTART/* INPUT
 
 # Move Intermediate Checkpoints to RESTARTS directory
 # ---------------------------------------------------
@@ -860,7 +860,7 @@ set restarts = `/bin/ls -1 *_rst`
 # ----------------------------------------------------
     set  restarts = `/bin/ls -1 $EXPID.*_rst.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}.*`
 foreach  restart ($restarts)
-@CPEXEC $restart ${EXPDIR}/restarts
+cp $restart ${EXPDIR}/restarts
 end
 
 # Remove EXPID from RESTART name
@@ -882,10 +882,10 @@ end
 # ---------------------
 cd $EXPDIR/restarts
     if( $FSEGMENT == 00000000 ) then
-	@DATAOCEAN @TAREXEC cf  restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}.*
-        @COUPLED @TAREXEC cvf  restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}.* RESTART.${edate}
+        @DATAOCEAN tar cf  restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}.*
+        @COUPLED tar cvf  restarts.${edate}.tar $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}.* RESTART.${edate}
         /bin/rm -rf `/bin/ls -d -1     $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}.*`
-	@COUPLED /bin/rm -rf RESTART.${edate}
+        @COUPLED /bin/rm -rf RESTART.${edate}
     endif
 cd $SCRDIR
 
@@ -894,7 +894,7 @@ cd $SCRDIR
 set monthlies = `/bin/ls *chk`
 if ( $#monthlies > 0 ) then
     foreach ff (*chk)
-	    /bin/mv $ff `basename $ff chk`rst
+       /bin/mv $ff `basename $ff chk`rst
     end
 endif
 
@@ -972,23 +972,23 @@ if( $GCMEMIP == TRUE ) then
      end
         /bin/rm -f $EXPDIR/restarts/$RSTDATE/cap_restart
      foreach rst ( `/bin/ls -1 *_rst` )
-       @CPEXEC $rst $EXPDIR/restarts/$RSTDATE/$rst &
+       cp $rst $EXPDIR/restarts/$RSTDATE/$rst &
      end
      wait
-     @CPEXEC cap_restart $EXPDIR/restarts/$RSTDATE/cap_restart
+     cp cap_restart $EXPDIR/restarts/$RSTDATE/cap_restart
 else
      foreach rst ( `/bin/ls -1 *_rst` )
         /bin/rm -f $EXPDIR/$rst
      end
         /bin/rm -f $EXPDIR/cap_restart
      foreach rst ( `/bin/ls -1 *_rst` )
-       @CPEXEC $rst $EXPDIR/$rst &
+       cp $rst $EXPDIR/$rst &
      end
      wait
-     @CPEXEC cap_restart $EXPDIR/cap_restart
+     cp cap_restart $EXPDIR/cap_restart
 endif
 
-@COUPLED @CPEXEC -rf RESTART $EXPDIR
+@COUPLED cp -rf RESTART $EXPDIR
 
 if ( $rc == 0 ) then
       cd  $HOMDIR

--- a/gcm_setup
+++ b/gcm_setup
@@ -475,6 +475,7 @@ if( $OGCM == TRUE ) then
     set DATAOCEAN = "#DELETE"
     set OCEAN_NAME = ""
     set CLDMICRO = "2MOMENT"
+
     # Ocean Model
     # -----------
     OCNMODEL:
@@ -1291,6 +1292,9 @@ endif
 # Default converter time
               setenv CONVERT_T  "0:15:00"                                              # Wallclock Time   for gcm_convert.j
 
+# several_tries only exists at NAS
+              setenv SEVERAL_TRIES  ""
+
 if( $SITE == 'NAS' ) then
               setenv BATCH_CMD "qsub"                 # PBS Batch command
               setenv BATCH_GROUP "PBS -W group_list=" # PBS Syntax for GROUP
@@ -1341,8 +1345,7 @@ if( $SITE == 'NAS' ) then
               setenv CHMDIR     /nobackup/gmao_SIteam/ModelData/fvInput_nc3            # locations of Aerosol Chemistry BCs
               setenv WRKDIR     /nobackup/$LOGNAME                                     # user work directory
               setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/coupled/Forcings       # Coupled Ocean/Atmos Forcing
-              setenv CPEXEC    'mcp -a'                                                # Copy utility for large copies
-              setenv TAREXEC    mtar                                                   # Tar utility for large archives
+              setenv SEVERAL_TRIES /u/scicon/tools/bin/several_tries                   # several_tries script
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
@@ -1390,8 +1393,6 @@ else if( $SITE == 'NCCS' ) then
               setenv CHMDIR     $SHARE/dao_ops/fvInput_nc3                             # locations of Aerosol Chemistry BCs
               setenv WRKDIR     /discover/nobackup/$LOGNAME                            # user work directory
               setenv COUPLEDIR  /discover/nobackup/yvikhlia/coupled/Forcings           # Coupled Ocean/Atmos Forcing
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar
 else if( $SITE == 'AWS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
               setenv BATCH_GROUP DELETE                                                # SLURM Syntax for account name
@@ -1427,8 +1428,6 @@ else if( $SITE == 'AWS' ) then
               setenv WRKDIR     /home/$LOGNAME                                         # user work directory
               setenv COUPLEDIR  /ford1/share/gmao_SIteam/ModelData/Forcings            # Coupled Ocean/Atmos Forcing
 
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar                                                    # Tar utility for large archives
               # By default on AWS, just ignore IOSERVER for now until testing
               set USE_IOSERVER = 0
               set IOS_NDS = 0
@@ -1472,8 +1471,6 @@ else
               set NY = 6
               set CNV_NX = ${NX}
               set CNV_NY = ${NY}
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar                                                    # Tar utility for large archives
               # By default on desktop, just ignore IOSERVER for now
               set USE_IOSERVER = 0
               set IOS_NDS = 0
@@ -2138,9 +2135,6 @@ s/@ANALYZE_TS/0/g
 
 s/@LSM_CHOICE/$LSM_CHOICE/g
 
-s?@CPEXEC?$CPEXEC?g
-s?@TAREXEC?$TAREXEC?g
-
 s/@MP_MG1/$MP_MG1/g
 s/@MP_GFDL/$MP_GFDL/g
 s/@MP_NO_USE_WSUB/$MP_NO_USE_WSUB/g
@@ -2150,6 +2144,8 @@ s?@FV_ZTRACER?$FV_ZTRACER?g
 s?@FV_MAKENH?$FV_MAKENH?g
 s?@FV_HYDRO?$FV_HYDRO?g
 s?@FV_SATADJ?$FV_SATADJ?g
+
+s?@SEVERAL_TRIES?$SEVERAL_TRIES?g
 
 EOF
 

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1336,6 +1336,9 @@ endif
 # Default converter time
               setenv CONVERT_T  "0:15:00"                                              # Wallclock Time   for gcm_convert.j
 
+# several_tries only exists at NAS
+              setenv SEVERAL_TRIES  ""
+
 if( $SITE == 'NAS' ) then
               setenv BATCH_CMD "qsub"                 # PBS Batch command
               setenv BATCH_GROUP "PBS -W group_list=" # PBS Syntax for GROUP
@@ -1386,8 +1389,7 @@ if( $SITE == 'NAS' ) then
               setenv CHMDIR     /nobackup/gmao_SIteam/ModelData/fvInput_nc3            # locations of Aerosol Chemistry BCs
               setenv WRKDIR     /nobackup/$LOGNAME                                     # user work directory
               setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/coupled/Forcings       # Coupled Ocean/Atmos Forcing
-              setenv CPEXEC    'mcp -a'                                                # Copy utility for large copies
-              setenv TAREXEC    mtar                                                   # Tar utility for large archives
+              setenv SEVERAL_TRIES /u/scicon/tools/bin/several_tries                   # several_tries script
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
@@ -1435,8 +1437,6 @@ else if( $SITE == 'NCCS' ) then
               setenv CHMDIR     $SHARE/dao_ops/fvInput_nc3                             # locations of Aerosol Chemistry BCs
               setenv WRKDIR     /discover/nobackup/$LOGNAME                            # user work directory
               setenv COUPLEDIR  /discover/nobackup/yvikhlia/coupled/Forcings           # Coupled Ocean/Atmos Forcing
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar
 else if( $SITE == 'AWS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
               setenv BATCH_GROUP DELETE                                                # SLURM Syntax for account name
@@ -1472,8 +1472,6 @@ else if( $SITE == 'AWS' ) then
               setenv WRKDIR     /home/$LOGNAME                                         # user work directory
               setenv COUPLEDIR  /ford1/share/gmao_SIteam/ModelData/Forcings            # Coupled Ocean/Atmos Forcing
 
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar                                                    # Tar utility for large archives
               # By default on AWS, just ignore IOSERVER for now until testing
               set USE_IOSERVER = 0
               set IOS_NDS = 0
@@ -1517,8 +1515,6 @@ else
               set NY = 6
               set CNV_NX = ${NX}
               set CNV_NY = ${NY}
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar                                                    # Tar utility for large archives
               # By default on desktop, just ignore IOSERVER for now
               set USE_IOSERVER = 0
               set IOS_NDS = 0
@@ -2188,9 +2184,6 @@ s/@ANALYZE_TS/0/g
 
 s/@LSM_CHOICE/$LSM_CHOICE/g
 
-s?@CPEXEC?$CPEXEC?g
-s?@TAREXEC?$TAREXEC?g
-
 s/@MP_MG1/$MP_MG1/g
 s/@MP_GFDL/$MP_GFDL/g
 s?@GFDL_HYDRO?$GFDL_HYDRO?g
@@ -2199,6 +2192,8 @@ s?@FV_ZTRACER?$FV_ZTRACER?g
 s?@FV_MAKENH?$FV_MAKENH?g
 s?@FV_HYDRO?$FV_HYDRO?g
 s?@FV_SATADJ?$FV_SATADJ?g
+
+s?@SEVERAL_TRIES?$SEVERAL_TRIES?g
 
 EOF
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1463,6 +1463,9 @@ endif
 # Default converter time
               setenv CONVERT_T  "0:15:00"                                              # Wallclock Time   for gcm_convert.j
 
+# several_tries only exists at NAS
+              setenv SEVERAL_TRIES  ""
+
 if( $SITE == 'NAS' ) then
               setenv BATCH_CMD "qsub"                 # PBS Batch command
               setenv BATCH_GROUP "PBS -W group_list=" # PBS Syntax for GROUP
@@ -1513,8 +1516,7 @@ if( $SITE == 'NAS' ) then
               setenv CHMDIR     /nobackup/gmao_SIteam/ModelData/fvInput_nc3            # locations of Aerosol Chemistry BCs
               setenv WRKDIR     /nobackup/$LOGNAME                                     # user work directory
               setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/coupled/Forcings       # Coupled Ocean/Atmos Forcing
-              setenv CPEXEC    'mcp -a'                                                # Copy utility for large copies
-              setenv TAREXEC    mtar                                                   # Tar utility for large archives
+              setenv SEVERAL_TRIES /u/scicon/tools/bin/several_tries                   # several_tries script
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
@@ -1562,8 +1564,6 @@ else if( $SITE == 'NCCS' ) then
               setenv CHMDIR     $SHARE/dao_ops/fvInput_nc3                             # locations of Aerosol Chemistry BCs
               setenv WRKDIR     /discover/nobackup/$LOGNAME                            # user work directory
               setenv COUPLEDIR  /discover/nobackup/yvikhlia/coupled/Forcings           # Coupled Ocean/Atmos Forcing
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar
 else if( $SITE == 'AWS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
               setenv BATCH_GROUP DELETE                                                # SLURM Syntax for account name
@@ -1599,8 +1599,6 @@ else if( $SITE == 'AWS' ) then
               setenv WRKDIR     /home/$LOGNAME                                         # user work directory
               setenv COUPLEDIR  /ford1/share/gmao_SIteam/ModelData/Forcings            # Coupled Ocean/Atmos Forcing
 
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar                                                    # Tar utility for large archives
               # By default on AWS, just ignore IOSERVER for now until testing
               set USE_IOSERVER = 0
               set IOS_NDS = 0
@@ -1644,8 +1642,6 @@ else
               set NY = 6
               set CNV_NX = ${NX}
               set CNV_NY = ${NY}
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar                                                    # Tar utility for large archives
               # By default on desktop, just ignore IOSERVER for now
               set USE_IOSERVER = 0
               set IOS_NDS = 0
@@ -2325,9 +2321,6 @@ s/@ANALYZE_TS/0/g
 
 s/@LSM_CHOICE/$LSM_CHOICE/g
 
-s?@CPEXEC?$CPEXEC?g
-s?@TAREXEC?$TAREXEC?g
-
 s/@MP_MG1/$MP_MG1/g
 s/@MP_GFDL/$MP_GFDL/g
 s/@MP_NO_USE_WSUB/$MP_NO_USE_WSUB/g
@@ -2337,6 +2330,8 @@ s?@FV_ZTRACER?$FV_ZTRACER?g
 s?@FV_MAKENH?$FV_MAKENH?g
 s?@FV_HYDRO?$FV_HYDRO?g
 s?@FV_SATADJ?$FV_SATADJ?g
+
+s?@SEVERAL_TRIES?$SEVERAL_TRIES?g
 
 EOF
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1321,6 +1321,9 @@ endif
 # Default converter time
               setenv CONVERT_T  "0:15:00"                                              # Wallclock Time   for gcm_convert.j
 
+# several_tries only exists at NAS
+              setenv SEVERAL_TRIES  ""
+
 if( $SITE == 'NAS' ) then
               setenv BATCH_CMD "qsub"                 # PBS Batch command
               setenv BATCH_GROUP "PBS -W group_list=" # PBS Syntax for GROUP
@@ -1371,8 +1374,7 @@ if( $SITE == 'NAS' ) then
               setenv CHMDIR     /nobackup/gmao_SIteam/ModelData/fvInput_nc3            # locations of Aerosol Chemistry BCs
               setenv WRKDIR     /nobackup/$LOGNAME                                     # user work directory
               setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/coupled/Forcings       # Coupled Ocean/Atmos Forcing
-              setenv CPEXEC    'mcp -a'                                                # Copy utility for large copies
-              setenv TAREXEC    mtar                                                   # Tar utility for large archives
+              setenv SEVERAL_TRIES /u/scicon/tools/bin/several_tries                   # several_tries script
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
@@ -1420,8 +1422,6 @@ else if( $SITE == 'NCCS' ) then
               setenv CHMDIR     $SHARE/dao_ops/fvInput_nc3                             # locations of Aerosol Chemistry BCs
               setenv WRKDIR     /discover/nobackup/$LOGNAME                            # user work directory
               setenv COUPLEDIR  /discover/nobackup/yvikhlia/coupled/Forcings           # Coupled Ocean/Atmos Forcing
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar
 else if( $SITE == 'AWS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
               setenv BATCH_GROUP DELETE                                                # SLURM Syntax for account name
@@ -1457,8 +1457,6 @@ else if( $SITE == 'AWS' ) then
               setenv WRKDIR     /home/$LOGNAME                                         # user work directory
               setenv COUPLEDIR  /ford1/share/gmao_SIteam/ModelData/Forcings            # Coupled Ocean/Atmos Forcing
 
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar                                                    # Tar utility for large archives
               # By default on AWS, just ignore IOSERVER for now until testing
               set USE_IOSERVER = 0
               set IOS_NDS = 0
@@ -1502,8 +1500,6 @@ else
               set NY = 6
               set CNV_NX = ${NX}
               set CNV_NY = ${NY}
-              setenv CPEXEC     /bin/cp                                                # Copy utility for large copies
-              setenv TAREXEC    tar                                                    # Tar utility for large archives
               # By default on desktop, just ignore IOSERVER for now
               set USE_IOSERVER = 0
               set IOS_NDS = 0
@@ -2172,9 +2168,6 @@ s/@ANALYZE_TS/0/g
 
 s/@LSM_CHOICE/$LSM_CHOICE/g
 
-s?@CPEXEC?$CPEXEC?g
-s?@TAREXEC?$TAREXEC?g
-
 s/@MP_MG1/$MP_MG1/g
 s/@MP_GFDL/$MP_GFDL/g
 s/@MP_NO_USE_WSUB/$MP_NO_USE_WSUB/g
@@ -2184,6 +2177,8 @@ s?@FV_ZTRACER?$FV_ZTRACER?g
 s?@FV_MAKENH?$FV_MAKENH?g
 s?@FV_HYDRO?$FV_HYDRO?g
 s?@FV_SATADJ?$FV_SATADJ?g
+
+s?@SEVERAL_TRIES?$SEVERAL_TRIES?g
 
 EOF
 


### PR DESCRIPTION
This PR updates the setup and run scripts for NAS.

1. Removes `mtar` and `mcp` as these can occasionally cause issues for users on certain disk systems at NAS (as seen recently by @gmao-ylim).
2. Adds `several_tries` at NAS. This is a script that [mitigate MPT startup failures](https://www.nas.nasa.gov/hecc/support/kb/mpt-startup-failures-workarounds_526.html)