### PR TITLE
Fix Emissions Handling: Use copy not link

### DIFF
--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -177,7 +177,7 @@ endif
 #            Copy and Modify RC Files from Home Directory
 #######################################################################
 
-                             /bin/ln -sf $EXPDIR/RC/* .
+                             cp -f  $EXPDIR/RC/* .
                              cp -f  $HOMDIR/*.rc .
                              cp -f  $HOMDIR/*.nml .
                              cp -f  $HOMDIR/*.yaml .
@@ -742,7 +742,7 @@ else
    # Remove the decorated restarts
    # -----------------------------
    /bin/rm $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
-   
+
    # Remove the saltwater internal restart
    # -------------------------------------
    /bin/rm $SCRDIR/saltwater_internal_rst
@@ -841,7 +841,7 @@ else
    set rc = -1
 endif
 echo GEOSgcm Run Status: $rc
- 
+
 #######################################################################
 #               Move HISTORY Files to Holding Directory
 #######################################################################

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -68,7 +68,7 @@ cd $HOMDIR
     end
 cd $EXPDIR/regress
 
-/bin/ln -s $EXPDIR/RC/*.rc  $EXPDIR/regress
+cp $EXPDIR/RC/*.rc     $EXPDIR/regress
 cp $EXPDIR/GEOSgcm.x   $EXPDIR/regress
 cp $EXPDIR/linkbcs     $EXPDIR/regress
 cp $HOMDIR/*.yaml      $EXPDIR/regress
@@ -154,7 +154,7 @@ else
 endif
 
 #######################################################################
-#                 Create Simple History for Efficiency 
+#                 Create Simple History for Efficiency
 #######################################################################
 
 set         FILE = HISTORY.rc0
@@ -283,7 +283,7 @@ if( $REPLAY_MODE == 'Exact' | $REPLAY_MODE == 'Regular' ) then
      /bin/ln -sf ${ANA_LOCATION}/${REPLAY_FILE_TYPE} .
      /bin/ln -sf ${ANA_LOCATION}/${REPLAY_FILE09_TYPE} .
 
-endif 
+endif
 
 ##################################################################
 ######
@@ -314,7 +314,7 @@ set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
 $RUN_CMD $NPES ./GEOSgcm.x
-                                                                                                                      
+
 
 set date = `cat cap_restart`
 set nymde = $date[1]
@@ -457,7 +457,7 @@ set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
 $RUN_CMD $NPES ./GEOSgcm.x
-                                                                                                                      
+
 set date = `cat cap_restart`
 set nymde = $date[1]
 set nhmse = $date[2]
@@ -480,7 +480,7 @@ foreach chk ( $chk_file_names )
   set file1 = ${chk}.${nymde}_${nhmse}.1
   set file2 = ${chk}.${nymde}_${nhmse}.2
   if( -e $file1 && -e $file2 ) then
-                               set check = true 
+                               set check = true
       foreach exempt (${EXEMPT_chk})
          if( $chk == $exempt ) set check = false
       end

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -243,7 +243,7 @@ endif
 
 cd $SCRDIR
 /bin/rm -rf *
-                             /bin/ln -sf $EXPDIR/RC/* .
+                             cp -f  $EXPDIR/RC/* .
                              cp     $EXPDIR/cap_restart .
                              cp -f  $HOMDIR/*.rc .
                              cp -f  $HOMDIR/*.nml .
@@ -587,7 +587,7 @@ if( ${EMISSIONS} == AMIP_EMISSIONS ) then
     # emissions (HFED instead of QFED) valid before 2000-03-01. Note
     # that if you make a change to anything in $EXPDIR/RC/AMIP or
     # $EXPDIR/RC/AMIP.20C, you might need to make a change in the other
-    # directory to be consistent. Some files in AMIP.20C are symlinks to 
+    # directory to be consistent. Some files in AMIP.20C are symlinks to
     # that in AMIP but others are not.
 
     if( $nymdc < ${AMIP_Transition_Date} ) then
@@ -723,7 +723,7 @@ else
    # Remove the decorated restarts
    # -----------------------------
    /bin/rm $EXPID.*.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
-   
+
    # Remove the saltwater internal restart
    # -------------------------------------
    /bin/rm $SCRDIR/saltwater_internal_rst
@@ -740,7 +740,7 @@ if ( -x $GEOSBIN/rs_numtiles.x ) then
 
    set N_OPENW_TILES_EXPECTED = `grep '^\s*0' tile.data | wc -l`
    set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $GEOSBIN/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
-         
+
    if ( $N_OPENW_TILES_EXPECTED != $N_OPENW_TILES_FOUND ) then
       echo "Error! Found $N_OPENW_TILES_FOUND tiles in openwater. Expect to find $N_OPENW_TILES_EXPECTED tiles."
       echo "Your restarts are probably for a different ocean."
@@ -858,7 +858,7 @@ else
 endif
 echo GEOSgcm Run Status: $rc
 if ( $rc == -1 ) exit -1
- 
+
 #######################################################################
 #   Rename Final Checkpoints => Restarts for Next Segment and Archive
 #        Note: cap_restart contains the current NYMD and NHMS
@@ -957,7 +957,7 @@ end
 #######################################################################
 
 $GEOSUTIL/post/gcmpost.script -source $EXPDIR -movefiles
- 
+
 if( $FSEGMENT != 00000000 ) then
      set REPLAY_BEG_DATE = `grep '^\s*BEG_REPDATE:' $HOMDIR/CAP.rc | cut -d: -f2`
      set REPLAY_END_DATE = `grep '^\s*END_REPDATE:' $HOMDIR/CAP.rc | cut -d: -f2`


### PR DESCRIPTION
Thanks to @mmanyin, it was found that #320 wasn't quite the full fix. The issue was the run scripts were still doing links to `$EXPDIR/RC` instead of full copies. Thus, the symlinks that were in `$EXPDIR/RC` were mutable and then the run script could screw them up after the fact.

Instead, we *copy* RC files from `$EXPDIR/RC` and then all is well. The AMIP changes cannot propagate back to `$EXPDIR/RC`