### PR TITLE
Add fv namelist entry for AIST work

### DIFF
--- a/fvcore_layout.rc
+++ b/fvcore_layout.rc
@@ -6,6 +6,7 @@
  @FV_STRETCH_FAC
  @FV_TARGET_LON
  @FV_TARGET_LAT
+ compute_coords_locally = .false.
 /
 
 &main_nml


### PR DESCRIPTION
This PR adds a new fv namelist entry for the AIST work by @tclune. To be used first https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/pull/83 → [GFDL_atmos_cubed_sphere geos/v2.7.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.7.0) must be used.

There is a corresponding PR in FV3 (https://github.com/GEOS-ESM/FVdycoreCubed_GridComp/pull/258) for the FV3 Standalone

By default, we add the flag as `.false.` which is zero-diff to current behavior. Enabling it will be non-zero-diff.

---

ETA: Now that [GFDL_atmos_cubed_sphere geos/v2.7.0](https://github.com/GEOS-ESM/GFDL_atmos_cubed_sphere/releases/tag/geos%2Fv2.7.0) is out and in GEOSgcm `main` (https://github.com/GEOS-ESM/GEOSgcm/pull/696), this can go in.