### PR TITLE
Coupled ocean DT must be heartbeat (for now)

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -243,25 +243,26 @@ endif
 
 cd $SCRDIR
 /bin/rm -rf *
-                             cp -f  $EXPDIR/RC/* .
-                             cp     $EXPDIR/cap_restart .
-                             cp -f  $HOMDIR/*.rc .
-                             cp -f  $HOMDIR/*.nml .
-                             cp -f  $HOMDIR/*.yaml .
-                             cp     $GEOSBIN/bundleParser.py .
 
-                             cat fvcore_layout.rc >> input.nml
-                             if (-z input.nml) then
-                                 echo "try cat for input.nml again"
-                                 cat fvcore_layout.rc >> input.nml
-                             endif
-                             if (-z input.nml) then
-                                 echo "input.nml is zero-length"
-                                 exit 0
-                             endif
+cp -f  $EXPDIR/RC/* .
+cp     $EXPDIR/cap_restart .
+cp -f  $HOMDIR/*.rc .
+cp -f  $HOMDIR/*.nml .
+cp -f  $HOMDIR/*.yaml .
+cp     $GEOSBIN/bundleParser.py .
 
-                             @MOM6cp -f  $HOMDIR/MOM_input .
-                             @MOM6cp -f  $HOMDIR/MOM_override .
+cat fvcore_layout.rc >> input.nml
+if (-z input.nml) then
+   echo "try cat for input.nml again"
+   cat fvcore_layout.rc >> input.nml
+endif
+if (-z input.nml) then
+   echo "input.nml is zero-length"
+   exit 0
+endif
+
+@MOM6cp -f  $HOMDIR/MOM_input .
+@MOM6cp -f  $HOMDIR/MOM_override .
 
 if( $GCMEMIP == TRUE ) then
     cp -f  $EXPDIR/restarts/$RSTDATE/cap_restart .

--- a/gcm_setup
+++ b/gcm_setup
@@ -2696,8 +2696,8 @@ endif
 # and change MOM_override to match.
 
 if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
-   sed -i -e "s/DT: [0-9]*\.[0-9]*/DT: $OCEAN_DT/g" \
-          -e "s/DT_THERM: [0-9]*\.[0-9]*/DT_THERM: $OCEAN_DT/g" $HOMDIR/MOM_override
+   sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+          -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
 endif
 
 #######################################################################

--- a/gcm_setup
+++ b/gcm_setup
@@ -1262,7 +1262,7 @@ if( $AGCM_IM == "c2160" ) then
      set CONUS = ''
      set STRETCH_FACTOR = 2.5
 endif
-if( "$OCNMODEL" == "MIT" ) then
+if( "$OGCM" == "TRUE" ) then
      set OCEAN_DT = $DT
 endif
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -1530,7 +1530,7 @@ set DT = $HEARTBEAT
 
 # For now, in a coupled run, the ocean model must have the same time step as the atmosphere
 if( "$OGCM" == "TRUE" ) then
-     set OCEAN_DT = $HEARTBEAT
+   set OCEAN_DT = $HEARTBEAT
 endif
 
 #######################################################################
@@ -2691,13 +2691,23 @@ endif
 #              Modify MOM_override to match HEARTBEAT
 #######################################################################
 
-# We also must change the MOM_override file to
-# have consistent DTs with the AGCM. So we use OCEAN_DT
-# and change MOM_override to match.
+if( $OGCM == TRUE ) then
 
-if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
-   sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
-          -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
+   if ("$OCNMODEL" == "MOM6" ) then
+      # We also must change the MOM_override file to
+      # have consistent DTs with the AGCM. So we use OCEAN_DT
+      # and change MOM_override to match. NOTE: This sed
+      # assumes floating point number with a decimal
+
+      sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+             -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
+   else if ("$OCNMODEL" == "MOM5" ) then
+      # With MOM5 we need to change dt lines in input.nml to 
+      # use $OCEAN_DT instead. NOTE: This sed assumes integer followed by comma
+
+      sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
+             -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
+
 endif
 
 #######################################################################

--- a/gcm_setup
+++ b/gcm_setup
@@ -2708,6 +2708,8 @@ if( $OGCM == TRUE ) then
       sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
              -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
 
+   endif
+
 endif
 
 #######################################################################

--- a/gcm_setup
+++ b/gcm_setup
@@ -1262,9 +1262,6 @@ if( $AGCM_IM == "c2160" ) then
      set CONUS = ''
      set STRETCH_FACTOR = 2.5
 endif
-if( "$OGCM" == "TRUE" ) then
-     set OCEAN_DT = $DT
-endif
 
 set IS_FCST = 0
 set FVCUBED         = ""
@@ -1531,6 +1528,10 @@ endif
 
 set DT = $HEARTBEAT
 
