### PR TITLE
Separate out the two regression tests: start-stop and layout

### DIFF
--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -339,9 +339,8 @@ set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
 
 echo "=== Running 24 hour test with NX = $NX and NY = $NY starting at $nymd0 $nhms0 ==="
- 
-@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
 
+@OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
 
 set date = `cat cap_restart`
 set nymde1 = $date[1]
@@ -499,7 +498,8 @@ set test_NY = 6
 # Copy Original Restarts to Regress directory
 # -------------------------------------------
 foreach rst ( $rst_file_names )
-       cp $EXPDIR/$rst $EXPDIR/regress
+  /bin/rm -f  $rst
+  cp $EXPDIR/$rst $EXPDIR/regress
 end
 
 /bin/rm              cap_restart
@@ -575,6 +575,7 @@ set NCCMP = `echo ${BASEDIR}/${ARCH}/bin/nccmp -dmfgBq `
 if( -e startstop_regress_test ) /bin/rm startstop_regress_test
 
 echo "=== Comparing restarts from 24-hour ${NX0}x${NY0} run with restarts from 6-hour + 18-hour ${NX0}x${NY0} runs ==="
+
 set startstop_pass = true
 foreach chk ( $chk_file_names )
   set file1 = ${chk}.${nymde1}_${nhmse1}.1
@@ -590,10 +591,10 @@ foreach chk ( $chk_file_names )
 # compare binary checkpoint files
          cmp $file1 $file2
          if( $status == 0 ) then
-             echo Success!
+             echo Start-Stop Success!
              echo " "
          else
-             echo Failed!
+             echo Start-Stop Failed!
              echo " "
              set startstop_pass = false
          endif
@@ -601,10 +602,10 @@ foreach chk ( $chk_file_names )
 # compare NetCDF-4 checkpoint files
 # 	 ${NCCMP} $file1 $file2
 # 	 if( status == 0 ) then
-# 	     echo Success!
+# 	     echo Start-Stop Success!
 # 	     echo " "
 # 	 else
-# 	     echo Failed!
+# 	     echo Start-Stop Failed!
 # 	     echo " "
 # 	     set startstop_pass = false
 # 	 endif
@@ -622,10 +623,10 @@ end
 @MOM6         echo Comparing "MOM6 restarts"
 @MOM6         cmp $file1 $file2
 @MOM6         if( $status == 0 ) then
-@MOM6             echo Success!
+@MOM6             echo Start-Stop Success!
 @MOM6             echo " "
 @MOM6         else
-@MOM6             echo Failed!
+@MOM6             echo Start-Stop Failed!
 @MOM6             echo " "
 @MOM6             set pass = false
 @MOM6         endif
@@ -646,10 +647,10 @@ foreach hist ( $complete_hist_file_names )
 # compare history files
          ${NCCMP} $file1 $file2
          if( $status == 0 ) then
-             echo Success!
+             echo Start-Stop Success!
              echo " "
          else
-             echo Failed!
+             echo Start-Stop Failed!
              echo " "
              set startstop_pass = false
          endif
@@ -693,10 +694,10 @@ foreach chk ( $chk_file_names )
 # compare binary checkpoint files
          cmp $file1 $file2
          if( $status == 0 ) then
-             echo Success!
+             echo Layout Success!
              echo " "
          else
-             echo Failed!
+             echo Layout Failed!
              echo " "
              set layout_pass = false
          endif
@@ -704,10 +705,10 @@ foreach chk ( $chk_file_names )
 # compare NetCDF-4 checkpoint files
 # 	 ${NCCMP} $file1 $file2
 # 	 if( status == 0 ) then
-# 	     echo Success!
+# 	     echo Layout Success!
 # 	     echo " "
 # 	 else
-# 	     echo Failed!
+# 	     echo Layout Failed!
 # 	     echo " "
 # 	     set layout_pass = false
 # 	 endif
@@ -725,10 +726,10 @@ end
 @MOM6         echo Comparing "MOM6 restarts"
 @MOM6         cmp $file1 $file2
 @MOM6         if( $status == 0 ) then
-@MOM6             echo Success!
+@MOM6             echo Layout Success!
 @MOM6             echo " "
 @MOM6         else
-@MOM6             echo Failed!
+@MOM6             echo Layout Failed!
 @MOM6             echo " "
 @MOM6             set pass = false
 @MOM6         endif
@@ -749,10 +750,10 @@ foreach hist ( $complete_hist_file_names )
 # compare history files
          ${NCCMP} $file1 $file2
          if( $status == 0 ) then
-             echo Success!
+             echo Layout Success!
              echo " "
          else
