### PR TITLE
Add PM fields to HISTORY

### DIFF
--- a/HISTORY.AGCM.rc.tmpl
+++ b/HISTORY.AGCM.rc.tmpl
@@ -838,6 +838,8 @@ PC@HIST_IMx@HIST_JM-DC.LM: @AGCM_LM
                                'TOTANGSTR'      , 'GOCART2G'  ,
                                'TOTSTEXTTAU'    , 'GOCART2G'  ,
                                'TOTSTSCATAU'    , 'GOCART2G'  ,
+                               'PM25'           , 'GOCART2G'  ,
+                               'PM'             , 'GOCART2G'  ,
                                'DUEM'           , 'DU'        , 'DUEM001;DUEM002;DUEM003;DUEM004;DUEM005' ,
                                'DUSD'           , 'DU'        , 'DUSD001;DUSD002;DUSD003;DUSD004;DUSD005' ,
                                'DUDP'           , 'DU'        , 'DUDP001;DUDP002;DUDP003;DUDP004;DUDP005' ,

--- a/HISTORY.rc.tmpl
+++ b/HISTORY.rc.tmpl
@@ -1455,6 +1455,8 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                   'TOTANGSTR'      , 'GOCART2G'  ,
                                   'TOTSTEXTTAU'    , 'GOCART2G'  ,
                                   'TOTSTSCATAU'    , 'GOCART2G'  ,
+                                  'PM25'           , 'GOCART2G'  ,
+                                  'PM'             , 'GOCART2G'  ,
                                    ::
 
   tavg3_2d_adg_Nx-.format:        'CFIO' ,
@@ -1606,6 +1608,9 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                   'SO2CMASS'    , 'SU'        ,
                                   'NISMASS'     , 'NI'        ,
                                   'NISMASS25'   , 'NI'        ,
+                                  'NH4SMASS'    , 'NI'        ,
+                                  'PM25'        , 'GOCART2G'  ,
+                                  'PM'          , 'GOCART2G'  ,
 # Fluxes
                                   'CA.bcFLUXU'  , 'CA.bc'     , 'BCFLUXU'  ,
                                   'CA.bcFLUXV'  , 'CA.bc'     , 'BCFLUXV'  ,
@@ -2640,6 +2645,9 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                   'SO2CMASS'     , 'SU'        ,
                                   'NISMASS'      , 'NI'        ,
                                   'NISMASS25'    , 'NI'        ,
+                                  'NH4SMASS'     , 'NI'        ,
+                                  'PM25'         , 'GOCART2G'  ,
+                                  'PM'           , 'GOCART2G'  ,
                                    ::
 
  #######################################################################

--- a/HISTORY_FP.rc.03z.tmpl
+++ b/HISTORY_FP.rc.03z.tmpl
@@ -1471,6 +1471,8 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                          'TOTANGSTR'      , 'GOCART2G'  ,
                                          'TOTSTEXTTAU'    , 'GOCART2G'  ,
                                          'TOTSTSCATAU'    , 'GOCART2G'  ,
+                                         'PM25'           , 'GOCART2G'  ,
+                                         'PM'             , 'GOCART2G'  ,
                                           ::
 
   tavg3_2d_adg_Nx-.format:               'CFIO' ,
@@ -1644,6 +1646,9 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                          'SO2CMASS'     , 'SU'        ,
                                          'NISMASS'      , 'NI'        ,
                                          'NISMASS25'    , 'NI'        ,
+                                         'NH4SMASS'     , 'NI'        ,
+                                         'PM25'         , 'GOCART2G'  ,
+                                         'PM'           , 'GOCART2G'  ,
 # Fluxes
                                          'CA.bcFLUXU'   , 'CA.bc'     , 'BCFLUXU'     ,
                                          'CA.bcFLUXV'   , 'CA.bc'     , 'BCFLUXV'     ,

