### PR TITLE
Update to new SCM file dir

### DIFF
--- a/scm_run.j
+++ b/scm_run.j
@@ -28,4 +28,4 @@ cd $EXPDIR
 
 $GEOSBIN/construct_extdata_yaml_list.py GEOS_ChemGridComp.rc
 
-$RUN_CMD 1 ./GEOSgcm.x
+$RUN_CMD 1 ./GEOSgcm.x --logging_config 'logging.yaml'

--- a/scm_setup
+++ b/scm_setup
@@ -385,6 +385,7 @@ SOURCEDIR=$SCMDIR/$selected_case
 mkdir -p $expdir
 
 /bin/cp $INSTALLDIR/bin/GEOSgcm.x $expdir
+/bin/cp $INSTALLDIR/etc/logging.yaml $expdir
 
 /bin/cp $SOURCEDIR/$DATFILE $expdir
 /bin/cp $SOURCEDIR/topo_dynave.data $expdir

--- a/scm_setup
+++ b/scm_setup
@@ -356,17 +356,17 @@ BCSTAG="Icarus_Reynolds"
 
 case $SITE in
    NCCS)
-   SCMDIR="/discover/swdev/gmao_SIteam/scm/scminfiles/git-v10.22/"
+   SCMDIR="/discover/swdev/gmao_SIteam/scm/scminfiles/git-v11.1/"
    BCSDIR="/discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs/Icarus/$BCSTAG"
    CHMDIR="/discover/nobackup/projects/gmao/share/gmao_ops/fvInput_nc3"
    ;;
    NAS)
-   SCMDIR="/nobackup/gmao_SIteam/ModelData/scminfiles/git-v10.22/"
+   SCMDIR="/nobackup/gmao_SIteam/ModelData/scminfiles/git-v11.1/"
    BCSDIR="/nobackup/gmao_SIteam/ModelData/bcs/Icarus/$BCSTAG"
    CHMDIR="/nobackup/gmao_SIteam/ModelData/fvInput_nc3"
    ;;
    GMAO*)
-   SCMDIR="/ford1/share/gmao_SIteam/ModelData/scminfiles/git-v10.22/"
+   SCMDIR="/ford1/share/gmao_SIteam/ModelData/scminfiles/git-v11.1/"
    BCSDIR="/ford1/share/gmao_SIteam/ModelData/bcs/Icarus/$BCSTAG"
    CHMDIR="/ford1/share/gmao_SIteam/ModelData/fvInput_nc3"
    ;;


### PR DESCRIPTION
The updates in v11 require fixes to sedfiles in the scminfiles. This PR brings them in.

NOTE: This PR in in combination with https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/725 The SCM will not run without that.

ETA: Per @narnold1, this only lets things work at L72. I have an idea on how to fix L137, but probably need the expertise of @bena-nasa to test. For now I'll keep this still mergable as it at least fixes part of the SCM.