-             echo Failed!
+             echo Layout Failed!
              echo " "
              set layout_pass = false
          endif

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -32,9 +32,9 @@ setenv OMP_NUM_THREADS 1
 
 setenv ARCH `uname`
 
-setenv SITE             @SITE
-setenv GEOSDIR          @GEOSDIR
-setenv GEOSBIN          @GEOSBIN
+setenv SITE    @SITE
+setenv GEOSDIR @GEOSDIR
+setenv GEOSBIN @GEOSBIN
 
 source $GEOSBIN/g5_modules
 setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib:${GEOSDIR}/lib
@@ -45,17 +45,17 @@ setenv RUN_CMD "$GEOSBIN/esma_mpirun -np "
 #             Experiment Specific Environment Variables
 #######################################################################
 
-setenv    EXPID   @EXPID
-setenv    EXPDIR  @EXPDIR
-setenv    HOMDIR  @HOMDIR
-setenv    SCRDIR  $EXPDIR/scratch
+setenv EXPID  @EXPID
+setenv EXPDIR @EXPDIR
+setenv HOMDIR @HOMDIR
+setenv SCRDIR $EXPDIR/scratch
 
 #######################################################################
 #                 Create Clean Regress Sub-Directory
 #######################################################################
 
-mkdir -p                    $EXPDIR/regress
-cd                          $EXPDIR/regress
+mkdir -p $EXPDIR/regress
+cd $EXPDIR/regress
 /bin/rm -rf `/bin/ls | grep -v  gcm_regress.j | grep -v slurm`
 
 # Copy RC Files from Home Directory
@@ -63,8 +63,8 @@ cd                          $EXPDIR/regress
 cd $HOMDIR
     set files = `ls -1 *.rc`
     foreach file ($files)
-            set fname = `echo $file | cut -d "." -f1`
-           cp $fname.rc $EXPDIR/regress
+      set fname = `echo $file | cut -d "." -f1`
+      cp $fname.rc $EXPDIR/regress
     end
 cd $EXPDIR/regress
 
@@ -166,11 +166,23 @@ COLLECTIONS: test_collection
   test_collection.format:           'CFIO' ,
   test_collection.deflate:           1 ,
   test_collection.frequency:         060000 ,
-  test_collection.fields:           'PHIS', 'AGCM' ,
-                                    'SLP' , 'DYN'  ,
-                                    'T'   , 'DYN'  ,
-                                    'U;V' , 'DYN'  ,
-                                    'Q'   , 'MOIST', 'QV',
+@DATAOCEAN  test_collection.fields:           'PHIS', 'AGCM' ,
+@DATAOCEAN                                    'SLP' , 'DYN'  ,
+@DATAOCEAN                                    'T'   , 'DYN'  ,
+@DATAOCEAN                                    'U;V' , 'DYN'  ,
+@DATAOCEAN                                    'Q'   , 'MOIST', 'QV',
+@MOM5  test_collection.fields:           'UW'   ,'MOM'  , 'US',
+@MOM5                                    'VW'   ,'MOM'  , 'VS',
+@MOM5                                    'TW'   ,'MOM'  , 'TS',
+@MOM5                                    'SW'   ,'MOM'  , 'SS',
+@MOM5                                    'SLV'  ,'MOM'  ,
+@MOM5                                    'QFLUX','OCEAN' ,
+@MOM6  test_collection.fields:           'UW'   ,'MOM6'  , 'US',
+@MOM6                                    'VW'   ,'MOM6'  , 'VS',
+@MOM6                                    'TW'   ,'MOM6'  , 'TS',
+@MOM6                                    'SW'   ,'MOM6'  , 'SS',
+@MOM6                                    'SLV'  ,'MOM6'  ,
+@MOM6                                    'QFLUX','OCEAN' ,
   ::
 _EOF_
 
@@ -225,9 +237,9 @@ if( @EMISSIONS == AMIP_EMISSIONS ) then
        set AMIP_Transition_Date = 20000301
 
        if( $nymd0 < ${AMIP_Transition_Date} ) then
-            set AMIP_EMISSIONS_DIRECTORY = $EXPDIR/RC/AMIP.20C
+         set AMIP_EMISSIONS_DIRECTORY = $EXPDIR/RC/AMIP.20C
        else
-            set AMIP_EMISSIONS_DIRECTORY = $EXPDIR/RC/AMIP
+         set AMIP_EMISSIONS_DIRECTORY = $EXPDIR/RC/AMIP
        endif
     else
        set AMIP_EMISSIONS_DIRECTORY = $EXPDIR/RC/AMIP
@@ -321,16 +333,16 @@ endif
 
 set test_duration = 240000
 
