### PR TITLE
Add GEOSCHEMchem_ExtData.yaml to list of yaml files for EXTDATA2G

### DIFF
--- a/construct_extdata_yaml_list.py
+++ b/construct_extdata_yaml_list.py
@@ -37,6 +37,8 @@ if __name__ == '__main__':
    - StratChem_ExtData.yaml
    GMICHEM:
    - GMI_ExtData.yaml
+   GEOSCHEM:
+   - GEOSCHEMchem_ExtData.yaml
    CARMA:
    - CARMAchem_GridComp_ExtData.yaml
    MAM:


### PR DESCRIPTION
I created an ExtData yaml file for GEOS-Chem, which is now included in the `geos/develop` branch of geos-chem ([GEOSCHEMchem_ExtData.yaml](https://github.com/GEOS-ESM/geos-chem/blob/geos/develop/run/GEOS/GEOSCHEMchem_ExtData.yaml)). This PR simply ensures that this yaml file gets indeed read when using EXTDATA2G.