### PR TITLE
Add Rome detections to other setup scripts

### DIFF
--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -388,30 +388,49 @@ if ( $SITE == 'NCCS' ) then
 
 else if ( $SITE == 'NAS' ) then
 
-   echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
-   echo "   ${C2}has (Haswell)${CN}"
-   echo "   ${C2}bro (Broadwell)${CN}"
-   echo "   ${C2}sky (Skylake)${CN} (default)"
-   echo "   ${C2}cas (Cascade Lake)${CN}"
-   echo "   ${C2}rom (AMD Rome)${CN}"
-   echo " "
-   echo " NOTE 1: Due to how FV3 is compiled by default, Sandy Bridge"
-   echo "         and Ivy Bridge are not supported by current GEOS"
-   echo " "
-   echo " NOTE 2: GEOS is non-zero-diff when running on AMD Rome"
-   echo "         compared to the other Intel nodes."
-   echo " "
-   set MODEL = `echo $<`
-   set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
-   if ( .$MODEL == .) then
-      set MODEL = 'sky'
-   endif
+   set BUILT_ON_ROME = @BUILT_ON_ROME@
 
-   if( $MODEL != 'has' & \
-       $MODEL != 'bro' & \
-       $MODEL != 'sky' & \
-       $MODEL != 'cas' & \
-       $MODEL != 'rom' ) goto ASKPROC
+   if ( $BUILT_ON_ROME == "TRUE") then
+
+      echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
+      echo "   ${C2}rom (AMD Rome) (default)${CN}"
+      echo " "
+      echo " NOTE GEOS is non-zero-diff when running on AMD Rome"
+      echo "      compared to the other Intel nodes."
+      echo " "
+      set MODEL = `echo $<`
+      set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
+      if ( .$MODEL == .) then
+         set MODEL = 'rom'
+      endif
+
+      if( $MODEL != 'rom' ) goto ASKPROC
+   else
+
+      echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
+      echo "   ${C2}has (Haswell)${CN}"
+      echo "   ${C2}bro (Broadwell)${CN}"
+      echo "   ${C2}sky (Skylake)${CN} (default)"
+      echo "   ${C2}cas (Cascade Lake)${CN}"
+      echo " "
+      echo " NOTE 1: Due to how FV3 is compiled by default, Sandy Bridge"
+      echo "         and Ivy Bridge are not supported by current GEOS"
+      echo " "
+      echo " NOTE 2: Due to OS differences, if you want to run on the AMD"
+      echo "         Rome nodes at NAS, you must recompile on the Rome nodes"
+      echo " "
+      set MODEL = `echo $<`
+      set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
+      if ( .$MODEL == .) then
+         set MODEL = 'sky'
+      endif
+
+      if( $MODEL != 'has' & \
+          $MODEL != 'bro' & \
+          $MODEL != 'sky' & \
+          $MODEL != 'cas' ) goto ASKPROC
+
+   endif
 
    # Some processors have weird names at NAS
    # ---------------------------------------

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -388,30 +388,49 @@ if ( $SITE == 'NCCS' ) then
 
 else if ( $SITE == 'NAS' ) then
 
-   echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
-   echo "   ${C2}has (Haswell)${CN}"
-   echo "   ${C2}bro (Broadwell)${CN}"
-   echo "   ${C2}sky (Skylake)${CN} (default)"
-   echo "   ${C2}cas (Cascade Lake)${CN}"
-   echo "   ${C2}rom (AMD Rome)${CN}"
-   echo " "
-   echo " NOTE 1: Due to how FV3 is compiled by default, Sandy Bridge"
-   echo "         and Ivy Bridge are not supported by current GEOS"
-   echo " "
-   echo " NOTE 2: GEOS is non-zero-diff when running on AMD Rome"
-   echo "         compared to the other Intel nodes."
-   echo " "
-   set MODEL = `echo $<`
-   set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
-   if ( .$MODEL == .) then
-      set MODEL = 'sky'
-   endif
+   set BUILT_ON_ROME = @BUILT_ON_ROME@
 
