### PR TITLE
Enable FV3_CONFIG: HWT for NH runs, CONVPAR_OPTION: NONE for ultra-high-res

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -39,7 +39,7 @@ UW_DT: @LONG_DT
 # dynamics options
 # ----------------------------------------
 DYCORE: @DYCORE
-@CONUS FV3_CONFIG: HWT
+@FV_HWT FV3_CONFIG: HWT
 AdvCore_Advection: 0
 ###########################################################
 

--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -84,7 +84,7 @@ SHALLOW_OPTION: UW
 ###########################################################
 # convection scheme options
 # ----------------------------------------
-CONVPAR_OPTION: GF
+CONVPAR_OPTION: @CONVPAR_OPTION
 #USE_GF2020: 1
 # Convective plumes to be activated (1 true, 0 false)
 DEEP: 1

--- a/gcm_setup
+++ b/gcm_setup
@@ -1400,12 +1400,15 @@ endif
 if ( "$USE_HYDROSTATIC" == "TRUE" ) then
    set FV_MAKENH     = "Make_NH     = .F."
    set FV_HYDRO      = "hydrostatic = .T."
+   set FV_HWT        = '#'
 else
    set FV_MAKENH     = "Make_NH     = .T."
    set FV_HYDRO      = "hydrostatic = .F."
    if ( "$CLDMICRO" == "GFDL_1M" ) then
       set GFDL_HYDRO = ".FALSE."
    endif
+   # Enable FV3_CONFIG: HWT when running non-hydrostatic
+   set FV_HWT        = ''
 endif
 
 if ($CONUS == '#') then
@@ -1418,6 +1421,8 @@ else
   set STRETCH_FAC = "stretch_fac = $STRETCH_FACTOR"
   set TARGET_LON  = "target_lon  = -98.35"
   set TARGET_LAT  = "target_lat  = 39.5"
+  # Always enable FV3_CONFIG: HWT for CONUS
+  set FV_HWT        = ''
 endif
 
 #######################################################################
@@ -2387,6 +2392,7 @@ s/@JOB_SGMT/${JOB_SGMT}/g
 s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
+s/@FV_HWT/${FV_HWT}/g
 s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g

--- a/gcm_setup
+++ b/gcm_setup
@@ -1008,6 +1008,11 @@ endif
      set NUM_READERS = 1
      set NUM_WRITERS = 1
 
+# Set default CONVPAR_OPTION to GF
+# (set to NONE at C2880 and C5760)
+# --------------------------------
+     set CONVPAR_OPTION = GF
+
 # Default Run Parameters
 # ----------------------
 if( $AGCM_IM ==  "c12" ) then
@@ -1202,6 +1207,7 @@ if( $AGCM_IM == "c2880" ) then
      set POST_NDS = 32
      set USE_SHMEM = 1
      set DEF_IOS_NDS = 4
+     set CONVPAR_OPTION = NONE
 endif
 if( $AGCM_IM == "c5760" ) then
      set       DT = 30
@@ -1223,6 +1229,7 @@ if( $AGCM_IM == "c5760" ) then
      set POST_NDS = 32
      set USE_SHMEM = 1
      set DEF_IOS_NDS = 4
+     set CONVPAR_OPTION = NONE
 endif
 # CONUS Stretched Grids
 set CONUS = '#'
@@ -2393,6 +2400,7 @@ s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
 s/@FV_HWT/${FV_HWT}/g
+s/@CONVPAR_OPTION/${CONVPAR_OPTION}/g
 s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1008,6 +1008,11 @@ endif
      set NUM_READERS = 1
      set NUM_WRITERS = 1
 
+# Set default CONVPAR_OPTION to GF
+# (set to NONE at C2880 and C5760)
+# --------------------------------
+     set CONVPAR_OPTION = GF
+
 # Default Run Parameters
 # ----------------------
 if( $AGCM_IM ==  "c12" ) then
@@ -1211,6 +1216,7 @@ if( $AGCM_IM == "c2880" ) then
      set POST_NDS = 32
      set USE_SHMEM = 1
      set DEF_IOS_NDS = 4
+     set CONVPAR_OPTION = NONE
 endif
 if( $AGCM_IM == "c5760" ) then
      set       DT = 30
@@ -1233,6 +1239,7 @@ if( $AGCM_IM == "c5760" ) then
      set POST_NDS = 32
      set USE_SHMEM = 1
      set DEF_IOS_NDS = 4