-cp     CAP.rc      CAP.rc.orig
-cp    AGCM.rc     AGCM.rc.orig
+cp CAP.rc      CAP.rc.orig
+cp AGCM.rc     AGCM.rc.orig
 cp HISTORY.rc0 HISTORY.rc
 
-set           NX0 = `grep "^ *NX:" AGCM.rc.orig | cut -d':' -f2`
-set           NY0 = `grep "^ *NY:" AGCM.rc.orig | cut -d':' -f2`
+set NX0 = `grep "^ *NX:" AGCM.rc.orig | cut -d':' -f2`
+set NY0 = `grep "^ *NY:" AGCM.rc.orig | cut -d':' -f2`
 
 ./strip CAP.rc
-set oldstring =  `cat CAP.rc | grep JOB_SGMT:`
-set newstring =  "JOB_SGMT: 00000000 ${test_duration}"
+set oldstring = `cat CAP.rc | grep JOB_SGMT:`
+set newstring = "JOB_SGMT: 00000000 ${test_duration}"
 /bin/mv CAP.rc CAP.tmp
 cat CAP.tmp | sed -e "s?$oldstring?$newstring?g" > CAP.rc
 
@@ -346,18 +358,18 @@ set date = `cat cap_restart`
 set nymde1 = $date[1]
 set nhmse1 = $date[2]
 
-foreach   chk ( $chk_file_names )
- /bin/mv -v $chk  ${chk}.${nymde1}_${nhmse1}.1
+foreach chk ( $chk_file_names )
+ /bin/mv -v $chk ${chk}.${nymde1}_${nhmse1}.1
 end
-@MOM6/bin/mv RESTART/MOM.res.nc MOM.res.nc.1
+@MOM6/bin/mv -v RESTART/MOM.res.nc MOM.res.nc.1
 
 # Move history as well
 set hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
 # Need also make another variable storing all the history files
 set complete_hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
 
-foreach   hist ( $hist_file_names )
- /bin/mv -v $hist  ${hist}.${nymde1}_${nhmse1}.1
+foreach hist ( $hist_file_names )
+ /bin/mv -v $hist ${hist}.${nymde1}_${nhmse1}.1
 end
 
 ##################################################################
@@ -372,13 +384,17 @@ set test_duration = 060000
 /bin/rm              cap_restart
 echo $nymd0 $nhms0 > cap_restart
 
-cp     CAP.rc.orig  CAP.rc
-cp    AGCM.rc.orig AGCM.rc
+cp CAP.rc.orig  CAP.rc
+cp AGCM.rc.orig AGCM.rc
 cp HISTORY.rc0  HISTORY.rc
 
