### PR TITLE
Fix issue with oserver node calculations

### DIFF
--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -122,7 +122,7 @@ endif
 @ MODEL_NPES = $NX * $NY
 
 set NCPUS_PER_NODE = @NCPUS_PER_NODE
-set NUM_MODEL_NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+set NUM_MODEL_NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
 if ( $NCPUS != NULL ) then
 

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -107,7 +107,7 @@ endif
 @ MODEL_NPES = $NX * $NY
 
 set NCPUS_PER_NODE = @NCPUS_PER_NODE
-set NUM_MODEL_NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+set NUM_MODEL_NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
 if ( $NCPUS != NULL ) then
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -1357,10 +1357,10 @@ if ( $DO_IOS == TRUE ) then
    # In the calculations below, the weird bc-awk command is to round up the floating point calcs
 
    # First we calculate the number of model nodes
-   set NUM_MODEL_NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_MODEL_NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # Next the number of frontend PEs is 10% of the model PEs
-   set NUM_FRONTEND_PES=`echo "scale=1;($MODEL_NPES * 0.1)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_FRONTEND_PES=`echo "scale=6;($MODEL_NPES * 0.1)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # Now we roughly figure out the number of collections in the HISTORY.rc (this is not perfect, but is close to right)
    set NUM_HIST_COLLECTIONS=`cat $TMPHIST | sed -n '/^COLLECTIONS:/,/^ *::$/{p;/^ *::$/q}' | grep -v '^ *#' | wc -l`
@@ -1369,10 +1369,10 @@ if ( $DO_IOS == TRUE ) then
    @ NUM_OSERVER_PES=$NUM_FRONTEND_PES + $NUM_HIST_COLLECTIONS
 
    # Now calculate the number of oserver nodes
-   set NUM_OSERVER_NODES=`echo "scale=1;($NUM_OSERVER_PES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_OSERVER_NODES=`echo "scale=6;($NUM_OSERVER_PES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # And then the number of backend PEs is the number of history collections divided by the number of oserver nodes
-   set NUM_BACKEND_PES=`echo "scale=1;($NUM_HIST_COLLECTIONS / $NUM_OSERVER_NODES)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_BACKEND_PES=`echo "scale=6;($NUM_HIST_COLLECTIONS / $NUM_OSERVER_NODES)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # multigroup requires at least two backend pes
    if ($NUM_BACKEND_PES < 2) set NUM_BACKEND_PES = 2
@@ -1382,7 +1382,7 @@ if ( $DO_IOS == TRUE ) then
 
 else
    # Calculate the number of model nodes
-   set NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    set NUM_OSERVER_NODES = 0
    set NUM_BACKEND_PES   = 0

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1408,10 +1408,10 @@ if ( $DO_IOS == TRUE ) then
    # In the calculations below, the weird bc-awk command is to round up the floating point calcs
 
    # First we calculate the number of model nodes
-   set NUM_MODEL_NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_MODEL_NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # Next the number of frontend PEs is 10% of the model PEs
-   set NUM_FRONTEND_PES=`echo "scale=1;($MODEL_NPES * 0.1)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_FRONTEND_PES=`echo "scale=6;($MODEL_NPES * 0.1)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # Now we roughly figure out the number of collections in the HISTORY.rc (this is not perfect, but is close to right)
    set NUM_HIST_COLLECTIONS=`cat $TMPHIST | sed -n '/^COLLECTIONS:/,/^ *::$/{p;/^ *::$/q}' | grep -v '^ *#' | wc -l`
@@ -1420,10 +1420,10 @@ if ( $DO_IOS == TRUE ) then
    @ NUM_OSERVER_PES=$NUM_FRONTEND_PES + $NUM_HIST_COLLECTIONS
 
    # Now calculate the number of oserver nodes
-   set NUM_OSERVER_NODES=`echo "scale=1;($NUM_OSERVER_PES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_OSERVER_NODES=`echo "scale=6;($NUM_OSERVER_PES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # And then the number of backend PEs is the number of history collections divided by the number of oserver nodes
-   set NUM_BACKEND_PES=`echo "scale=1;($NUM_HIST_COLLECTIONS / $NUM_OSERVER_NODES)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_BACKEND_PES=`echo "scale=6;($NUM_HIST_COLLECTIONS / $NUM_OSERVER_NODES)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # multigroup requires at least two backend pes
    if ($NUM_BACKEND_PES < 2) set NUM_BACKEND_PES = 2
@@ -1433,7 +1433,7 @@ if ( $DO_IOS == TRUE ) then
 
 else
    # Calculate the number of model nodes
-   set NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    set NUM_OSERVER_NODES = 0
    set NUM_BACKEND_PES   = 0

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1541,10 +1541,10 @@ if ( $DO_IOS == TRUE ) then
    # In the calculations below, the weird bc-awk command is to round up the floating point calcs
 
    # First we calculate the number of model nodes