-   if( $MODEL != 'has' & \
-       $MODEL != 'bro' & \
-       $MODEL != 'sky' & \
-       $MODEL != 'cas' & \
-       $MODEL != 'rom' ) goto ASKPROC
+   if ( $BUILT_ON_ROME == "TRUE") then
+
+      echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
+      echo "   ${C2}rom (AMD Rome) (default)${CN}"
+      echo " "
+      echo " NOTE GEOS is non-zero-diff when running on AMD Rome"
+      echo "      compared to the other Intel nodes."
+      echo " "
+      set MODEL = `echo $<`
+      set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
+      if ( .$MODEL == .) then
+         set MODEL = 'rom'
+      endif
+
+      if( $MODEL != 'rom' ) goto ASKPROC
+   else
+
+      echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
+      echo "   ${C2}has (Haswell)${CN}"
+      echo "   ${C2}bro (Broadwell)${CN}"
+      echo "   ${C2}sky (Skylake)${CN} (default)"
+      echo "   ${C2}cas (Cascade Lake)${CN}"
+      echo " "
+      echo " NOTE 1: Due to how FV3 is compiled by default, Sandy Bridge"
+      echo "         and Ivy Bridge are not supported by current GEOS"
+      echo " "
+      echo " NOTE 2: Due to OS differences, if you want to run on the AMD"
+      echo "         Rome nodes at NAS, you must recompile on the Rome nodes"
+      echo " "
+      set MODEL = `echo $<`
+      set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
+      if ( .$MODEL == .) then
+         set MODEL = 'sky'
+      endif
+
+      if( $MODEL != 'has' & \
+          $MODEL != 'bro' & \
+          $MODEL != 'sky' & \
+          $MODEL != 'cas' ) goto ASKPROC
+
+   endif
 
    # Some processors have weird names at NAS
    # ---------------------------------------

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -388,30 +388,49 @@ if ( $SITE == 'NCCS' ) then
 
 else if ( $SITE == 'NAS' ) then
 
-   echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
-   echo "   ${C2}has (Haswell)${CN}"
-   echo "   ${C2}bro (Broadwell)${CN}"
-   echo "   ${C2}sky (Skylake)${CN} (default)"
-   echo "   ${C2}cas (Cascade Lake)${CN}"
-   echo "   ${C2}rom (AMD Rome)${CN}"
-   echo " "
-   echo " NOTE 1: Due to how FV3 is compiled by default, Sandy Bridge"
-   echo "         and Ivy Bridge are not supported by current GEOS"
-   echo " "
-   echo " NOTE 2: GEOS is non-zero-diff when running on AMD Rome"
-   echo "         compared to the other Intel nodes."
-   echo " "
-   set MODEL = `echo $<`
-   set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
-   if ( .$MODEL == .) then
-      set MODEL = 'sky'
-   endif
+   set BUILT_ON_ROME = @BUILT_ON_ROME@
 
-   if( $MODEL != 'has' & \
-       $MODEL != 'bro' & \
-       $MODEL != 'sky' & \
-       $MODEL != 'cas' & \
-       $MODEL != 'rom' ) goto ASKPROC
+   if ( $BUILT_ON_ROME == "TRUE") then
+
+      echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
+      echo "   ${C2}rom (AMD Rome) (default)${CN}"
+      echo " "
+      echo " NOTE GEOS is non-zero-diff when running on AMD Rome"
+      echo "      compared to the other Intel nodes."
+      echo " "
+      set MODEL = `echo $<`
+      set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
+      if ( .$MODEL == .) then
+         set MODEL = 'rom'
+      endif
+
+      if( $MODEL != 'rom' ) goto ASKPROC
+   else
+
+      echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
+      echo "   ${C2}has (Haswell)${CN}"
+      echo "   ${C2}bro (Broadwell)${CN}"
+      echo "   ${C2}sky (Skylake)${CN} (default)"
+      echo "   ${C2}cas (Cascade Lake)${CN}"
+      echo " "
+      echo " NOTE 1: Due to how FV3 is compiled by default, Sandy Bridge"
+      echo "         and Ivy Bridge are not supported by current GEOS"
+      echo " "
+      echo " NOTE 2: Due to OS differences, if you want to run on the AMD"
+      echo "         Rome nodes at NAS, you must recompile on the Rome nodes"
+      echo " "
+      set MODEL = `echo $<`
+      set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
+      if ( .$MODEL == .) then
+         set MODEL = 'sky'
+      endif
+
+      if( $MODEL != 'has' & \
+          $MODEL != 'bro' & \
+          $MODEL != 'sky' & \
+          $MODEL != 'cas' ) goto ASKPROC
+
+   endif
 
    # Some processors have weird names at NAS
    # ---------------------------------------


### PR DESCRIPTION
Mea culpa. With PR #411 I only touched `gcm_setup` and I forgot to update the stratchem, GMI, and GEOS-Chem scripts.

For @mmanyin and @christophkeller 's benefit:

Because you can only run on Romes at NAS if you build on Romes at NAS (because of different OSs), this PR is an attempt to allow users to only select Rome nodes if you built on Rome, and only Intel nodes if you built on Intel.