+# For now, in a coupled run, the ocean model must have the same time step as the atmosphere
+if( "$OGCM" == "TRUE" ) then
+     set OCEAN_DT = $HEARTBEAT
+endif
 
 #######################################################################
 #                    Create Desired HISTORY template

--- a/gcm_setup
+++ b/gcm_setup
@@ -2688,6 +2688,19 @@ endif
 
 
 #######################################################################
+#              Modify MOM_override to match HEARTBEAT
+#######################################################################
+
+# We also must change the MOM_override file to
+# have consistent DTs with the AGCM. So we use OCEAN_DT
+# and change MOM_override to match.
+
+if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
+   sed -i -e "s/DT: [0-9]*\.[0-9]*/DT: $OCEAN_DT/g" \
+          -e "s/DT_THERM: [0-9]*\.[0-9]*/DT_THERM: $OCEAN_DT/g" $HOMDIR/MOM_override
+endif
+
+#######################################################################
 #                       Echo Settings and Messages
 #######################################################################
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -2688,7 +2688,7 @@ endif
 
 
 #######################################################################
-#              Modify MOM_override to match HEARTBEAT
+#              Modify MOM input files to match HEARTBEAT
 #######################################################################
 
 if( $OGCM == TRUE ) then

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -2883,8 +2883,8 @@ endif
 # and change MOM_override to match.
 
 if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
-   sed -i -e "s/DT: [0-9]*\.[0-9]*/DT: $OCEAN_DT/g" \
-          -e "s/DT_THERM: [0-9]*\.[0-9]*/DT_THERM: $OCEAN_DT/g" $HOMDIR/MOM_override
+   sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+          -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
 endif
 
 #######################################################################

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -2874,6 +2874,18 @@ endif
 # ---------------------
 # (By default, ENABLE_TR is TRUE in RC/GEOS_ChemGridComp.rc)
 
+#######################################################################
+#              Modify MOM_override to match HEARTBEAT
+#######################################################################
+
+# We also must change the MOM_override file to
+# have consistent DTs with the AGCM. So we use OCEAN_DT
+# and change MOM_override to match.
+
+if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
+   sed -i -e "s/DT: [0-9]*\.[0-9]*/DT: $OCEAN_DT/g" \
+          -e "s/DT_THERM: [0-9]*\.[0-9]*/DT_THERM: $OCEAN_DT/g" $HOMDIR/MOM_override
+endif
 
 #######################################################################
 #                       Echo Settings and Messages

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1560,7 +1560,7 @@ set DT = $HEARTBEAT
 
 # For now, in a coupled run, the ocean model must have the same time step as the atmosphere
 if( "$OGCM" == "TRUE" ) then
-     set OCEAN_DT = $HEARTBEAT
+   set OCEAN_DT = $HEARTBEAT
 endif
 
 #######################################################################
@@ -2878,13 +2878,23 @@ endif
 #              Modify MOM_override to match HEARTBEAT
 #######################################################################
 
-# We also must change the MOM_override file to
-# have consistent DTs with the AGCM. So we use OCEAN_DT
-# and change MOM_override to match.
+if( $OGCM == TRUE ) then
 
-if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
-   sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
-          -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
+   if ("$OCNMODEL" == "MOM6" ) then
+      # We also must change the MOM_override file to
+      # have consistent DTs with the AGCM. So we use OCEAN_DT
+      # and change MOM_override to match. NOTE: This sed
+      # assumes floating point number with a decimal
+
+      sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+             -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
+   else if ("$OCNMODEL" == "MOM5" ) then
+      # With MOM5 we need to change dt lines in input.nml to
+      # use $OCEAN_DT instead. NOTE: This sed assumes integer followed by comma
+
+      sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
+             -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
+
 endif
 
 #######################################################################

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1277,9 +1277,6 @@ if( $AGCM_IM == "c2160" ) then
      set CONUS = ''
      set STRETCH_FACTOR = 2.5
 endif
-if( "$OGCM" == "TRUE" ) then
-     set OCEAN_DT = $DT
-endif
 
 set IS_FCST = 0
 set FVCUBED         = ""
@@ -1561,6 +1558,10 @@ endif
 
 set DT = $HEARTBEAT
 
+# For now, in a coupled run, the ocean model must have the same time step as the atmosphere
+if( "$OGCM" == "TRUE" ) then
+     set OCEAN_DT = $HEARTBEAT
+endif
 
 #######################################################################
 #                    Create Desired HISTORY template

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -2895,6 +2895,8 @@ if( $OGCM == TRUE ) then
       sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
              -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
 