-   set NUM_MODEL_NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_MODEL_NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # Next the number of frontend PEs is 10% of the model PEs
-   set NUM_FRONTEND_PES=`echo "scale=1;($MODEL_NPES * 0.1)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_FRONTEND_PES=`echo "scale=6;($MODEL_NPES * 0.1)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # Now we roughly figure out the number of collections in the HISTORY.rc (this is not perfect, but is close to right)
    set NUM_HIST_COLLECTIONS=`cat $TMPHIST | sed -n '/^COLLECTIONS:/,/^ *::$/{p;/^ *::$/q}' | grep -v '^ *#' | wc -l`
@@ -1553,10 +1553,10 @@ if ( $DO_IOS == TRUE ) then
    @ NUM_OSERVER_PES=$NUM_FRONTEND_PES + $NUM_HIST_COLLECTIONS
 
    # Now calculate the number of oserver nodes
-   set NUM_OSERVER_NODES=`echo "scale=1;($NUM_OSERVER_PES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_OSERVER_NODES=`echo "scale=6;($NUM_OSERVER_PES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # And then the number of backend PEs is the number of history collections divided by the number of oserver nodes
-   set NUM_BACKEND_PES=`echo "scale=1;($NUM_HIST_COLLECTIONS / $NUM_OSERVER_NODES)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_BACKEND_PES=`echo "scale=6;($NUM_HIST_COLLECTIONS / $NUM_OSERVER_NODES)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # multigroup requires at least two backend pes
    if ($NUM_BACKEND_PES < 2) set NUM_BACKEND_PES = 2
@@ -1566,7 +1566,7 @@ if ( $DO_IOS == TRUE ) then
 
 else
    # Calculate the number of model nodes
-   set NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    set NUM_OSERVER_NODES = 0
    set NUM_BACKEND_PES   = 0

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1393,10 +1393,10 @@ if ( $DO_IOS == TRUE ) then
    # In the calculations below, the weird bc-awk command is to round up the floating point calcs
 
    # First we calculate the number of model nodes
-   set NUM_MODEL_NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_MODEL_NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # Next the number of frontend PEs is 10% of the model PEs
-   set NUM_FRONTEND_PES=`echo "scale=1;($MODEL_NPES * 0.1)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_FRONTEND_PES=`echo "scale=6;($MODEL_NPES * 0.1)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # Now we roughly figure out the number of collections in the HISTORY.rc (this is not perfect, but is close to right)
    set NUM_HIST_COLLECTIONS=`cat $TMPHIST | sed -n '/^COLLECTIONS:/,/^ *::$/{p;/^ *::$/q}' | grep -v '^ *#' | wc -l`
@@ -1405,10 +1405,10 @@ if ( $DO_IOS == TRUE ) then
    @ NUM_OSERVER_PES=$NUM_FRONTEND_PES + $NUM_HIST_COLLECTIONS
 
    # Now calculate the number of oserver nodes
-   set NUM_OSERVER_NODES=`echo "scale=1;($NUM_OSERVER_PES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_OSERVER_NODES=`echo "scale=6;($NUM_OSERVER_PES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # And then the number of backend PEs is the number of history collections divided by the number of oserver nodes
-   set NUM_BACKEND_PES=`echo "scale=1;($NUM_HIST_COLLECTIONS / $NUM_OSERVER_NODES)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NUM_BACKEND_PES=`echo "scale=6;($NUM_HIST_COLLECTIONS / $NUM_OSERVER_NODES)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    # multigroup requires at least two backend pes
    if ($NUM_BACKEND_PES < 2) set NUM_BACKEND_PES = 2
@@ -1418,7 +1418,7 @@ if ( $DO_IOS == TRUE ) then
 
 else
    # Calculate the number of model nodes
-   set NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
+   set NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
    set NUM_OSERVER_NODES = 0
    set NUM_BACKEND_PES   = 0


### PR DESCRIPTION
Testing on AWS exposed a bug in the calculations used for oserver use in the setup and run scripts. The issue is this code:

```csh
   set NUM_MODEL_NODES=`echo "scale=1;($MODEL_NPES / $NCPUS_PER_NODE)"  \
    | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
```
and the `scale=1` bit. 

What this is supposed to do is divide the model NPES by the NCPUS_PER_NODE and then round *UP* with that `ceil()` function in case of a partial node.

And it does that. 

90% of the time.

On AWS, we were running 15x60 = 900 model PEs and 64 cores per node. By hand we see this is 14.0625 nodes → round up to 15.

Now the math:
```shell
❯ echo "scale=1;900./64." | bc
14.0
❯ echo "scale=1;900./64." | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'
14
```
Oh dear. What is 14.0 rounded up? 14! If we up the scale:
```
❯ echo "scale=6;900./64." | bc
14.062500
❯ echo "scale=6;900./64." | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'
15
```
Ah. There we go.

So, about 10% of the time, you'd get `XX.0` and the rounding would fail.

I'll test on discover now to make sure it works...and it should.