### PR TITLE
Initialize USE_WAVES to 0

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -116,7 +116,7 @@ CLOSURE_CONGESTUS: 3
 @HIST_GOCARTCA.br::CA.brphilic default
 @HIST_GOCARTCA.oc::CA.ocphilic default
 @HIST_GOCARTNI::NO3an1 "NI::NO3an2,NI::NO3an3"
-@HIST_GOCARTPCHEM::OX default 
+@HIST_GOCARTPCHEM::OX default
 @HIST_GOCART::
 @HIST_GOCART###########################################################
 
@@ -905,6 +905,10 @@ USE_SATSIM_RADAR: @RADAR_SATSIM
 USE_SATSIM_LIDAR: @LIDAR_SATSIM
 USE_SATSIM_MISR:  @MISR_SATSIM
 
+# Flags to enable wave code
+# -------------------------
+USE_WAVES: 0
+
 @COUPLED INTERPOLATE_ATMLM: 0
 @COUPLED INTERPOLATE_ATMTAU: 1
 @COUPLED INTERPOLATE_OCEAN_ICE_CURRENTS: 0
@@ -929,7 +933,7 @@ USE_SATSIM_MISR:  @MISR_SATSIM
 @MOM5#DATA_SST_FILE: sst.data
 @MOM5#DATA_FRT_FILE: fraci.data
 
-@COUPLED 
+@COUPLED
 @COUPLED# Section for CICE
 @COUPLED# -----------------
 @CICE4USE_CICE_Thermo: 1

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -644,7 +644,7 @@ else
     end
 
     # WW3 restart file
-    if( $wavemodel == "WW3" ) then
+    if( $USE_WAVES != 0 && $wavemodel == "WW3" ) then
         set rst_ww3 = "restart.ww3"
         if(-e $EXPDIR/${rst_ww3} ) /bin/cp $EXPDIR/${rst_ww3} . &
     endif
@@ -679,7 +679,7 @@ if($numrs == 0) then
    wait
 @COUPLED    cp -r $EXPDIR/RESTART ${EXPDIR}/restarts/RESTART.${edate}
    # WW3 restart file
-   if( $wavemodel == "WW3" ) then
+   if( $USE_WAVES != 0 && $wavemodel == "WW3" ) then
        set rst_ww3 = "restart.ww3"
        if( -e ${rst_ww3} ) cp ${rst_ww3}  ${EXPDIR}/restarts/$EXPID.${rst_ww3}.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}
    endif
@@ -1318,7 +1318,7 @@ end
 
 # WW3 restarts - assumes that there is at least one NEW restart file
 # ------------------------------------------------------------------
-if( $wavemodel == "WW3" ) then
+if( $USE_WAVES != 0 && $wavemodel == "WW3" ) then
 
     set ww3checkpoint  = `/bin/ls -1 restart[0-9][0-9][0-9].ww3 | sort -n | tail -n 1`
     set rst_ww3 = "restart.ww3"
@@ -1326,7 +1326,7 @@ if( $wavemodel == "WW3" ) then
     cp $rst_ww3 ${EXPDIR}/restarts/$EXPID.${rst_ww3}.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}.bin
 
     # remove intermediate restarts
-    set ww3checkpoint  = `/bin/ls -1 restart[0-9][0-9][0-9].ww3 | sort -n | tail -n 1` 
+    set ww3checkpoint  = `/bin/ls -1 restart[0-9][0-9][0-9].ww3 | sort -n | tail -n 1`
     if ( $#ww3checkpoint != 0 ) /bin/rm  ./restart[0-9][0-9][0-9].ww3
 endif
 
@@ -1437,7 +1437,7 @@ else
      wait
      cp cap_restart $EXPDIR/cap_restart
 
-     if( $wavemodel == "WW3" ) then 
+     if( $USE_WAVES != 0 &&  $wavemodel == "WW3" ) then
         set rst_ww3 = "restart.ww3"
         /bin/rm -f $EXPDIR/$rst_ww3
         cp $rst_ww3 $EXPDIR/$rst_ww3 &


### PR DESCRIPTION
As noted by @sdrabenh, @sanAkel, and myself, recent runs of GEOS output:
```
cp: ww3_multi.nml: No such file or directory
ww3_multi.nml.orig: No such file or directory.
grep: ww3_multi.nml: No such file or directory
mv: rename ww3_multi.nml to ww3_multi.nml.tmp: No such file or directory
cat: ww3_multi.nml.tmp: No such file or directory
rm: ww3_multi.nml.tmp: No such file or directory
```
on runs.

Testing shows, it's because in this code:

https://github.com/GEOS-ESM/GEOSgcm_App/blob/b96f3e63002f9a7aec6e2755508f52617642e8a8/gcm_run.j#L632-L633

https://github.com/GEOS-ESM/GEOSgcm_App/blob/b96f3e63002f9a7aec6e2755508f52617642e8a8/gcm_run.j#L842-L845

`USE_WAVES` is not set to anything, but `wavemodel` is set to `WW3` (via `WGCM.rc`). And it seems an empty variable is not "falsey" like 0 in tcsh.

So, this PR just adds a section to `AGCM.rc.tmpl` that just has:
```
USE_WAVES: 0
```

I'll add @adarmenov as a reviewer to make sure this is okay with him. Eventually, we can template this with a question about wave models, but for now, this avoids the extra code.