+   endif
+
 endif
 
 #######################################################################

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -2875,7 +2875,7 @@ endif
 # (By default, ENABLE_TR is TRUE in RC/GEOS_ChemGridComp.rc)
 
 #######################################################################
-#              Modify MOM_override to match HEARTBEAT
+#              Modify MOM input files to match HEARTBEAT
 #######################################################################
 
 if( $OGCM == TRUE ) then

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1277,7 +1277,7 @@ if( $AGCM_IM == "c2160" ) then
      set CONUS = ''
      set STRETCH_FACTOR = 2.5
 endif
-if( "$OCNMODEL" == "MIT" ) then
+if( "$OGCM" == "TRUE" ) then
      set OCEAN_DT = $DT
 endif
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -3107,8 +3107,8 @@ mkdir $HOMDIR/extra
 # and change MOM_override to match.
 
 if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
-   sed -i -e "s/DT: [0-9]*\.[0-9]*/DT: $OCEAN_DT/g" \
-          -e "s/DT_THERM: [0-9]*\.[0-9]*/DT_THERM: $OCEAN_DT/g" $HOMDIR/MOM_override
+   sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+          -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
 endif
 
 #######################################################################

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1374,9 +1374,6 @@ if( $AGCM_IM == "c2160" ) then
      set CONUS = ''
      set STRETCH_FACTOR = 2.5
 endif
-if( "$OGCM" == "TRUE" ) then
-     set OCEAN_DT = $DT
-endif
 
 set IS_FCST = 0
 set FVCUBED         = ""
@@ -1722,6 +1719,10 @@ endif
 
 set DT = $HEARTBEAT
 
+# For now, in a coupled run, the ocean model must have the same time step as the atmosphere
+if( "$OGCM" == "TRUE" ) then
+     set OCEAN_DT = $HEARTBEAT
+endif
 
 #######################################################################
 #                    Create Desired HISTORY template

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -3119,6 +3119,8 @@ if( $OGCM == TRUE ) then
       sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
              -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
 
+   endif
+
 endif
 
 #######################################################################

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1721,7 +1721,7 @@ set DT = $HEARTBEAT
 
 # For now, in a coupled run, the ocean model must have the same time step as the atmosphere
 if( "$OGCM" == "TRUE" ) then
-     set OCEAN_DT = $HEARTBEAT
+   set OCEAN_DT = $HEARTBEAT
 endif
 
 #######################################################################
@@ -3102,13 +3102,23 @@ mkdir $HOMDIR/extra
 #              Modify MOM_override to match HEARTBEAT
 #######################################################################
 
-# We also must change the MOM_override file to
-# have consistent DTs with the AGCM. So we use OCEAN_DT
-# and change MOM_override to match.
+if( $OGCM == TRUE ) then
 
-if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
-   sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
-          -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
+   if ("$OCNMODEL" == "MOM6" ) then
+      # We also must change the MOM_override file to
+      # have consistent DTs with the AGCM. So we use OCEAN_DT
+      # and change MOM_override to match. NOTE: This sed
+      # assumes floating point number with a decimal
+
+      sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+             -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
+   else if ("$OCNMODEL" == "MOM5" ) then
+      # With MOM5 we need to change dt lines in input.nml to
+      # use $OCEAN_DT instead. NOTE: This sed assumes integer followed by comma
+
+      sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
+             -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
+
 endif
 
 #######################################################################

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -3099,6 +3099,19 @@ mkdir $HOMDIR/extra
 /bin/mv $HOMDIR/gcm_emip.setup $HOMDIR/extra/
 
 #######################################################################
+#              Modify MOM_override to match HEARTBEAT
+#######################################################################
+
+# We also must change the MOM_override file to
+# have consistent DTs with the AGCM. So we use OCEAN_DT
+# and change MOM_override to match.
+
+if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
+   sed -i -e "s/DT: [0-9]*\.[0-9]*/DT: $OCEAN_DT/g" \
+          -e "s/DT_THERM: [0-9]*\.[0-9]*/DT_THERM: $OCEAN_DT/g" $HOMDIR/MOM_override
+endif
+
+#######################################################################
 #                       Echo Settings and Messages
 #######################################################################
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -3099,7 +3099,7 @@ mkdir $HOMDIR/extra
 /bin/mv $HOMDIR/gcm_emip.setup $HOMDIR/extra/
 
 #######################################################################
-#              Modify MOM_override to match HEARTBEAT
+#              Modify MOM input files to match HEARTBEAT
 #######################################################################
 
 if( $OGCM == TRUE ) then

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1374,7 +1374,7 @@ if( $AGCM_IM == "c2160" ) then
      set CONUS = ''
      set STRETCH_FACTOR = 2.5
 endif
