### PR TITLE
Add explicit CONTACT to History

### DIFF
--- a/HISTAENS.rc.tmpl
+++ b/HISTAENS.rc.tmpl
@@ -5,6 +5,8 @@
 EXPID:  >>>EXPID<<<
 EXPDSC: ensemble_bkg
  
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'bkg.eta'
              'bkg.sfc'
               ::

--- a/HISTFDDA.rc.tmpl
+++ b/HISTFDDA.rc.tmpl
@@ -5,6 +5,8 @@
 EXPID:  @EXPID
 EXPDSC: @EXPDSC
  
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'bkg.eta'
              'bkg.sfc'
              'cbkg.eta'

--- a/HISTFDDAL.rc.tmpl
+++ b/HISTFDDAL.rc.tmpl
@@ -5,6 +5,8 @@
 EXPID:  @EXPID
 EXPDSC: @EXPDSC
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'asm.eta'
              'bkg.eta'
              'bkg.sfc'

--- a/HISTORY.AGCM.rc.tmpl
+++ b/HISTORY.AGCM.rc.tmpl
@@ -4,6 +4,8 @@ EXPDSC: @EXPDSC
 EXPSRC: @EXPSRC
 
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'geosgcm_prog'
 #             'prog.eta'
              'geosgcm_surf'

--- a/HISTORY.AOGCM-MOM5.rc.tmpl
+++ b/HISTORY.AOGCM-MOM5.rc.tmpl
@@ -4,6 +4,8 @@ EXPDSC: @EXPDSC
 EXPSRC: @EXPSRC
 
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'geosgcm_prog'
              'geosgcm_surf'
              'geosgcm_rad'

--- a/HISTORY.AOGCM.rc.tmpl
+++ b/HISTORY.AOGCM.rc.tmpl
@@ -4,6 +4,8 @@ EXPDSC: @EXPDSC
 EXPSRC: @EXPSRC
 
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'geosgcm_prog'
 #             'prog.eta'
              'geosgcm_surf'

--- a/HISTORY.rc.tmpl
+++ b/HISTORY.rc.tmpl
@@ -66,6 +66,8 @@ PC540x361-DC.POLE: PC
 PC540x361-DC.DATELINE: DC
 PC288x181-DC.LM: 72
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'inst3_3d_asm_Np-'
 #            'inst3_3d_asm_Nv-'
              'inst1_2d_asm_Nx-'

--- a/HISTORY_FP.rc.03z.tmpl
+++ b/HISTORY_FP.rc.03z.tmpl
@@ -58,6 +58,8 @@ PC540x361-DC.POLE: PC
 PC540x361-DC.DATELINE: DC
 PC540x361-DC.LM: 72
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'inst3_3d_asm_Np-'
              'inst3_3d_asm_Nv-'
              'inst3_2d_asm_Nx-'

--- a/HISTORY_FP.rc.09z.tmpl
+++ b/HISTORY_FP.rc.09z.tmpl
@@ -58,6 +58,8 @@ PC540x361-DC.POLE: PC
 PC540x361-DC.DATELINE: DC
 PC540x361-DC.LM: 72
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'inst3_3d_asm_Np-'
              'inst3_3d_asm_Nv-'
              'inst3_2d_asm_Nx-'

--- a/HISTORY_FP.rc.15z.tmpl
+++ b/HISTORY_FP.rc.15z.tmpl
@@ -58,6 +58,8 @@ PC540x361-DC.POLE: PC
 PC540x361-DC.DATELINE: DC
 PC540x361-DC.LM: 72
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'inst3_3d_asm_Np-'
              'inst3_3d_asm_Nv-'
              'inst3_2d_asm_Nx-'

--- a/HISTORY_FP.rc.21z.tmpl
+++ b/HISTORY_FP.rc.21z.tmpl
@@ -57,6 +57,8 @@ PC540x361-DC.POLE: PC
 PC540x361-DC.DATELINE: DC
 PC540x361-DC.LM: 72
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'inst3_3d_asm_Np-'
              'inst3_3d_asm_Nv-'
              'inst3_2d_asm_Nx-'

