### PR TITLE
Updates for Spack Support, Round 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,16 @@
 ecbuild_add_executable (
   TARGET GEOSgcm.x
   SOURCES GEOSgcm.F90
-  LIBS GEOSgcm_GridComp 
+  LIBS GEOSgcm_GridComp esmf OpenMP::OpenMP_Fortran
   )
 
 ecbuild_add_executable (
   TARGET idfupd.x
   SOURCES idfupd.F90
-  LIBS GEOSgcm_GridComp 
+  LIBS GEOSgcm_GridComp esmf
   )
 
 set (CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_FLAGS_VECT}")
-
-target_link_libraries (GEOSgcm.x OpenMP::OpenMP_Fortran)
-target_include_directories (GEOSgcm.x PUBLIC ${INC_ESMF})
 
 file (GLOB templates CONFIGURE_DEPENDS *.tmpl)
 


### PR DESCRIPTION
Due to insufficient grepping on my part, some remnants of the
"not-canonical" CMake still remain. Apparently these were not necessary
changes for Spack, but they are changes that unify the CMake style of
GEOS to be more like "correct" CMake.

In this go-around, it is mainly finding `INC_ESMF` which I apparently
forgot to grep for last time (I was focused on NetCDF).