--- a/HISTORY_FP.rc.09z.tmpl
+++ b/HISTORY_FP.rc.09z.tmpl
@@ -1508,6 +1508,8 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                          'TOTANGSTR'      , 'GOCART2G'  ,
                                          'TOTSTEXTTAU'    , 'GOCART2G'  ,
                                          'TOTSTSCATAU'    , 'GOCART2G'  ,
+                                         'PM25'           , 'GOCART2G'  ,
+                                         'PM'             , 'GOCART2G'  ,
                                           ::
 
   tavg3_2d_adg_Nx-.format:               'CFIO' ,
@@ -1681,6 +1683,9 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                          'SO2CMASS'     , 'SU'        ,
                                          'NISMASS'      , 'NI'        ,
                                          'NISMASS25'    , 'NI'        ,
+                                         'NH4SMASS'     , 'NI'        ,
+                                         'PM25'         , 'GOCART2G'  ,
+                                         'PM'           , 'GOCART2G'  ,
 # Fluxes
                                          'CA.bcFLUXU'   , 'CA.bc'     , 'BCFLUXU'     ,
                                          'CA.bcFLUXV'   , 'CA.bc'     , 'BCFLUXV'     ,

--- a/HISTORY_FP.rc.15z.tmpl
+++ b/HISTORY_FP.rc.15z.tmpl
@@ -1471,6 +1471,8 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                          'TOTANGSTR'      , 'GOCART2G'  ,
                                          'TOTSTEXTTAU'    , 'GOCART2G'  ,
                                          'TOTSTSCATAU'    , 'GOCART2G'  ,
+                                         'PM25'           , 'GOCART2G'  ,
+                                         'PM'             , 'GOCART2G'  ,
                                           ::
 
   tavg3_2d_adg_Nx-.format:               'CFIO' ,
@@ -1644,6 +1646,9 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                          'SO2CMASS'     , 'SU'        ,
                                          'NISMASS'      , 'NI'        ,
                                          'NISMASS25'    , 'NI'        ,
+                                         'NH4SMASS'     , 'NI'        ,
+                                         'PM25'         , 'GOCART2G'  ,
+                                         'PM'           , 'GOCART2G'  ,
 # Fluxes
                                          'CA.bcFLUXU'   , 'CA.bc'     , 'BCFLUXU'     ,
                                          'CA.bcFLUXV'   , 'CA.bc'     , 'BCFLUXV'     ,

--- a/HISTORY_FP.rc.21z.tmpl
+++ b/HISTORY_FP.rc.21z.tmpl
@@ -1471,6 +1471,8 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                          'TOTANGSTR'      , 'GOCART2G'  ,
                                          'TOTSTEXTTAU'    , 'GOCART2G'  ,
                                          'TOTSTSCATAU'    , 'GOCART2G'  ,
+                                         'PM25'           , 'GOCART2G'  ,
+                                         'PM'             , 'GOCART2G'  ,
                                           ::
 
   tavg3_2d_adg_Nx-.format:               'CFIO' ,
@@ -1644,6 +1646,9 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                                          'SO2CMASS'     , 'SU'        ,
                                          'NISMASS'      , 'NI'        ,
                                          'NISMASS25'    , 'NI'        ,
+                                         'NH4SMASS'     , 'NI'        ,
+                                         'PM25'         , 'GOCART2G'  ,
+                                         'PM'           , 'GOCART2G'  ,
 # Fluxes
                                          'CA.bcFLUXU'   , 'CA.bc'     , 'BCFLUXU'     ,
                                          'CA.bcFLUXV'   , 'CA.bc'     , 'BCFLUXV'     ,


### PR DESCRIPTION
PM25 and PM diags were added to the inst2d_hwl and tavg3_aer collections and NH4SMASS was added to the inst2d_hwl collection in the HISTORY.rc files for FP, HISTORY.rc.tmpl, and HISTORY.AGCM.rc.tmpl.