### PR TITLE
Add gwd_internal_rst to gcm_regress.j

### DIFF
--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -161,9 +161,14 @@ end
 # Copy Restarts to Regress directory
 # ----------------------------------
 foreach rst ( $rst_file_names )
-       cp $EXPDIR/$rst $EXPDIR/regress
+   cp $EXPDIR/$rst $EXPDIR/regress
 end
 cp $EXPDIR/cap_restart $EXPDIR/regress
+
+# Get proper ridge scheme GWD internal restart
+# --------------------------------------------
+/bin/rm gwd_internal_rst
+/bin/cp @GWDRSDIR/gwd_internal_c${IM} gwd_internal_rst
 
 @COUPLED /bin/mkdir INPUT
 @COUPLED cp $EXPDIR/RESTART/* INPUT
@@ -634,6 +639,11 @@ if ( $RUN_LAYOUT == TRUE) then
       /bin/rm -f $rst
       cp $EXPDIR/$rst $EXPDIR/regress
    end
+
+   # Get proper ridge scheme GWD internal restart
+   # --------------------------------------------
+   /bin/rm gwd_internal_rst
+   /bin/cp @GWDRSDIR/gwd_internal_c${IM} gwd_internal_rst
 
    @COUPLED /bin/rm -rf INPUT
    @COUPLED /bin/mkdir INPUT


### PR DESCRIPTION
Testing of `gcm_regress.j` at 137-levels showed we need to include the `gwd_internal_rst` copies that are in `gcm_run.j` also in the regress script.

Keeping draft until I can see if this is all that's needed. 