-if( "$OCNMODEL" == "MIT" ) then
+if( "$OGCM" == "TRUE" ) then
      set OCEAN_DT = $DT
 endif
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -2801,7 +2801,7 @@ endif
     endif
 
 #######################################################################
-#              Modify MOM_override to match HEARTBEAT
+#              Modify MOM input files to match HEARTBEAT
 #######################################################################
 
 if( $OGCM == TRUE ) then

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1277,9 +1277,6 @@ if( $AGCM_IM == "c2160" ) then
      set CONUS = ''
      set STRETCH_FACTOR = 2.5
 endif
-if( "$OGCM" == "TRUE" ) then
-     set OCEAN_DT = $DT
-endif
 
 set IS_FCST = 0
 set FVCUBED         = ""
@@ -1546,6 +1543,10 @@ endif
 
 set DT = $HEARTBEAT
 
+# For now, in a coupled run, the ocean model must have the same time step as the atmosphere
+if( "$OGCM" == "TRUE" ) then
+     set OCEAN_DT = $HEARTBEAT
+endif
 
 #######################################################################
 #                    Create Desired HISTORY template

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -2801,6 +2801,19 @@ endif
     endif
 
 #######################################################################
+#              Modify MOM_override to match HEARTBEAT
+#######################################################################
+
+# We also must change the MOM_override file to
+# have consistent DTs with the AGCM. So we use OCEAN_DT
+# and change MOM_override to match.
+
+if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
+   sed -i -e "s/DT: [0-9]*\.[0-9]*/DT: $OCEAN_DT/g" \
+          -e "s/DT_THERM: [0-9]*\.[0-9]*/DT_THERM: $OCEAN_DT/g" $HOMDIR/MOM_override
+endif
+
+#######################################################################
 #                       Echo Settings and Messages
 #######################################################################
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1545,7 +1545,7 @@ set DT = $HEARTBEAT
 
 # For now, in a coupled run, the ocean model must have the same time step as the atmosphere
 if( "$OGCM" == "TRUE" ) then
-     set OCEAN_DT = $HEARTBEAT
+   set OCEAN_DT = $HEARTBEAT
 endif
 
 #######################################################################
@@ -2804,13 +2804,23 @@ endif
 #              Modify MOM_override to match HEARTBEAT
 #######################################################################
 
-# We also must change the MOM_override file to
-# have consistent DTs with the AGCM. So we use OCEAN_DT
-# and change MOM_override to match.
+if( $OGCM == TRUE ) then
 
-if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
-   sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
-          -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
+   if ("$OCNMODEL" == "MOM6" ) then
+      # We also must change the MOM_override file to
+      # have consistent DTs with the AGCM. So we use OCEAN_DT
+      # and change MOM_override to match. NOTE: This sed
+      # assumes floating point number with a decimal
+
+      sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+             -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
+   else if ("$OCNMODEL" == "MOM5" ) then
+      # With MOM5 we need to change dt lines in input.nml to
+      # use $OCEAN_DT instead. NOTE: This sed assumes integer followed by comma
+
+      sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
+             -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
+
 endif
 
 #######################################################################

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -2821,6 +2821,8 @@ if( $OGCM == TRUE ) then
       sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
              -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
 
+   endif
+
 endif
 
 #######################################################################

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1277,7 +1277,7 @@ if( $AGCM_IM == "c2160" ) then
      set CONUS = ''
      set STRETCH_FACTOR = 2.5
 endif
-if( "$OCNMODEL" == "MIT" ) then
+if( "$OGCM" == "TRUE" ) then
      set OCEAN_DT = $DT
 endif
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -2809,8 +2809,8 @@ endif
 # and change MOM_override to match.
 
 if( $OGCM == TRUE & "$OCNMODEL" == "MOM6" ) then
-   sed -i -e "s/DT: [0-9]*\.[0-9]*/DT: $OCEAN_DT/g" \
-          -e "s/DT_THERM: [0-9]*\.[0-9]*/DT_THERM: $OCEAN_DT/g" $HOMDIR/MOM_override
+   sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+          -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
 endif
 
 #######################################################################


### PR DESCRIPTION
NOTE: This is zero-diff for AMIP, but non-zero-diff for MOM6 due to changes to DT.

Per @amolod, until other fixes can go in (cc @atrayano), coupled runs must have `OGCM_RUN_DT` equal to the heartbeat. 

Moreover, I assume (?) that the `DT` and `DT_THERM` in `MOM_override` must have the same number. So I do some sed at the end of `gcm_setup` to change that as well. (@sanAkel or @yvikhlya can tell me if this is true.)

I don't know how to run MOM5 so I'm not sure if something similar needs to be done there with its input files. If someone can tell me what to look for, I can try to sed/awk that too.

I'll keep this draft until the coupled folks can weigh in on it. It seems to work for me...but they are the arbiters.