### PR TITLE
Add LD_PRELOAD for Coupled Model

### DIFF
--- a/gcm_convert.j
+++ b/gcm_convert.j
@@ -509,7 +509,7 @@ set LOGFILE = "$CNVDIR/GEOSgcm.log"
 # Assume gcm_setup set these properly for the local platform
 /bin/rm -f EGRESS
 @SETENVS
-$RUN_CMD $NPES ./GEOSgcm.x >& $LOGFILE
+@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x >& $LOGFILE
 if( -e EGRESS ) then
    set rc = 0
 else

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -335,7 +335,7 @@ cat CAP.tmp | sed -e "s?$oldstring?$newstring?g" > CAP.rc
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-$RUN_CMD $NPES ./GEOSgcm.x
+@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x
 
 
 set date = `cat cap_restart`
@@ -398,7 +398,7 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-$RUN_CMD $NPES ./GEOSgcm.x
+@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x
 
 foreach rst ( $rst_file_names )
   /bin/rm -f  $rst
@@ -478,7 +478,7 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
-$RUN_CMD $NPES ./GEOSgcm.x
+@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x
 
 set date = `cat cap_restart`
 set nymde = $date[1]

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -869,7 +869,7 @@ else
    set IOSERVER_EXTRA = ""
 endif
 
-$RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
+@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -481,6 +481,7 @@ if( $OGCM == TRUE ) then
     set OGRIDTYP  = "TM"
     set DATAOCEAN = "#DELETE"
     set OCEAN_NAME = ""
+    set OCEAN_PRELOAD = ""
     set CLDMICRO = "2MOMENT"
 
     # Ocean Model
@@ -507,10 +508,12 @@ if( $OGCM == TRUE ) then
 
     if ( $OCNMODEL == "MOM5" ) then
        set OCEAN_NAME="MOM"
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
        set MOM5=""
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
+       set OCEAN_PRELOAD = ""
        set MOM6=""
        set MOM5 = "#DELETE"
     endif
@@ -729,6 +732,7 @@ else
 
     set DATAOCEAN = ""
     set OCEAN_NAME = ""
+    set OCEAN_PRELOAD = ""
     set OGCM_LM   =  34
     set COUPLED   = "#DELETE"
     set MOM5      = "#DELETE"
@@ -2079,6 +2083,7 @@ s?>>>EMIP_OLDLAND<<<?$EMIP_OLDLAND?g
 s?>>>EMIP_NEWLAND<<<?$EMIP_NEWLAND?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
+s?@OCEAN_PRELOAD?$OCEAN_PRELOAD?g
 
 s?>>>4DIAUDAS<<<?#DELETE?g
 s?>>>REGULAR_REPLAY<<<?#?g

--- a/gcm_setup
+++ b/gcm_setup
@@ -513,7 +513,7 @@ if( $OGCM == TRUE ) then
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
-       set OCEAN_PRELOAD = ""
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
        set MOM6=""
        set MOM5 = "#DELETE"
     endif

--- a/gcm_setup
+++ b/gcm_setup
@@ -506,14 +506,16 @@ if( $OGCM == TRUE ) then
        endif
     endif
 
+    # NOTE: We use a CMake variable here because the shared library
+    # suffix is different on Linux and macOS. This is set by configure_file()
     if ( $OCNMODEL == "MOM5" ) then
        set OCEAN_NAME="MOM"
-       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM5=""
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
-       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM6=""
        set MOM5 = "#DELETE"
     endif

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -481,6 +481,7 @@ if( $OGCM == TRUE ) then
     set OGRIDTYP  = "TM"
     set DATAOCEAN = "#DELETE"
     set OCEAN_NAME = ""
+    set OCEAN_PRELOAD = ""
     set CLDMICRO = "2MOMENT"
 
     # Ocean Model
@@ -507,10 +508,12 @@ if( $OGCM == TRUE ) then
 
     if ( $OCNMODEL == "MOM5" ) then
        set OCEAN_NAME="MOM"
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
        set MOM5=""
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
+       set OCEAN_PRELOAD = ""
        set MOM6=""
        set MOM5 = "#DELETE"
     endif
@@ -729,6 +732,7 @@ else
 
     set DATAOCEAN = ""
     set OCEAN_NAME = ""
+    set OCEAN_PRELOAD = ""
     set OGCM_LM   =  34
     set COUPLED   = "#DELETE"
     set MOM5      = "#DELETE"
@@ -2130,6 +2134,7 @@ s?>>>EMIP_OLDLAND<<<?$EMIP_OLDLAND?g
 s?>>>EMIP_NEWLAND<<<?$EMIP_NEWLAND?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
+s?@OCEAN_PRELOAD?$OCEAN_PRELOAD?g
 
 s?>>>4DIAUDAS<<<?#DELETE?g
 s?>>>REGULAR_REPLAY<<<?#?g

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -513,7 +513,7 @@ if( $OGCM == TRUE ) then
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
-       set OCEAN_PRELOAD = ""
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
        set MOM6=""
        set MOM5 = "#DELETE"
     endif

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -506,14 +506,16 @@ if( $OGCM == TRUE ) then
        endif
     endif
 
+    # NOTE: We use a CMake variable here because the shared library
+    # suffix is different on Linux and macOS. This is set by configure_file()
     if ( $OCNMODEL == "MOM5" ) then
        set OCEAN_NAME="MOM"
