### PR TITLE
Bugfix/yury/aogcm notilehist `regrid_exch: tile_hist.data` was removed from history template

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -329,8 +329,6 @@ cat << _EOF_ > $FILE
 @COUPLED/bin/ln -sf $ABCSDIR/@ATMOStag_@OCEANtag-Pfafstetter.TRN   runoff.bin
 @COUPLED/bin/ln -sf $OBCSDIR/MAPL_Tripolar.nc .
 @COUPLED/bin/ln -sf $OBCSDIR/vgrid${OGCM_LM}.ascii ./vgrid.ascii
-@MOM5#/bin/ln -s @COUPLEDIR/a@HIST_IMx@HIST_JM_o${OGCM_IM}x${OGCM_JM}/DC0@HIST_IMxPC0@HIST_JM_@OCEANtag-Pfafstetter.til tile_hist.data
-@MOM6#/bin/ln -s @COUPLEDIR/MOM6/DC0@HIST_IMxPC0@HIST_JM_@OCEANtag/DC0@HIST_IMxPC0@HIST_JM_@OCEANtag-Pfafstetter.til tile_hist.data
 
 # Precip correction
 #/bin/ln -s /discover/nobackup/projects/gmao/share/gmao_ops/fvInput/merra_land/precip_CPCUexcludeAfrica-CMAP_corrected_MERRA/GEOSdas-2_1_4 ExtData/PCP
@@ -778,7 +776,6 @@ setenv YEAR $yearc
 
 if (! -e tile.bin) then
 $GEOSBIN/binarytile.x tile.data tile.bin
-@MOM5 $GEOSBIN/binarytile.x tile_hist.data tile_hist.bin
 endif
 
 # If running in dual ocean mode, link sst and fraci data here


### PR DESCRIPTION
... for tripolar collections in previous PR and this PR removes linking tile_hist.data in gcm_run.j script, since it is not necessary anymore. Interpolation of tripolar output to latlon grid is done with `grid_label` option. Perhaps, `regrid_exch` option should be removed from MAPL too, but I am not sure about this.