### PR TITLE
Add circleci tests to GEOSgcm_App

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2.1
+
+# Anchors to prevent forgetting to update a version
+baselibs_version: &baselibs_version v7.5.0
+bcs_version: &bcs_version v10.22.5
+
+orbs:
+  ci: geos-esm/circleci-tools@1
+
+workflows:
+  build-test:
+    jobs:
+      # Build GEOSgcm
+      - ci/build:
+          name: build-GEOSgcm-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          baselibs_version: *baselibs_version
+          repo: GEOSgcm
+          checkout_fixture: true
+          mepodevelop: true
+          persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
+      # Run GCM (1 hour, no ExtData)
+      - ci/run_gcm:
+          name: run-GCM-on-<< matrix.compiler >>
+          context:
+            - docker-hub-creds
+          matrix:
+            parameters:
+              compiler: [gfortran, ifort]
+          requires:
+            - build-GEOSgcm-on-<< matrix.compiler >>
+          repo: GEOSgcm
+          baselibs_version: *baselibs_version
+          bcs_version: *bcs_version
+


### PR DESCRIPTION
This PR adds CircleCI tests to GEOSgcm_App. PRs will both build the model (nigh trivial since only `GEOSgcm.F90` is here, but it could catch CMake issues) and then *run* the model for 1 hour (this might catch History issues?).

Still, we've gone too long without it here.