-       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM5=""
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
-       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM6=""
        set MOM5 = "#DELETE"
     endif

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -486,6 +486,7 @@ if( $OGCM == TRUE ) then
     set OGRIDTYP  = "TM"
     set DATAOCEAN = "#DELETE"
     set OCEAN_NAME = ""
+    set OCEAN_PRELOAD = ""
     set CLDMICRO = "2MOMENT"
 
     # Ocean Model
@@ -512,10 +513,12 @@ if( $OGCM == TRUE ) then
 
     if ( $OCNMODEL == "MOM5" ) then
        set OCEAN_NAME="MOM"
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
        set MOM5=""
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
+       set OCEAN_PRELOAD = ""
        set MOM6=""
        set MOM5 = "#DELETE"
     endif
@@ -826,6 +829,7 @@ else
 
     set DATAOCEAN = ""
     set OCEAN_NAME = ""
+    set OCEAN_PRELOAD = ""
     set OGCM_LM   =  34
     set COUPLED   = "#DELETE"
     set MOM5      = "#DELETE"
@@ -2297,6 +2301,7 @@ s?>>>EMIP_OLDLAND<<<?$EMIP_OLDLAND?g
 s?>>>EMIP_NEWLAND<<<?$EMIP_NEWLAND?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
+s?@OCEAN_PRELOAD?$OCEAN_PRELOAD?g
 
 s?>>>4DIAUDAS<<<?#DELETE?g
 s?>>>REGULAR_REPLAY<<<?#?g

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -518,7 +518,7 @@ if( $OGCM == TRUE ) then
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
-       set OCEAN_PRELOAD = ""
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
        set MOM6=""
        set MOM5 = "#DELETE"
     endif

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -511,14 +511,16 @@ if( $OGCM == TRUE ) then
        endif
     endif
 
+    # NOTE: We use a CMake variable here because the shared library
+    # suffix is different on Linux and macOS. This is set by configure_file()
     if ( $OCNMODEL == "MOM5" ) then
        set OCEAN_NAME="MOM"
-       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM5=""
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
-       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM6=""
        set MOM5 = "#DELETE"
     endif

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -481,6 +481,7 @@ if( $OGCM == TRUE ) then
     set OGRIDTYP  = "TM"
     set DATAOCEAN = "#DELETE"
     set OCEAN_NAME = ""
+    set OCEAN_PRELOAD = ""
     set CLDMICRO = "2MOMENT"
 
     # Ocean Model
@@ -507,10 +508,12 @@ if( $OGCM == TRUE ) then
 
     if ( $OCNMODEL == "MOM5" ) then
        set OCEAN_NAME="MOM"
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
        set MOM5=""
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
+       set OCEAN_PRELOAD = ""
        set MOM6=""
        set MOM5 = "#DELETE"
     endif
@@ -729,6 +732,7 @@ else
 
     set DATAOCEAN = ""
     set OCEAN_NAME = ""
+    set OCEAN_PRELOAD = ""
     set OGCM_LM   =  34
     set COUPLED   = "#DELETE"
     set MOM5      = "#DELETE"
@@ -2115,6 +2119,7 @@ s?>>>EMIP_OLDLAND<<<?$EMIP_OLDLAND?g
 s?>>>EMIP_NEWLAND<<<?$EMIP_NEWLAND?g
 s?@LSM_PARMS?$LSM_PARMS?g
 s?@OCEAN_NAME?$OCEAN_NAME?g
+s?@OCEAN_PRELOAD?$OCEAN_PRELOAD?g
 
 s?>>>4DIAUDAS<<<?#DELETE?g
 s?>>>REGULAR_REPLAY<<<?#?g

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -513,7 +513,7 @@ if( $OGCM == TRUE ) then
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
-       set OCEAN_PRELOAD = ""
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
        set MOM6=""
        set MOM5 = "#DELETE"
     endif

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -506,14 +506,16 @@ if( $OGCM == TRUE ) then
        endif
     endif
 
+    # NOTE: We use a CMake variable here because the shared library
+    # suffix is different on Linux and macOS. This is set by configure_file()
     if ( $OCNMODEL == "MOM5" ) then
        set OCEAN_NAME="MOM"
-       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom.so'
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM5=""
        set MOM6 = "#DELETE"
     else if ( $OCNMODEL == "MOM6" ) then
        set OCEAN_NAME="MOM6"
-       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6.so'
+       set OCEAN_PRELOAD = 'env LD_PRELOAD=$GEOSDIR/lib/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM6=""
        set MOM5 = "#DELETE"
     endif


### PR DESCRIPTION
Recent testing with mom5 by @yvikhlya and @sanAkel (see https://github.com/GEOS-ESM/GEOSgcm/issues/352 and https://github.com/GEOS-ESM/GEOSgcm/issues/430) in GEOSgcm has shown a need to bring back the old `LD_PRELOAD` mechanism that was removed in #204. So this PR brings back `LD_PRELOAD` but only in the case of MOM5

Obviously not ideal, but until this oddity can be examined by @tclune and @weiyuan-jiang (and maybe @atrayano), ~we bring back `LD_PRELOAD` *ONLY* when running MOM5 as runs of MOM6 don't seem to care!~

As @yvikhlya pointed out below, MOM6 might only work due to luck. So we preload both.