+@COUPLED /bin/rm -rf INPUT
+@COUPLED /bin/mkdir INPUT
+@COUPLED cp $EXPDIR/RESTART/* INPUT
+
 ./strip CAP.rc
-set oldstring =  `cat CAP.rc | grep JOB_SGMT:`
-set newstring =  "JOB_SGMT: 00000000 ${test_duration}"
+set oldstring = `cat CAP.rc | grep JOB_SGMT:`
+set newstring = "JOB_SGMT: 00000000 ${test_duration}"
 /bin/mv CAP.rc CAP.tmp
 cat CAP.tmp | sed -e "s?$oldstring?$newstring?g" > CAP.rc
 
@@ -396,20 +412,23 @@ set date = `cat cap_restart`
 set nymde2 = $date[1]
 set nhmse2 = $date[2]
 
-foreach   chk ( $chk_file_names )
- /bin/cp -v $chk  ${chk}.${nymde2}_${nhmse2}.2
+foreach chk ( $chk_file_names )
+ /bin/cp -v $chk ${chk}.${nymde2}_${nhmse2}.2
 end
-@MOM6/bin/mv RESTART/MOM.res.nc MOM.res.nc.2
+@MOM6/bin/cp -v RESTART/MOM.res.nc MOM.res.nc.2
 
-# Move history as well
+# *Copy* history as well
 set hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
 
-foreach   hist ( $hist_file_names )
- /bin/mv -v $hist  ${hist}.${nymde2}_${nhmse2}.2
+# Note: We copy the history here because this lets the file(s)
+#       be available for Test #3 so a full compare can be made
+#       with Test #1
+foreach hist ( $hist_file_names )
+ /bin/cp -v $hist ${hist}.${nymde2}_${nhmse2}.2
 end
 
 foreach rst ( $rst_file_names )
-  /bin/rm -f  $rst
+  /bin/rm -f $rst
 end
 set numrst = `echo $rst_files | wc -w`
 set numchk = `echo $chk_files | wc -w`
@@ -447,9 +466,14 @@ set test_duration = 180000
 
 cp HISTORY.rc0 HISTORY.rc
 
+@MOM6# When you restart in MOM6 mode, you must change input_filename
+@MOM6# in the input.nml file from 'n' to 'r'
+@MOM6 /bin/cp input.nml input.nml.orig
+@MOM6 sed -i -e "s/input_filename = 'n'/input_filename = 'r'/g" input.nml
+
 ./strip CAP.rc
-set oldstring =  `cat CAP.rc | grep JOB_SGMT:`
-set newstring =  "JOB_SGMT: 00000000 ${test_duration}"
+set oldstring = `cat CAP.rc | grep JOB_SGMT:`
+set newstring = "JOB_SGMT: 00000000 ${test_duration}"
 /bin/mv CAP.rc CAP.tmp
 cat CAP.tmp | sed -e "s?$oldstring?$newstring?g" > CAP.rc
 
@@ -471,16 +495,16 @@ set date = `cat cap_restart`
 set nymde3 = $date[1]
 set nhmse3 = $date[2]
 
-foreach   chk ( $chk_file_names )
- /bin/mv -v $chk  ${chk}.${nymde3}_${nhmse3}.3
+foreach chk ( $chk_file_names )
+ /bin/mv -v $chk ${chk}.${nymde3}_${nhmse3}.3
 end
-@MOM6/bin/mv RESTART/MOM.res.nc MOM.res.nc.3
+@MOM6/bin/mv -v RESTART/MOM.res.nc MOM.res.nc.3
 
 # Move history as well
 set hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
 
-foreach   hist ( $hist_file_names )
- /bin/mv -v $hist  ${hist}.${nymde3}_${nhmse3}.3
+foreach hist ( $hist_file_names )
+ /bin/mv -v $hist ${hist}.${nymde3}_${nhmse3}.3
 end
 
 ##################################################################
@@ -498,43 +522,50 @@ set test_NY = 6
 # Copy Original Restarts to Regress directory
 # -------------------------------------------
 foreach rst ( $rst_file_names )
-  /bin/rm -f  $rst
+  /bin/rm -f $rst
   cp $EXPDIR/$rst $EXPDIR/regress
 end
+
+@COUPLED /bin/rm -rf INPUT
+@COUPLED /bin/mkdir INPUT
+@COUPLED cp $EXPDIR/RESTART/* INPUT
+
+@COUPLED # restore original input.nml
+@COUPLED /bin/mv input.nml.orig input.nml
 
 /bin/rm              cap_restart
 echo $nymd0 $nhms0 > cap_restart
 
-cp     CAP.rc.orig  CAP.rc
-cp    AGCM.rc.orig AGCM.rc
+cp CAP.rc.orig  CAP.rc
+cp AGCM.rc.orig AGCM.rc
 cp HISTORY.rc0  HISTORY.rc
 
 ./strip CAP.rc
-set oldstring =  `cat CAP.rc | grep JOB_SGMT:`
-set newstring =  "JOB_SGMT: 00000000 ${test_duration}"
+set oldstring = `cat CAP.rc | grep JOB_SGMT:`
+set newstring = "JOB_SGMT: 00000000 ${test_duration}"
 /bin/mv CAP.rc CAP.tmp
 cat CAP.tmp | sed -e "s?$oldstring?$newstring?g" > CAP.rc
 
 ./strip AGCM.rc
-set oldstring =  `cat AGCM.rc | grep "^ *NX:"`
-set newstring =  "NX: ${test_NX}"
+set oldstring = `cat AGCM.rc | grep "^ *NX:"`
+set newstring = "NX: ${test_NX}"
 /bin/mv AGCM.rc AGCM.tmp
 cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
-set oldstring =  `cat AGCM.rc | grep "^ *NY:"`
-set newstring =  "NY: ${test_NY}"
+set oldstring = `cat AGCM.rc | grep "^ *NY:"`
+set newstring = "NY: ${test_NY}"
 /bin/mv AGCM.rc AGCM.tmp
 cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
-@COUPLED set oldstring =  `cat AGCM.rc | grep "^ *OGCM.NX:"`
-@COUPLED set newstring =  "OGCM.NX: ${test_NY}"
+@COUPLED set oldstring = `cat AGCM.rc | grep "^ *OGCM.NX:"`
+@COUPLED set newstring = "OGCM.NX: ${test_NY}"
 @COUPLED /bin/mv AGCM.rc AGCM.tmp
 @COUPLED cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
-@COUPLED set oldstring =  `cat AGCM.rc | grep "^ *OGCM.NY:"`
-@COUPLED set newstring =  "OGCM.NY: ${test_NX}"
+@COUPLED set oldstring = `cat AGCM.rc | grep "^ *OGCM.NY:"`
+@COUPLED set newstring = "OGCM.NY: ${test_NX}"
 @COUPLED /bin/mv AGCM.rc AGCM.tmp
 @COUPLED cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
 
 @MOM5sed -r -i -e "/^ *layout/ s#= ([0-9]+),*([0-9]+)#= ${test_NY},${test_NX}#" input.nml
-@MOM6sed -r -i -e "/^ *LAYOUT/ s#= ([0-9]+), *([0-9]+)#= ${test_NY}, ${test_NX}#" MOM_input
+@MOM6sed -r -i -e "s/#override LAYOUT = 3, 2/#override LAYOUT = ${test_NY}, ${test_NX}/g" MOM_override
 
 setenv YEAR `cat cap_restart | cut -c1-4`
 ./linkbcs
@@ -550,16 +581,16 @@ set date = `cat cap_restart`
 set nymde4 = $date[1]
 set nhmse4 = $date[2]
 
-foreach   chk ( $chk_file_names )
- /bin/mv -v $chk  ${chk}.${nymde4}_${nhmse4}.4
+foreach chk ( $chk_file_names )
+ /bin/mv -v $chk ${chk}.${nymde4}_${nhmse4}.4
 end
-@MOM6/bin/mv RESTART/MOM.res.nc MOM.res.nc.4
+@MOM6/bin/mv -v RESTART/MOM.res.nc MOM.res.nc.4
 
 # Move history as well
 set hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
 
-foreach   hist ( $hist_file_names )
- /bin/mv -v $hist  ${hist}.${nymde4}_${nhmse4}.4
+foreach hist ( $hist_file_names )
+ /bin/mv -v $hist ${hist}.${nymde4}_${nhmse4}.4
 end
 
 #######################################################################
@@ -581,11 +612,11 @@ foreach chk ( $chk_file_names )
   set file1 = ${chk}.${nymde1}_${nhmse1}.1
   set file2 = ${chk}.${nymde3}_${nhmse3}.3
   if( -e $file1 && -e $file2 ) then
-                               set startstop_check = true
+      set check = true
       foreach exempt (${EXEMPT_chk})
-         if( $chk == $exempt ) set startstop_check = false
+         if( $chk == $exempt ) set check = false
       end
-      if( $startstop_check == true ) then
+      if( $check == true ) then
          echo Comparing ${chk}
 
 # compare binary checkpoint files
@@ -618,7 +649,7 @@ end
 @MOM6set file1 = MOM.res.nc.1
 @MOM6set file2 = MOM.res.nc.3
 @MOM6if( -e $file1 && -e $file2 ) then
-@MOM6                             set check = true
+@MOM6      set check = true
 @MOM6      if( $check == true ) then
 @MOM6         echo Comparing "MOM6 restarts"
 @MOM6         cmp $file1 $file2
@@ -640,8 +671,8 @@ foreach hist ( $complete_hist_file_names )
   set file1 = ${hist}.${nymde1}_${nhmse1}.1
   set file2 = ${hist}.${nymde3}_${nhmse3}.3
   if( -e $file1 && -e $file2 ) then
-                               set startstop_check = true
-      if( $startstop_check == true ) then
+      set check = true
+      if( $check == true ) then
          echo Comparing ${hist}
 
 # compare history files
@@ -660,9 +691,9 @@ foreach hist ( $complete_hist_file_names )
 end
 
 if( $startstop_pass == true ) then
-     echo "<font color=green> PASS </font>"                > startstop_regress_test
+   echo "<font color=green> PASS </font>"                > startstop_regress_test
 else
-     echo "<font color=red> <blink> FAIL </blink> </font>" > startstop_regress_test
+   echo "<font color=red> <blink> FAIL </blink> </font>" > startstop_regress_test
 endif
 
 #######################################################################
@@ -684,11 +715,11 @@ foreach chk ( $chk_file_names )
   set file1 = ${chk}.${nymde2}_${nhmse2}.2
   set file2 = ${chk}.${nymde4}_${nhmse4}.4
   if( -e $file1 && -e $file2 ) then
-                               set layout_check = true
+      set check = true
       foreach exempt (${EXEMPT_chk})
-         if( $chk == $exempt ) set layout_check = false
+         if( $chk == $exempt ) set check = false
       end
-      if( $layout_check == true ) then
+      if( $check == true ) then
          echo Comparing ${chk}
 
 # compare binary checkpoint files
@@ -721,7 +752,7 @@ end
 @MOM6set file1 = MOM.res.nc.2
 @MOM6set file2 = MOM.res.nc.4
 @MOM6if( -e $file1 && -e $file2 ) then
-@MOM6                             set check = true
+@MOM6      set check = true
 @MOM6      if( $check == true ) then
 @MOM6         echo Comparing "MOM6 restarts"
 @MOM6         cmp $file1 $file2
@@ -743,8 +774,8 @@ foreach hist ( $complete_hist_file_names )
   set file1 = ${hist}.${nymde2}_${nhmse4}.2
   set file2 = ${hist}.${nymde2}_${nhmse4}.4
   if( -e $file1 && -e $file2 ) then
-                               set layout_check = true
-      if( $layout_check == true ) then
+      set check = true
+      if( $check == true ) then
          echo Comparing ${hist}
 
 # compare history files
@@ -763,7 +794,13 @@ foreach hist ( $complete_hist_file_names )
 end
 
 if( $layout_pass == true ) then
-     echo "<font color=green> PASS </font>"                > layout_regress_test
+   echo "<font color=green> PASS </font>"                > layout_regress_test
 else
-     echo "<font color=red> <blink> FAIL </blink> </font>" > layout_regress_test
+   echo "<font color=red> <blink> FAIL </blink> </font>" > layout_regress_test
+endif
+
+if( $startstop_pass == true && $layout_pass == true ) then
+   echo "<font color=green> PASS </font>"                > regress_test
+else
+   echo "<font color=red> <blink> FAIL </blink> </font>" > regress_test
 endif

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -337,23 +337,28 @@ cat CAP.tmp | sed -e "s?$oldstring?$newstring?g" > CAP.rc
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
+
+echo "=== Running 24 hour test with NX = $NX and NY = $NY starting at $nymd0 $nhms0 ==="
+ 
 @OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
 
 
 set date = `cat cap_restart`
-set nymde = $date[1]
-set nhmse = $date[2]
+set nymde1 = $date[1]
+set nhmse1 = $date[2]
 
 foreach   chk ( $chk_file_names )
- /bin/mv $chk  ${chk}.${nymde}_${nhmse}.1
+ /bin/mv -v $chk  ${chk}.${nymde1}_${nhmse1}.1
 end
 @MOM6/bin/mv RESTART/MOM.res.nc MOM.res.nc.1
 
 # Move history as well
 set hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
+# Need also make another variable storing all the history files
+set complete_hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
 
 foreach   hist ( $hist_file_names )
- /bin/mv $hist  ${hist}.${nymde}_${nhmse}.1
+ /bin/mv -v $hist  ${hist}.${nymde1}_${nhmse1}.1
 end
 
 ##################################################################
@@ -383,7 +388,26 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
+
+echo "=== Running 6 hour test with NX = $NX and NY = $NY starting at $nymd0 $nhms0 ==="
+
 @OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
+
+set date = `cat cap_restart`
+set nymde2 = $date[1]
+set nhmse2 = $date[2]
+
+foreach   chk ( $chk_file_names )
+ /bin/cp -v $chk  ${chk}.${nymde2}_${nhmse2}.2
+end
+@MOM6/bin/mv RESTART/MOM.res.nc MOM.res.nc.2
+
+# Move history as well
+set hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
+
+foreach   hist ( $hist_file_names )
+ /bin/mv -v $hist  ${hist}.${nymde2}_${nhmse2}.2
+end
 
 foreach rst ( $rst_file_names )
   /bin/rm -f  $rst
@@ -411,18 +435,6 @@ while ( $n <= $numchk )
 @ n = $n + 1
 end
 
-foreach   chk ( $chk_file_names )
- /bin/mv $chk  ${chk}.${nymde}_${nhmse}.2
-end
-@MOM6/bin/mv RESTART/MOM.res.nc MOM.res.nc.2
-
-# Move history as well
-set hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
-
-foreach   hist ( $hist_file_names )
- /bin/mv $hist  ${hist}.${nymde}_${nhmse}.2
-end
-
 @COUPLED cp RESTART/* INPUT
 
 ##################################################################
@@ -433,6 +445,8 @@ end
 ##################################################################
 
 set test_duration = 180000
+
+cp HISTORY.rc0 HISTORY.rc
 
 ./strip CAP.rc
 set oldstring =  `cat CAP.rc | grep JOB_SGMT:`
@@ -445,20 +459,29 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
+
+set date = `cat cap_restart`
+set nymdb = $date[1]
+set nhmsb = $date[2]
+
+echo "=== Running 18 hour test with NX = $NX and NY = $NY starting at $nymdb $nhmsb ==="
+
 @OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
 
 set date = `cat cap_restart`
-set nymde = $date[1]
-set nhmse = $date[2]
+set nymde3 = $date[1]
+set nhmse3 = $date[2]
 
 foreach   chk ( $chk_file_names )
- /bin/mv $chk  ${chk}.${nymde}_${nhmse}.3
+ /bin/mv -v $chk  ${chk}.${nymde3}_${nhmse3}.3
 end
 @MOM6/bin/mv RESTART/MOM.res.nc MOM.res.nc.3
 
 # Move history as well
+set hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
+
 foreach   hist ( $hist_file_names )
- /bin/mv $hist  ${hist}.${nymde}_${nhmse}.3
+ /bin/mv -v $hist  ${hist}.${nymde3}_${nhmse3}.3
 end
 
 ##################################################################
@@ -472,6 +495,12 @@ set test_duration = 060000
 
 set test_NX = 1
 set test_NY = 6
+
+# Copy Original Restarts to Regress directory
+# -------------------------------------------
+foreach rst ( $rst_file_names )
+       cp $EXPDIR/$rst $EXPDIR/regress
+end
 
 /bin/rm              cap_restart
 echo $nymd0 $nhms0 > cap_restart
@@ -512,20 +541,25 @@ setenv YEAR `cat cap_restart | cut -c1-4`
 set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
 set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 @ NPES = $NX * $NY
+
+echo "=== Running 6 hour test with NX = $test_NX and NY = $test_NY starting at $nymd0 $nhms0 ==="
+
 @OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
 
 set date = `cat cap_restart`
-set nymde = $date[1]
-set nhmse = $date[2]
+set nymde4 = $date[1]
+set nhmse4 = $date[2]
 
 foreach   chk ( $chk_file_names )
- /bin/mv $chk  ${chk}.${nymde}_${nhmse}.4
+ /bin/mv -v $chk  ${chk}.${nymde4}_${nhmse4}.4
 end
 @MOM6/bin/mv RESTART/MOM.res.nc MOM.res.nc.4
 
 # Move history as well
+set hist_file_names = `ls -1 ${EXPID}.test_collection.*.nc4`
+
 foreach   hist ( $hist_file_names )
- /bin/mv $hist  ${hist}.${nymde}_${nhmse}.4
+ /bin/mv -v $hist  ${hist}.${nymde4}_${nhmse4}.4
 end
 
 #######################################################################
@@ -536,20 +570,21 @@ end
 # This part compares the restarts from the 24-hour NXxNY run (.1) with the
 # restarts at the end of the 6-hour + 18-hour runs (.3)
 
-set NCCMP = `echo ${BASEDIR}/${ARCH}/bin/nccmp -dmfgsB `
+set NCCMP = `echo ${BASEDIR}/${ARCH}/bin/nccmp -dmfgBq `
 
 if( -e startstop_regress_test ) /bin/rm startstop_regress_test
 
-set pass = true
+echo "=== Comparing restarts from 24-hour ${NX0}x${NY0} run with restarts from 6-hour + 18-hour ${NX0}x${NY0} runs ==="
+set startstop_pass = true
 foreach chk ( $chk_file_names )
-  set file1 = ${chk}.${nymde}_${nhmse}.1
-  set file2 = ${chk}.${nymde}_${nhmse}.3
+  set file1 = ${chk}.${nymde1}_${nhmse1}.1
+  set file2 = ${chk}.${nymde3}_${nhmse3}.3
   if( -e $file1 && -e $file2 ) then
-                               set check = true
+                               set startstop_check = true
       foreach exempt (${EXEMPT_chk})
-         if( $chk == $exempt ) set check = false
+         if( $chk == $exempt ) set startstop_check = false
       end
-      if( $check == true ) then
+      if( $startstop_check == true ) then
          echo Comparing ${chk}
 
 # compare binary checkpoint files
@@ -560,7 +595,7 @@ foreach chk ( $chk_file_names )
          else
              echo Failed!
              echo " "
-             set pass = false
+             set startstop_pass = false
          endif
 
 # compare NetCDF-4 checkpoint files
@@ -571,7 +606,7 @@ foreach chk ( $chk_file_names )
 # 	 else
 # 	     echo Failed!
 # 	     echo " "
-# 	     set pass = false
+# 	     set startstop_pass = false
 # 	 endif
 
       endif
@@ -597,14 +632,15 @@ end
 @MOM6      endif
 @MOM6endif
 
+echo "=== Comparing history files from 24-hour ${NX0}x${NY0} run with history files from 6-hour + 18-hour ${NX0}x${NY0} runs ==="
 
 # Check history files
-foreach hist ( $hist_file_names )
-  set file1 = ${hist}.${nymde}_${nhmse}.1
-  set file2 = ${hist}.${nymde}_${nhmse}.3
+foreach hist ( $complete_hist_file_names )
+  set file1 = ${hist}.${nymde1}_${nhmse1}.1
+  set file2 = ${hist}.${nymde3}_${nhmse3}.3
   if( -e $file1 && -e $file2 ) then
-                               set check = true
-      if( $check == true ) then
+                               set startstop_check = true
+      if( $startstop_check == true ) then
          echo Comparing ${hist}
 
 # compare history files
@@ -615,14 +651,14 @@ foreach hist ( $hist_file_names )
          else
              echo Failed!
              echo " "
-             set pass = false
+             set startstop_pass = false
          endif
 
       endif
   endif
 end
 
-if( $pass == true ) then
+if( $startstop_pass == true ) then
      echo "<font color=green> PASS </font>"                > startstop_regress_test
 else
      echo "<font color=red> <blink> FAIL </blink> </font>" > startstop_regress_test
@@ -636,20 +672,22 @@ endif
 # This part compares the restarts from the 6-hour NXxNY run (.2) with the
 # restarts from the 6-hour 1x6 run (.4)
 
-set NCCMP = `echo ${BASEDIR}/${ARCH}/bin/nccmp -dmfgsB `
+set NCCMP = `echo ${BASEDIR}/${ARCH}/bin/nccmp -dmfgBq `
 
 if( -e layout_regress_test ) /bin/rm layout_regress_test
 
-set pass = true
+echo "=== Comparing restarts from 6-hour ${NX0}x${NY0} run with restarts from 6-hour ${test_NX}x${test_NY} run ==="
+
+set layout_pass = true
 foreach chk ( $chk_file_names )
-  set file1 = ${chk}.${nymde}_${nhmse}.2
-  set file2 = ${chk}.${nymde}_${nhmse}.4
+  set file1 = ${chk}.${nymde2}_${nhmse2}.2
+  set file2 = ${chk}.${nymde4}_${nhmse4}.4
   if( -e $file1 && -e $file2 ) then
-                               set check = true
+                               set layout_check = true
       foreach exempt (${EXEMPT_chk})
-         if( $chk == $exempt ) set check = false
+         if( $chk == $exempt ) set layout_check = false
       end
-      if( $check == true ) then
+      if( $layout_check == true ) then
          echo Comparing ${chk}
 
 # compare binary checkpoint files
@@ -660,7 +698,7 @@ foreach chk ( $chk_file_names )
          else
              echo Failed!
              echo " "
-             set pass = false
+             set layout_pass = false
          endif
 
 # compare NetCDF-4 checkpoint files
@@ -671,7 +709,7 @@ foreach chk ( $chk_file_names )
 # 	 else
 # 	     echo Failed!
 # 	     echo " "
-# 	     set pass = false
+# 	     set layout_pass = false
 # 	 endif
 
       endif
@@ -697,14 +735,15 @@ end
 @MOM6      endif
 @MOM6endif
 
+echo "=== Comparing history files from 6-hour ${NX0}x${NY0} run with history files from 6-hour ${test_NX}x${test_NY} run ==="
 
 # Check history files
-foreach hist ( $hist_file_names )
-  set file1 = ${hist}.${nymde}_${nhmse}.2
-  set file2 = ${hist}.${nymde}_${nhmse}.4
+foreach hist ( $complete_hist_file_names )
+  set file1 = ${hist}.${nymde2}_${nhmse4}.2
+  set file2 = ${hist}.${nymde2}_${nhmse4}.4
   if( -e $file1 && -e $file2 ) then
-                               set check = true
-      if( $check == true ) then
+                               set layout_check = true
+      if( $layout_check == true ) then
          echo Comparing ${hist}
 
 # compare history files
@@ -715,14 +754,14 @@ foreach hist ( $hist_file_names )
          else
              echo Failed!
              echo " "
-             set pass = false
+             set layout_pass = false
          endif
 
       endif
   endif
 end
 
-if( $pass == true ) then
+if( $layout_pass == true ) then
      echo "<font color=green> PASS </font>"                > layout_regress_test
 else
      echo "<font color=red> <blink> FAIL </blink> </font>" > layout_regress_test


### PR DESCRIPTION
This PR changes up the `gcm_regress.j` script to now do:

1. Run 24 hours at NX x NY
2. Move back to orig restarts, run 6 hours at NX x NY
3. Run 18 hours at NX x NY
4. Move back to orig restarts, run 6 hours at 1 x 6

So, comparing the output of 1 and 3 look at start-stop regression and 2 and 4 look at layout regression.