### PR TITLE
Fix doubled logger output

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -119,7 +119,6 @@ loggers:
    # To enable this logger, set the console handler
    # above to DEBUG level
    CAP.EXTDATA:
-      handlers: [console]
       level: WARNING
       root_level: DEBUG
 


### PR DESCRIPTION
In #508, I thought I was being clever. But it turns out I don't know pflogger that well. My entry for `CAP.EXTDATA` actually *doubled* all ExtData output:
```
        EXTDATA: INFO: *******************************************************
        EXTDATA: INFO: *******************************************************
        EXTDATA: INFO: ** Variables to be provided by the ExtData Component **
        EXTDATA: INFO: ** Variables to be provided by the ExtData Component **
        EXTDATA: INFO: *******************************************************
        EXTDATA: INFO: *******************************************************
        EXTDATA: INFO: ---- 00001: BC_AIRCRAFT
        EXTDATA: INFO: ---- 00001: BC_AIRCRAFT
        EXTDATA: INFO: ---- 00002: BC_ANTEBC1
        EXTDATA: INFO: ---- 00002: BC_ANTEBC1
        EXTDATA: INFO: ---- 00003: BC_ANTEBC2
        EXTDATA: INFO: ---- 00003: BC_ANTEBC2
```

After consulting with @tclune, turns out this PR has what I wanted. We can have a `CAP.EXTDATA` there and uncommented, but not double everything.