### PR TITLE
Update logging.yaml with example, some changes

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 # Example on how to use the logging.yaml file based on
-# 
+#
 #   https://github.com/GEOS-ESM/MAPL/wiki/How-to-use-the-MAPL-logging-library,-aka-%22pFlogger%22
 #
 # Let us say you want to get all the debugging loggers

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,6 +1,8 @@
 schema_version: 1
 
-# Example on how to use the logging.yaml file
+# Example on how to use the logging.yaml file based on
+# 
+#   https://github.com/GEOS-ESM/MAPL/wiki/How-to-use-the-MAPL-logging-library,-aka-%22pFlogger%22
 #
 # Let us say you want to get all the debugging loggers
 # from ExtData in MAPL. To do this you first want to

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,5 +1,27 @@
 schema_version: 1
 
+# Example on how to use the logging.yaml file
+#
+# Let us say you want to get all the debugging loggers
+# from ExtData in MAPL. To do this you first want to
+# set the 'console' handler below to DEBUG level:
+#
+# handlers:
+#   console:
+#      class: streamhandler
+#      formatter: basic
+#      unit: OUTPUT_UNIT
+#      level: DEBUG
+#
+# Now we need to add a logger for ExtData. We do this
+# by adding the following to the loggers section:
+#
+# loggers:
+#    CAP.EXTDATA:
+#       handlers: [console]
+#       level: WARNING
+#       root_level: DEBUG
+
 ###############################
 locks:
    mpi:
@@ -80,23 +102,23 @@ root:
 loggers:
 
    errors:
-       handlers: [errors]
-       level: ERROR
+      handlers: [errors]
+      level: ERROR
 
    CAP:
-       level: WARNING
-       root_level: INFO
+      level: WARNING
+      root_level: INFO
 
    MAPL:
-       handlers: [mpi_shared]
-       level: WARNING
-       root_level: INFO
+      handlers: [mpi_shared]
+      level: WARNING
+      root_level: INFO
 
    MAPL.profiler:
-       handlers: [console_plain]
-       propagate: FALSE
-       level: WARNING
-       root_level: INFO
+      handlers: [console_plain]
+      propagate: FALSE
+      level: WARNING
+      root_level: INFO
 
   # Note: When enabling another logger, make sure
   #       indentation matches that of the above
@@ -108,6 +130,8 @@ loggers:
 
   # SHARED.GMAOSHARED.GEOSSHARED.QSAT:
 
+  # CAP.EXTDATA:
+  # CAP.HISTORY:
   # CAP.GCM.DATATM:
   # CAP.GCM.AGCM:
   # CAP.GCM.AGCM.SCMDYNAMICS:
@@ -124,21 +148,20 @@ loggers:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.HEMCO:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.PCHEM:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.ACHEM:
-  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART:
-  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.BC:
-  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.BRC:
+  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART2G:
+  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART2G.CA.bc:
+  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART2G.CA.br:
+  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART2G.CA.oc:
+  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART2G.DU:
+  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART2G.NI:
+  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART2G.SS:
+  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART2G.SU:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.CFC:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.CH4:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.CO2:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.CO:
-  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.DU:
-  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.NI:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.O3:
-  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.OC:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.Rn:
-  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.SS:
-  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.SU:
-  # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GOCART.data:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.GAAS:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.H2O:
   # CAP.GCM.AGCM.PHYSICS.CHEMISTRY.STRATCHEM:


### PR DESCRIPTION
This PR updates the `logging.yaml` file with a nice example based on the one found on the [MAPL wiki for logger](https://github.com/GEOS-ESM/MAPL/wiki/How-to-use-the-MAPL-logging-library,-aka-%22pFlogger%22).

Also, some of the "example" commented out loggers in the file are fixed up for GOCART2G.

Finally, some indentation is made consistent with the 3-space indents throughout the file. 