--- a/HISTORY_GEOSCHEMCHEM.rc.tmpl
+++ b/HISTORY_GEOSCHEMCHEM.rc.tmpl
@@ -3,6 +3,8 @@ EXPID:  @EXPID
 EXPDSC: @EXPDSC
 EXPSRC: @EXPSRC
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'tavg24_3d_chm_Nv'
              'tavg24_3d_met_Nv'
              'tavg24_2d_chm_Nx'

--- a/HISTORY_GEOSIT.rc.tmpl
+++ b/HISTORY_GEOSIT.rc.tmpl
@@ -67,6 +67,8 @@ PC540x361-DC.DATELINE: DC
 PC288x181-DC.LM: 72
 
 # GEOS-IT File Spec
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'asm_inst_3hr_glo_L576x361_p42_NCKS'
              'asm_inst_3hr_glo_L576x361_v72_NCKS'
              'asm_inst_3hr_glo_C180x180x6_v72_NCKS'

--- a/HISTORY_GMICHEM.rc.tmpl
+++ b/HISTORY_GMICHEM.rc.tmpl
@@ -3,6 +3,8 @@ EXPID:  @EXPID
 EXPDSC: @EXPDSC
 EXPSRC: @EXPSRC
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'eta_tavg24'
 #            'eta_edge_tavg24'
              'plev_tavg24'

--- a/HISTORY_MERRA2-DD.rc.tmpl
+++ b/HISTORY_MERRA2-DD.rc.tmpl
@@ -6,6 +6,8 @@ EXPID:  @EXPID
 EXPDSC: @EXPDSC
 EXPSRC: @EXPSRC
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'inst3_3d_asm_Cp' # Equivalent MERRA2 1/2 degree of ASM
              'inst3_3d_asm_Cv'
              'inst1_2d_asm_Cx'

--- a/HISTORY_MERRA2.rc.tmpl
+++ b/HISTORY_MERRA2.rc.tmpl
@@ -5,6 +5,8 @@
 EXPID:  @EXPID
 EXPDSC: @EXPDSC
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'inst3_3d_asm_Np-'
              'inst3_3d_asm_Nv-'
              'inst1_2d_asm_Nx-'

--- a/HISTORY_MERRA_CFIO.rc.tmpl
+++ b/HISTORY_MERRA_CFIO.rc.tmpl
@@ -5,6 +5,8 @@
 EXPID:  @EXPID
 EXPDSC: @EXPDSC
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'inst3_3d_asm_Cp'
              'tavg3_3d_cld_Cp'
              'tavg3_3d_mst_Cp'

--- a/HISTORY_S2S.rc.tmpl
+++ b/HISTORY_S2S.rc.tmpl
@@ -3,6 +3,8 @@ EXPID:  @EXPID
 EXPDSC: @EXPDSC
 EXPSRC: @EXPSRC
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'geosgcm_6hrins'
              'geosgcm_6hravg'
              'geosgcm_chmx'

--- a/HISTORY_STRATCHEM.rc.tmpl
+++ b/HISTORY_STRATCHEM.rc.tmpl
@@ -3,6 +3,8 @@ EXPID:  @EXPID
 EXPDSC: @EXPDSC
 EXPSRC: @EXPSRC
 
+CONTACT: 'http://gmao.gsfc.nasa.gov'
+
 COLLECTIONS: 'geosgcm_eta'
              'stratchem_eta'
              ::


### PR DESCRIPTION
Due to a request from NOAA, in an upcoming version of MAPL, [the default `Contact:` normally inserted into History output will change from `http://gmao.gsfc.nasa.gov` to a blank string](https://github.com/GEOS-ESM/MAPL/pull/1715). 

In order to keep history metadata the same, this PR adds:
```
CONTACT: 'http://gmao.gsfc.nasa.gov'
```
to all HISTORY files in this repo.

Note that this is a no-op as this just overrides the default `Contact:` in the History output to be the current default.

---

Files changed by:
```bash
$ sed -e "/^ *COLLEC/i CONTACT: 'http://gmao.gsfc.nasa.gov'\n" -i HIST*
```