### PR TITLE
Update RRTMGP file locations and half gpoints

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -745,10 +745,10 @@ NUM_BANDS: 30
 
 #USE_RRTMGP_IRRAD: 1.0
 #USE_RRTMGP_SORAD: 1.0
-#RRTMGP_DATA_LW: /discover/nobackup/pnorris/RRTMGP-data.new.20200503/rrtmgp/data/rrtmgp-data-lw-g256-2018-12-04.nc
-#RRTMGP_DATA_SW: /discover/nobackup/pnorris/RRTMGP-data.new.20200503/rrtmgp/data/rrtmgp-data-sw-g224-2018-12-04.nc
-#RRTMGP_CLOUD_OPTICS_COEFFS_LW: /discover/nobackup/pnorris/RRTMGP-data.new.20200503/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc
-#RRTMGP_CLOUD_OPTICS_COEFFS_SW: /discover/nobackup/pnorris/RRTMGP-data.new.20200503/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-sw.nc
+#RRTMGP_DATA_LW: /discover/nobackup/pnorris/RRTMGP-data.v1.5/rrtmgp/data/rrtmgp-data-lw-g128-210809.nc
+#RRTMGP_DATA_SW: /discover/nobackup/pnorris/RRTMGP-data.v1.5/rrtmgp/data/rrtmgp-data-sw-g112-210809.nc
+#RRTMGP_CLOUD_OPTICS_COEFFS_LW: /discover/nobackup/pnorris/RRTMGP-data.v1.5/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-lw.nc
+#RRTMGP_CLOUD_OPTICS_COEFFS_SW: /discover/nobackup/pnorris/RRTMGP-data.v1.5/extensions/cloud_optics/rrtmgp-cloud-optics-coeffs-sw.nc
 
 DIURNAL_BIOMASS_BURNING: yes
 


### PR DESCRIPTION
This update from @dr0cloud updates RRTMGP files. Note that these are commented out by default and even then, won't be read by the GCM unless RRTMGP is enables.

This is trivially zero-diff.