### PR TITLE
Fixes for stretched grid

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1346,12 +1346,12 @@ endif
 
 if ($CONUS == '#') then
   set SCHMIDT     = "do_schmidt  = .false."
-  set FV_STRETCH_FAC = "stretch_fac = 1.0"
+  set STRETCH_FAC = "stretch_fac = 1.0"
   set TARGET_LON  = "target_lon  = 0.0"
   set TARGET_LAT  = "target_lat  = 0.0"
 else
   set SCHMIDT     = "do_schmidt  = .true."
-  set FV_STRETCH_FAC = "stretch_fac = $STRETCH_FACTOR"
+  set STRETCH_FAC = "stretch_fac = $STRETCH_FACTOR"
   set TARGET_LON  = "target_lon  = -98.35"
   set TARGET_LAT  = "target_lat  = 39.5"
 endif
@@ -2377,7 +2377,7 @@ s/@JOB_SGMT/${JOB_SGMT}/g
 s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
-s/@FV_STRETCH_FAC/${FV_STRETCH_FAC}/g
+s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g
 s/@HIST_IM/$HIST_IM/g

--- a/gcm_setup
+++ b/gcm_setup
@@ -1158,7 +1158,7 @@ if( $AGCM_IM == "c270" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF270x6C
+     set ATMOS_RES = CF0270x6C
      set   CNV_NX = 8
      set POST_NDS = 32
      set USE_SHMEM = 1
@@ -1182,7 +1182,7 @@ if( $AGCM_IM == "c540" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF540x6C
+     set ATMOS_RES = CF0540x6C
      set   CNV_NX = 8
      set POST_NDS = 32
      set USE_SHMEM = 1
@@ -1346,12 +1346,12 @@ endif
 
 if ($CONUS == '#') then
   set SCHMIDT     = "do_schmidt  = .false."
-  set STRETCH_FAC = "stretch_fac = 1.0"
+  set FV_STRETCH_FAC = "stretch_fac = 1.0"
   set TARGET_LON  = "target_lon  = 0.0"
   set TARGET_LAT  = "target_lat  = 0.0"
 else
   set SCHMIDT     = "do_schmidt  = .true."
-  set STRETCH_FAC = "stretch_fac = $STRETCH_FACTOR"
+  set FV_STRETCH_FAC = "stretch_fac = $STRETCH_FACTOR"
   set TARGET_LON  = "target_lon  = -98.35"
   set TARGET_LAT  = "target_lat  = 39.5"
 endif
@@ -2377,7 +2377,7 @@ s/@JOB_SGMT/${JOB_SGMT}/g
 s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
-s/@STRETCH_FAC/${STRETCH_FAC}/g
+s/@FV_STRETCH_FAC/${FV_STRETCH_FAC}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g
 s/@HIST_IM/$HIST_IM/g

--- a/gcm_setup
+++ b/gcm_setup
@@ -1141,6 +1141,7 @@ if( $AGCM_IM == "c5760" ) then
 endif
 # CONUS Stretched Grids
 set CONUS = '#'
+set STRETCH_FACTOR = ""
 if( $AGCM_IM == "c270" ) then
      set       DT = 600
      set SOLAR_DT = 3600

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1151,6 +1151,7 @@ if( $AGCM_IM == "c5760" ) then
 endif
 # CONUS Stretched Grids
 set CONUS = '#'
+set STRETCH_FACTOR = ""
 if( $AGCM_IM == "c270" ) then
      set       DT = 600
      set SOLAR_DT = 3600

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1169,7 +1169,7 @@ if( $AGCM_IM == "c270" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF270x6C
+     set ATMOS_RES = CF0270x6C
      set   CNV_NX = 8
      set POST_NDS = 32
      set USE_SHMEM = 1
@@ -2407,7 +2407,7 @@ s/@JOB_SGMT/${JOB_SGMT}/g
 s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
-s/@STRETCH_FAC/${STRETCH_FAC}/g
+s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 /SATSIM_DT/a GEOSCHEMCHEM_DT: $GEOSCHEMCHEM_DT
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1266,7 +1266,7 @@ if( $AGCM_IM == "c270" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF270x6C
+     set ATMOS_RES = CF0270x6C
      set   CNV_NX = 8
      set POST_NDS = 32
      set USE_SHMEM = 1
@@ -2575,7 +2575,7 @@ s/@JOB_SGMT/${JOB_SGMT}/g
 s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
-s/@STRETCH_FAC/${STRETCH_FAC}/g
+s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g
 s/@HIST_IM/$HIST_IM/g

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1248,6 +1248,7 @@ if( $AGCM_IM == "c5760" ) then
 endif
 # CONUS Stretched Grids
 set CONUS = '#'
+set STRETCH_FACTOR = ""
 if( $AGCM_IM == "c270" ) then
      set       DT = 600
      set SOLAR_DT = 3600

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1151,6 +1151,7 @@ if( $AGCM_IM == "c5760" ) then
 endif
 # CONUS Stretched Grids
 set CONUS = '#'
+set STRETCH_FACTOR = ""
 if( $AGCM_IM == "c270" ) then
      set       DT = 600
      set SOLAR_DT = 3600

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1169,7 +1169,7 @@ if( $AGCM_IM == "c270" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF270x6C
+     set ATMOS_RES = CF0270x6C
      set   CNV_NX = 8
      set POST_NDS = 32
      set USE_SHMEM = 1
@@ -2393,7 +2393,7 @@ s/@JOB_SGMT/${JOB_SGMT}/g
 s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
-s/@STRETCH_FAC/${STRETCH_FAC}/g
+s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g
 s/@HIST_IM/$HIST_IM/g


### PR DESCRIPTION
In talking with @christophkeller I realized I don't have a good test of even our lowest resolution stretched grid case, c270. So, in my testing, I found a couple of issues that need fixing.

1. Most of our BCs seem to assume we'd use a 4-digit resolution like `CF0720x6C`. But the low stretched cases had `CF270x6C` and not `CF0270x6C`. This sort of...broke some assumptions in my scripts. So we make it consistent.
2. It turns out the sed we have isn't perfect. The script has both `STRETCH_FACTOR` and `STRETCH_FAC`. For C270 these are `2.5` and `stretch_fac = 2.5`. But when sed did its thing, `AGCM.rc` ended up with:
  `AGCM.STRETCH_FACTOR: stretch_fac = 2.5TOR`
which MAPL was *NOT* happy with. So we fix that.