+     set CONVPAR_OPTION = NONE
 endif
 # CONUS Stretched Grids
 set CONUS = '#'
@@ -2423,6 +2430,7 @@ s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
 s/@FV_HWT/${FV_HWT}/g
+s/@CONVPAR_OPTION/${CONVPAR_OPTION}/g
 s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 /SATSIM_DT/a GEOSCHEMCHEM_DT: $GEOSCHEMCHEM_DT

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1415,12 +1415,15 @@ endif
 if ( "$USE_HYDROSTATIC" == "TRUE" ) then
    set FV_MAKENH     = "Make_NH     = .F."
    set FV_HYDRO      = "hydrostatic = .T."
+   set FV_HWT        = '#'
 else
    set FV_MAKENH     = "Make_NH     = .T."
    set FV_HYDRO      = "hydrostatic = .F."
    if ( "$CLDMICRO" == "GFDL_1M" ) then
       set GFDL_HYDRO = ".FALSE."
    endif
+   # Enable FV3_CONFIG: HWT when running non-hydrostatic
+   set FV_HWT        = ''
 endif
 
 if ($CONUS == '#') then
@@ -1433,6 +1436,8 @@ else
   set STRETCH_FAC = "stretch_fac = $STRETCH_FACTOR"
   set TARGET_LON  = "target_lon  = -98.35"
   set TARGET_LAT  = "target_lat  = 39.5"
+  # Always enable FV3_CONFIG: HWT for CONUS
+  set FV_HWT        = ''
 endif
 
 #######################################################################
@@ -2321,7 +2326,7 @@ s?@OGCM_NY?$OGCM_NY?g
 s?@OGCM_NPROCS?$OGCM_NPROCS?g
 
 s?@OBSERVER_FRQ?0?g
-s?RECORD_?#RECORD_?g
+s?^[ \t]*RECORD_?#RECORD_?g
 
 s?@DASTUNING?#?g
 
@@ -2417,6 +2422,7 @@ s/@JOB_SGMT/${JOB_SGMT}/g
 s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
+s/@FV_HWT/${FV_HWT}/g
 s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 /SATSIM_DT/a GEOSCHEMCHEM_DT: $GEOSCHEMCHEM_DT

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1512,12 +1512,15 @@ endif
 if ( "$USE_HYDROSTATIC" == "TRUE" ) then
    set FV_MAKENH     = "Make_NH     = .F."
    set FV_HYDRO      = "hydrostatic = .T."
+   set FV_HWT        = '#'
 else
    set FV_MAKENH     = "Make_NH     = .T."
    set FV_HYDRO      = "hydrostatic = .F."
    if ( "$CLDMICRO" == "GFDL_1M" ) then
       set GFDL_HYDRO = ".FALSE."
    endif
+   # Enable FV3_CONFIG: HWT when running non-hydrostatic
+   set FV_HWT        = ''
 endif
 
 if ($CONUS == '#') then
@@ -1530,6 +1533,8 @@ else
   set STRETCH_FAC = "stretch_fac = $STRETCH_FACTOR"
   set TARGET_LON  = "target_lon  = -98.35"
   set TARGET_LAT  = "target_lat  = 39.5"
+  # Always enable FV3_CONFIG: HWT for CONUS
+  set FV_HWT        = ''
 endif
 
 #######################################################################
@@ -2488,7 +2493,7 @@ s?@OGCM_NY?$OGCM_NY?g
 s?@OGCM_NPROCS?$OGCM_NPROCS?g
 
 s?@OBSERVER_FRQ?0?g
-s?RECORD_?#RECORD_?g
+s?^[ \t]*RECORD_?#RECORD_?g
 
 s?@DASTUNING?#?g
 
@@ -2585,6 +2590,7 @@ s/@JOB_SGMT/${JOB_SGMT}/g
 s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
+s/@FV_HWT/${FV_HWT}/g
 s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1105,6 +1105,11 @@ endif
      set NUM_READERS = 1
      set NUM_WRITERS = 1
 
+# Set default CONVPAR_OPTION to GF
+# (set to NONE at C2880 and C5760)
+# --------------------------------
+     set CONVPAR_OPTION = GF
+
 # Default Run Parameters
 # ----------------------
 if( $AGCM_IM ==  "c12" ) then
