### PR TITLE
Updates for Singularity: Add site option

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -32,8 +32,8 @@ setenv GEOSBIN          @GEOSBIN
 setenv GEOSETC          @GEOSETC
 setenv GEOSUTIL         @GEOSSRC
 
-@NATIVE_BUILD source $GEOSBIN/g5_modules
-@NATIVE_BUILD setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib:${GEOSDIR}/lib
+source $GEOSBIN/g5_modules
+setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib:${GEOSDIR}/lib
 
 setenv RUN_CMD "$GEOSBIN/esma_mpirun -np "
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -117,7 +117,7 @@ end
 
 setenv NODE `uname -n`
 setenv ARCH `uname -s`
-if ($USER_SITE = "") then
+if ($USER_SITE == "") then
    setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
 else
    setenv SITE $USER_SITE

--- a/gcm_setup
+++ b/gcm_setup
@@ -60,6 +60,7 @@ endif
 set LINKX = FALSE
 set EXE_VERB = "copied"
 set USING_SINGULARITY = FALSE
+set USER_SITE = ""
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -69,6 +70,22 @@ while ( $#argv > 0 )
       case -[Cc]:
       case --[Cc][Oo][Ll][Oo][Rr]:
          goto SETCOLOR
+
+      # Testing with singularity found we need the ability to override
+      # the SITE variable below because images might be built on, say,
+      # AWS and thus "block" us from running at NCCS.
+      #
+      # So, we make a --site flag that allows us to override the SITE
+      # variable
+      case --site:
+         set USER_SITE = $1
+         # if USER_SITE is empty, then we error out
+         if ( "$USER_SITE" == "" ) then
+            echo "ERROR: --site flag requires a site name"
+            exit 1
+         endif
+         shift argv
+         breaksw
 
       # Symlink GEOSgcm.x
       case --link:
@@ -100,7 +117,11 @@ end
 
 setenv NODE `uname -n`
 setenv ARCH `uname -s`
-setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
+if ($USER_SITE = "") then
+   setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
+else
+   setenv SITE $USER_SITE
+endif
 
 #######################################################################
 #                 Test for Compiler and MPI Setup

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -117,7 +117,7 @@ end
 
 setenv NODE `uname -n`
 setenv ARCH `uname -s`
-if ($USER_SITE = "") then
+if ($USER_SITE == "") then
    setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
 else
    setenv SITE $USER_SITE

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -60,6 +60,7 @@ endif
 set LINKX = FALSE
 set EXE_VERB = "copied"
 set USING_SINGULARITY = FALSE
+set USER_SITE = ""
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -69,6 +70,22 @@ while ( $#argv > 0 )
       case -[Cc]:
       case --[Cc][Oo][Ll][Oo][Rr]:
          goto SETCOLOR
+
+      # Testing with singularity found we need the ability to override
+      # the SITE variable below because images might be built on, say,
+      # AWS and thus "block" us from running at NCCS.
+      #
+      # So, we make a --site flag that allows us to override the SITE
+      # variable
+      case --site:
+         set USER_SITE = $1
+         # if USER_SITE is empty, then we error out
+         if ( "$USER_SITE" == "" ) then
+            echo "ERROR: --site flag requires a site name"
+            exit 1
+         endif
+         shift argv
+         breaksw
 
       # Symlink GEOSgcm.x
       case --link:
@@ -100,7 +117,11 @@ end
 
 setenv NODE `uname -n`
 setenv ARCH `uname -s`
-setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
+if ($USER_SITE = "") then
+   setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
+else
+   setenv SITE $USER_SITE
+endif
 
 #######################################################################
 #                 Test for Compiler and MPI Setup

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -117,7 +117,7 @@ end
 
 setenv NODE `uname -n`
 setenv ARCH `uname -s`
-if ($USER_SITE = "") then
+if ($USER_SITE == "") then
    setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
 else
    setenv SITE $USER_SITE

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -60,6 +60,7 @@ endif
 set LINKX = FALSE
 set EXE_VERB = "copied"
 set USING_SINGULARITY = FALSE
+set USER_SITE = ""
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -69,6 +70,22 @@ while ( $#argv > 0 )
       case -[Cc]:
       case --[Cc][Oo][Ll][Oo][Rr]:
          goto SETCOLOR
+
+      # Testing with singularity found we need the ability to override
+      # the SITE variable below because images might be built on, say,
+      # AWS and thus "block" us from running at NCCS.
+      #
+      # So, we make a --site flag that allows us to override the SITE
+      # variable
+      case --site:
+         set USER_SITE = $1
+         # if USER_SITE is empty, then we error out
+         if ( "$USER_SITE" == "" ) then
+            echo "ERROR: --site flag requires a site name"
+            exit 1
+         endif
+         shift argv
+         breaksw
 
       # Symlink GEOSgcm.x
       case --link:
@@ -100,7 +117,11 @@ end
 
 setenv NODE `uname -n`
 setenv ARCH `uname -s`
-setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
+if ($USER_SITE = "") then
+   setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
+else
+   setenv SITE $USER_SITE
+endif
 
 #######################################################################
 #                 Test for Compiler and MPI Setup

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -117,7 +117,7 @@ end
 
 setenv NODE `uname -n`
 setenv ARCH `uname -s`
-if ($USER_SITE = "") then
+if ($USER_SITE == "") then
    setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
 else
    setenv SITE $USER_SITE

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -60,6 +60,7 @@ endif
 set LINKX = FALSE
 set EXE_VERB = "copied"
 set USING_SINGULARITY = FALSE
+set USER_SITE = ""
 
 while ( $#argv > 0 )
    set arg = $argv[1]
@@ -69,6 +70,22 @@ while ( $#argv > 0 )
       case -[Cc]:
       case --[Cc][Oo][Ll][Oo][Rr]:
          goto SETCOLOR
+
+      # Testing with singularity found we need the ability to override
+      # the SITE variable below because images might be built on, say,
+      # AWS and thus "block" us from running at NCCS.
+      #
+      # So, we make a --site flag that allows us to override the SITE
+      # variable
+      case --site:
+         set USER_SITE = $1
+         # if USER_SITE is empty, then we error out
+         if ( "$USER_SITE" == "" ) then
+            echo "ERROR: --site flag requires a site name"
+            exit 1
+         endif
+         shift argv
+         breaksw
 
       # Symlink GEOSgcm.x
       case --link:
@@ -100,7 +117,11 @@ end
 
 setenv NODE `uname -n`
 setenv ARCH `uname -s`
-setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
+if ($USER_SITE = "") then
+   setenv SITE `awk '{print $2}' $ETCDIR/SITE.rc`
+else
+   setenv SITE $USER_SITE
+endif
 
 #######################################################################
 #                 Test for Compiler and MPI Setup


### PR DESCRIPTION
This PR has a change needed for singularity testing. Namely, a docker or singularity image might be built on the cloud in AWS or Azure and so the model thinks "I was built on AWS, I need to run on AWS" but this is not the case. 