### PR TITLE
Move from FLAP to fArgParse

### DIFF
--- a/GEOSgcm.F90
+++ b/GEOSgcm.F90
@@ -22,16 +22,15 @@ program GEOS5_Main
 
    character(len=*), parameter :: Iam="GEOS5_Main"
    type (MAPL_Cap) :: cap
-   type (MAPL_FlapCLI) :: cli
+   type (MAPL_FargparseCLI) :: cli
    type (MAPL_CapOptions) :: cap_options
    integer :: status
 
-   cli = MAPL_FlapCLI(description = 'GEOS AGCM', &
-                                     authors     = 'GMAO')
+   cli = MAPL_FargparseCLI()
    cap_options = MAPL_CapOptions(cli)
    cap = MAPL_Cap('GCM', ROOT_SetServices, cap_options = cap_options)
 
    call cap%run(_RC)
 
 end program GEOS5_Main
-   
+


### PR DESCRIPTION
This PR moves `GEOSgcm.x` from using FLAP to fArgParse for command line options. This is so that we can move away from FLAP (remove support in MAPL3) as well as better support GEOS use of spack.

Note: For best support, this requires ESMA_env v4.11.0 or newer, so this will remain blocked until https://github.com/GEOS-ESM/GEOSgcm/pull/520 (update ESMA_env) is merged in.