@@ -1308,6 +1313,7 @@ if( $AGCM_IM == "c2880" ) then
      set POST_NDS = 32
      set USE_SHMEM = 1
      set DEF_IOS_NDS = 4
+     set CONVPAR_OPTION = NONE
 endif
 if( $AGCM_IM == "c5760" ) then
      set       DT = 30
@@ -1330,6 +1336,7 @@ if( $AGCM_IM == "c5760" ) then
      set POST_NDS = 32
      set USE_SHMEM = 1
      set DEF_IOS_NDS = 4
+     set CONVPAR_OPTION = NONE
 endif
 # CONUS Stretched Grids
 set CONUS = '#'
@@ -2591,6 +2598,7 @@ s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
 s/@FV_HWT/${FV_HWT}/g
+s/@CONVPAR_OPTION/${CONVPAR_OPTION}/g
 s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1415,12 +1415,15 @@ endif
 if ( "$USE_HYDROSTATIC" == "TRUE" ) then
    set FV_MAKENH     = "Make_NH     = .F."
    set FV_HYDRO      = "hydrostatic = .T."
+   set FV_HWT        = '#'
 else
    set FV_MAKENH     = "Make_NH     = .T."
    set FV_HYDRO      = "hydrostatic = .F."
    if ( "$CLDMICRO" == "GFDL_1M" ) then
       set GFDL_HYDRO = ".FALSE."
    endif
+   # Enable FV3_CONFIG: HWT when running non-hydrostatic
+   set FV_HWT        = ''
 endif
 
 if ($CONUS == '#') then
@@ -1433,6 +1436,8 @@ else
   set STRETCH_FAC = "stretch_fac = $STRETCH_FACTOR"
   set TARGET_LON  = "target_lon  = -98.35"
   set TARGET_LAT  = "target_lat  = 39.5"
+  # Always enable FV3_CONFIG: HWT for CONUS
+  set FV_HWT        = ''
 endif
 
 #######################################################################
@@ -2306,7 +2311,7 @@ s?@OGCM_NY?$OGCM_NY?g
 s?@OGCM_NPROCS?$OGCM_NPROCS?g
 
 s?@OBSERVER_FRQ?0?g
-s?RECORD_?#RECORD_?g
+s?^[ \t]*RECORD_?#RECORD_?g
 
 s?@DASTUNING?#?g
 
@@ -2403,6 +2408,7 @@ s/@JOB_SGMT/${JOB_SGMT}/g
 s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
+s/@FV_HWT/${FV_HWT}/g
 s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1008,6 +1008,11 @@ endif
      set NUM_READERS = 1
      set NUM_WRITERS = 1
 
+# Set default CONVPAR_OPTION to GF
+# (set to NONE at C2880 and C5760)
+# --------------------------------
+     set CONVPAR_OPTION = GF
+
 # Default Run Parameters
 # ----------------------
 if( $AGCM_IM ==  "c12" ) then
@@ -1211,6 +1216,7 @@ if( $AGCM_IM == "c2880" ) then
      set POST_NDS = 32
      set USE_SHMEM = 1
      set DEF_IOS_NDS = 4
+     set CONVPAR_OPTION = NONE
 endif
 if( $AGCM_IM == "c5760" ) then
      set       DT = 30
@@ -1233,6 +1239,7 @@ if( $AGCM_IM == "c5760" ) then
      set POST_NDS = 32
      set USE_SHMEM = 1
      set DEF_IOS_NDS = 4
+     set CONVPAR_OPTION = NONE
 endif
 # CONUS Stretched Grids
 set CONUS = '#'
@@ -2409,6 +2416,7 @@ s/@NUM_SGMT/${NUM_SGMT}/g
 
 s/@CONUS/${CONUS}/g
 s/@FV_HWT/${FV_HWT}/g
+s/@CONVPAR_OPTION/${CONVPAR_OPTION}/g
 s/@STRETCH_FACTOR/${STRETCH_FACTOR}/g
 
 s/@INTERPOLATE_SST/$INTERPOLATE_SST/g


### PR DESCRIPTION
Per a comment by @wmputman:

> Anytime we run NH, we should enable FV3_CONFIG: HWT (this is a gcm_setup issue)

This PR does that. Per the starting code, we also enable `FV3_CONFIG: HWT` when running CONUS.

I'll mark as zero-diff as it is for hydrostatic runs, but it's also non-zero-diff (I assume) for NH runs. So...