### PR TITLE
Update logging.yaml, add YAML linter

### DIFF
--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -1,0 +1,31 @@
+---
+
+# Based on code from https://github.com/marketplace/actions/yaml-lint
+
+name: Yaml Lint
+
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+# This validation is equivalent to running on the command line:
+#   yamllint -d relaxed --no-warnings
+# and is controlled by the .yamllint.yml file
+jobs:
+  validate-YAML:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - id: yaml-lint
+        name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          no_warnings: true
+          format: colored
+          config_file: .yamllint.yml
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: yamllint-logfile
+          path: ${{ steps.yaml-lint.outputs.logfile }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,29 @@
+---
+
+extends: default
+
+rules:
+  braces:
+    level: warning
+    max-spaces-inside: 1
+  brackets:
+    level: warning
+    max-spaces-inside: 1
+  colons:
+    level: warning
+  commas:
+    level: warning
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    level: warning
+  hyphens:
+    level: warning
+  indentation:
+    level: warning
+    indent-sequences: consistent
+  line-length:
+    level: warning
+    allow-non-breakable-inline-mappings: true
+  truthy: disable

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,12 +1,12 @@
 schema_version: 1
 
-###############################      
+###############################
 locks:
    mpi:
       class: MpiLock
       comm:  MPI_COMM_WORLD
 
-###############################      
+###############################
 formatters:
    plain:
       class: Formatter
@@ -25,9 +25,7 @@ formatters:
       class: Formatter
       format: '(%(i)i3.3,%(j)i3.3): %(level_name)'
 
-
-
-###############################      
+###############################
 handlers:
 
    console:
@@ -35,14 +33,13 @@ handlers:
       formatter: basic
       unit: OUTPUT_UNIT
       level: INFO
- 
+
    console_plain:
       class: streamhandler
       formatter: plain
       unit: OUTPUT_UNIT
       level: INFO
- 
-      
+
    warnings:
       class:  FileHandler
       filename: warnings_and_errors.log
@@ -69,17 +66,17 @@ handlers:
       class: MpiFileHandler
       formatter: basic
       filename:  debug_%(rank)i3.3~.log
-      comm: MPI_COMM_WORLD      
+      comm: MPI_COMM_WORLD
       rank_prefix: rank
       level: DEBUG
 
-###############################      
+###############################
 root:
    handlers: [warnings,errors,console]
    level: WARNING
    root_level: WARNING
 
-###############################      
+###############################
 loggers:
 
    errors:
@@ -89,7 +86,7 @@ loggers:
    CAP:
        level: WARNING
        root_level: INFO
-       
+
    MAPL:
        handlers: [mpi_shared]
        level: WARNING
@@ -102,7 +99,7 @@ loggers:
        root_level: INFO
 
   # Note: When enabling another logger, make sure
-  #       indentation matches that of the above 
+  #       indentation matches that of the above
   #       loggers!
 
   # MAPL.base:

--- a/logging.yaml
+++ b/logging.yaml
@@ -95,7 +95,7 @@ loggers:
        level: WARNING
        root_level: INFO
 
-   MAPL.PROF:
+   MAPL.profiler:
        handlers: [console_plain]
        propagate: FALSE
        level: WARNING


### PR DESCRIPTION
This PR is a minor update to the `logging.yaml` file which will be useful for an upcoming MAPL PR:

https://github.com/GEOS-ESM/MAPL/pull/1938

Without the MAPL PR, no change should be seen in log output. This PR in combination with the MAPL PR will change:
```
MAPL: INFO: Model Throughput:     1001.424 days per day
```
to:
```
Model Throughput:     1001.203 days per day
```

I've also added the GEOS YAML validator action as well. Always nice make sure our YAML is good. 
