### PR TITLE
Add OH restart files (commented out)

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -685,6 +685,14 @@ HEMCO_IMPORT_RESTART_FILE:              hemco_import_rst
 HEMCO_IMPORT_CHECKPOINT_FILE:           hemco_import_checkpoint
 HEMCO_IMPORT_CHECKPOINT_TYPE:           @CHECKPOINT_TYPE
 
+#OH_INTERNAL_RESTART_FILE:               oh_internal_rst
+#OH_INTERNAL_CHECKPOINT_FILE:            oh_internal_checkpoint
+#OH_INTERNAL_CHECKPOINT_TYPE:            @CHECKPOINT_TYPE
+
+#OH_IMPORT_RESTART_FILE:                 oh_import_rst
+#OH_IMPORT_CHECKPOINT_FILE:              oh_import_checkpoint
+#OH_IMPORT_CHECKPOINT_TYPE:              @CHECKPOINT_TYPE
+
 # OCEAN Model Restart Files
 # -------------------------
 SALTWATER_IMPORT_RESTART_FILE:          saltwater_import_rst


### PR DESCRIPTION
Added internal and import restart files for OH, which will be introduced under the QuickChem module in the upcoming CHEMISTRY release.  This is zero diff.