### PR TITLE
Fix COUPLEDIR at NAS

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1697,7 +1697,7 @@ if( $SITE == 'NAS' ) then
               if ( "$OCNMODEL" == "MIT" ) then
                 setenv COUPLEDIR  /nobackupp2/estrobac/geos5/GRIDDIR                   # Coupled Ocean/Atmos Forcing
               else
-                setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/coupled/Forcings     # Coupled Ocean/Atmos Forcing
+                setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/aogcm                # Coupled Ocean/Atmos Forcing
               endif
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1727,7 +1727,7 @@ if( $SITE == 'NAS' ) then
               if ( "$OCNMODEL" == "MIT" ) then
                 setenv COUPLEDIR  /nobackupp2/estrobac/geos5/GRIDDIR                   # Coupled Ocean/Atmos Forcing
               else
-                setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/coupled/Forcings     # Coupled Ocean/Atmos Forcing
+                setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/aogcm                # Coupled Ocean/Atmos Forcing
               endif
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1888,7 +1888,7 @@ if( $SITE == 'NAS' ) then
               if ( "$OCNMODEL" == "MIT" ) then
                 setenv COUPLEDIR  /nobackupp2/estrobac/geos5/GRIDDIR                   # Coupled Ocean/Atmos Forcing
               else
-                setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/coupled/Forcings     # Coupled Ocean/Atmos Forcing
+                setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/aogcm                # Coupled Ocean/Atmos Forcing
               endif
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1712,7 +1712,7 @@ if( $SITE == 'NAS' ) then
               if ( "$OCNMODEL" == "MIT" ) then
                 setenv COUPLEDIR  /nobackupp2/estrobac/geos5/GRIDDIR                   # Coupled Ocean/Atmos Forcing
               else
-                setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/coupled/Forcings     # Coupled Ocean/Atmos Forcing
+                setenv COUPLEDIR  /nobackup/gmao_SIteam/ModelData/aogcm                # Coupled Ocean/Atmos Forcing
               endif
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command


### PR DESCRIPTION
With the whole TOSS4 transition at NAS, my nightly tests stopped running a while back. As such, I missed that we broke MOM6 at NAS. So, this PR fixes it by correcting a path.

NOTE: This is obviously zero-diff in the sense that it doesn't affect the AMIP runs and, well, without it, MOM6 can't even run at NAS!