### PR TITLE
Fixes for non-72-level runs with ExtData2G

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -2332,7 +2332,7 @@ if( $OGCM == TRUE ) /bin/mv $HOMDIR/plotocn.j       $EXPDIR/plot
 # Modify RC Files for LM
 # ----------------------
 if( $AGCM_LM != 72 ) then
-    set files = `ls -1 $EXPDIR/RC/*.rc`
+    set files = `ls -1 $EXPDIR/RC/*.rc $EXPDIR/RC/*.yaml`
     foreach file ($files)
        /bin/rm -f    $EXPDIR/RC/dummy
        /bin/mv $file $EXPDIR/RC/dummy

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -2508,7 +2508,7 @@ if( $OGCM == TRUE ) /bin/mv $HOMDIR/plotocn.j       $EXPDIR/plot
 # Modify RC Files for LM
 # ----------------------
 if( $AGCM_LM != 72 ) then
-    set files = `ls -1 $EXPDIR/RC/*.rc`
+    set files = `ls -1 $EXPDIR/RC/*.rc $EXPDIR/RC/*.yaml`
     foreach file ($files)
        /bin/rm -f    $EXPDIR/RC/dummy
        /bin/mv $file $EXPDIR/RC/dummy

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2630,7 +2630,7 @@ cat           $HOMDIR/dummy | sed -e "/SATSIM_DT/a GMICHEM_DT: $GMICHEM_DT" > $f
 # Modify RC Files for LM
 # ----------------------
 if( $AGCM_LM != 72 ) then
-    set files = `ls -1 $EXPDIR/RC/*.rc`
+    set files = `ls -1 $EXPDIR/RC/*.rc $EXPDIR/RC/*.yaml`
     foreach file ($files)
        /bin/rm -f    $EXPDIR/RC/dummy
        /bin/mv $file $EXPDIR/RC/dummy

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -2409,7 +2409,7 @@ if( $OGCM == TRUE ) /bin/mv $HOMDIR/plotocn.j       $EXPDIR/plot
 # Modify RC Files for LM
 # ----------------------
 if( $AGCM_LM != 72 ) then
-    set files = `ls -1 $EXPDIR/RC/*.rc`
+    set files = `ls -1 $EXPDIR/RC/*.rc $EXPDIR/RC/*.yaml`
     foreach file ($files)
        /bin/rm -f    $EXPDIR/RC/dummy
        /bin/mv $file $EXPDIR/RC/dummy


### PR DESCRIPTION
As discovered by @wmputman, L181 runs were failing with ExtData2G. Until a proper fix can go into MAPL, etc. this is a quick fix to let things work. 

@bena-nasa has tested and it works for him.

Note to @sdrabenh: You'll want to do the same thing in the Bill development branch as well.