### PR TITLE
Turn back on WRITE_RESTART_BY_OSERVER at all res

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -2162,13 +2162,7 @@ if( $MPI == openmpi ) then
 # Open MPI and GEOS has issues with restart writing. Having the
 # oserver write them can be orders of magnitude faster
 
-# Note that at low res, this is not strictly needed and can interfere with some
-# testing. So, if LOW_ATM_RES is TRUE then we set to NO, otherwise set to YES
-# as at high res this flag is *needed* 
-
-if( $LOW_ATM_RES == 'FALSE') then
-   set RESTART_BY_OSERVER = YES
-endif
+set RESTART_BY_OSERVER = YES
 
 # This turns off an annoying warning when running
 # Open MPI on a system where TMPDIRs are on a networked


### PR DESCRIPTION
With the release of [MAPL 2.42.0](https://github.com/GEOS-ESM/MAPL/releases/tag/v2.42.0) we can now undo the changes from #530.