### PR TITLE
Disable Catchment-CN4.5 land model option (LSM_CHOICE=3) for GCM simulations

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -529,7 +529,6 @@ RECORD_REF_TIME: >>>REFTIME<<< >>>FCSTIME<<<
 # Choice for Land Surface Model
 #      1 : Catchment
 #      2 : CatchmentCNCLM40
-#      3 : CatchmentCNCLM45
 # ------------------------------------------------------------
 LSM_CHOICE: @LSM_CHOICE
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -1519,26 +1519,22 @@ endif
 # ----------------------
 if( $LSM_BCS == "Icarus-NLv3" ) then
     LSM_CHOICE:
-    echo "Enter the choice of ${C1} Land Surface Model${CN} using: ${C2}1${CN} (Default: Catchment), ${C2}2${CN} (CatchmentCN-CLM4.0 (CN_CLM40)), ${C2}3${CN} (CatchmentCN-CLM4.5 (CN_CLM45))"
+    echo "Enter the choice of ${C1} Land Surface Model${CN} using: ${C2}1${CN} (Default: Catchment) or ${C2}2${CN} (CatchmentCN-CLM4.0 (CN_CLM40))"
     set   LSM_CHOICE = $<
     if( .$LSM_CHOICE == . ) set LSM_CHOICE  = 1
-    if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 &  $LSM_CHOICE != 3 ) then
+    if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 ) then
         echo
-        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} , ${C2}2${CN} or ${C2}3${CN}!"
+        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} or ${C2}2${CN}!"
         goto LSM_CHOICE
     else
         echo
     endif
     if( $LSM_CHOICE == 1 ) set HIST_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set HIST_CATCHCN = ""
-    if( $LSM_CHOICE == 3 ) set HIST_CATCHCN = ""
     if( $LSM_CHOICE == 1 ) set GCMRUN_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set GCMRUN_CATCHCN = ""
-    if( $LSM_CHOICE == 3 ) set GCMRUN_CATCHCN = ""
     if( $LSM_CHOICE == 2 ) then
       echo "IMPORTANT: please set LAND_PARAMS: to CN_CLM40 in RC/GEOS_SurfaceGridComp.rc in the experiment directory."
-    else if ( $LSM_CHOICE == 3 ) then
-      echo "IMPORTANT: please set LAND_PARAMS: to CN_CLM45 in RC/GEOS_SurfaceGridComp.rc in the experiment directory."
     endif
 else
     set LSM_CHOICE = 1

--- a/gcm_setup
+++ b/gcm_setup
@@ -1524,7 +1524,7 @@ if( $LSM_BCS == "Icarus-NLv3" ) then
     if( .$LSM_CHOICE == . ) set LSM_CHOICE  = 1
     if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 ) then
         echo
-        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} or ${C2}2${CN}!"
+        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1${CN} or ${C2}2${CN}!"
         goto LSM_CHOICE
     else
         echo

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1534,26 +1534,22 @@ endif
 # ----------------------
 if( $LSM_BCS == "Icarus-NLv3" ) then
     LSM_CHOICE:
-    echo "Enter the choice of ${C1} Land Surface Model${CN} using: ${C2}1${CN} (Default: Catchment), ${C2}2${CN} (CatchmentCN-CLM4.0 (CN_CLM40)), ${C2}3${CN} (CatchmentCN-CLM4.5 (CN_CLM45))"
+    echo "Enter the choice of ${C1} Land Surface Model${CN} using: ${C2}1${CN} (Default: Catchment), ${C2}2${CN} (CatchmentCN-CLM4.0 (CN_CLM40))"
     set   LSM_CHOICE = $<
     if( .$LSM_CHOICE == . ) set LSM_CHOICE  = 1
-    if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 &  $LSM_CHOICE != 3 ) then
+    if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 ) then
         echo
-        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} , ${C2}2${CN} or ${C2}3${CN}!"
+        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} or ${C2}2${CN}!"
         goto LSM_CHOICE
     else
         echo
     endif
     if( $LSM_CHOICE == 1 ) set HIST_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set HIST_CATCHCN = ""
-    if( $LSM_CHOICE == 3 ) set HIST_CATCHCN = ""
     if( $LSM_CHOICE == 1 ) set GCMRUN_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set GCMRUN_CATCHCN = ""
-    if( $LSM_CHOICE == 3 ) set GCMRUN_CATCHCN = ""
     if( $LSM_CHOICE == 2 ) then
       echo "IMPORTANT: please set LAND_PARAMS: to CN_CLM40 in RC/GEOS_SurfaceGridComp.rc in the experiment directory."
-    else if ( $LSM_CHOICE == 3 ) then
-      echo "IMPORTANT: please set LAND_PARAMS: to CN_CLM45 in RC/GEOS_SurfaceGridComp.rc in the experiment directory."
     endif
 else
     set LSM_CHOICE = 1

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1539,7 +1539,7 @@ if( $LSM_BCS == "Icarus-NLv3" ) then
     if( .$LSM_CHOICE == . ) set LSM_CHOICE  = 1
     if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 ) then
         echo
-        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} or ${C2}2${CN}!"
+        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1${CN} or ${C2}2${CN}!"
         goto LSM_CHOICE
     else
         echo

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1631,26 +1631,22 @@ endif
 # ----------------------
 if( $LSM_BCS == "Icarus-NLv3" ) then
     LSM_CHOICE:
-    echo "Enter the choice of ${C1} Land Surface Model${CN} using: ${C2}1${CN} (Default: Catchment), ${C2}2${CN} (CatchmentCN-CLM4.0 (CN_CLM40)), ${C2}3${CN} (CatchmentCN-CLM4.5 (CN_CLM45))"
+    echo "Enter the choice of ${C1} Land Surface Model${CN} using: ${C2}1${CN} (Default: Catchment) or ${C2}2${CN} (CatchmentCN-CLM4.0 (CN_CLM40))"
     set   LSM_CHOICE = $<
     if( .$LSM_CHOICE == . ) set LSM_CHOICE  = 1
-    if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 &  $LSM_CHOICE != 3 ) then
+    if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2) then
         echo
-        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} , ${C2}2${CN} or ${C2}3${CN}!"
+        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} or ${C2}2${CN}!"
         goto LSM_CHOICE
     else
         echo
     endif
     if( $LSM_CHOICE == 1 ) set HIST_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set HIST_CATCHCN = ""
-    if( $LSM_CHOICE == 3 ) set HIST_CATCHCN = ""
     if( $LSM_CHOICE == 1 ) set GCMRUN_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set GCMRUN_CATCHCN = ""
-    if( $LSM_CHOICE == 3 ) set GCMRUN_CATCHCN = ""
     if( $LSM_CHOICE == 2 ) then
       echo "IMPORTANT: please set LAND_PARAMS: to CN_CLM40 in RC/GEOS_SurfaceGridComp.rc in the experiment directory."
-    else if ( $LSM_CHOICE == 3 ) then
-      echo "IMPORTANT: please set LAND_PARAMS: to CN_CLM45 in RC/GEOS_SurfaceGridComp.rc in the experiment directory."
     endif
 else
     set LSM_CHOICE = 1

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1636,7 +1636,7 @@ if( $LSM_BCS == "Icarus-NLv3" ) then
     if( .$LSM_CHOICE == . ) set LSM_CHOICE  = 1
     if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2) then
         echo
-        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} or ${C2}2${CN}!"
+        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1${CN} or ${C2}2${CN}!"
         goto LSM_CHOICE
     else
         echo

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1539,7 +1539,7 @@ if( $LSM_BCS == "Icarus-NLv3" ) then
     if( .$LSM_CHOICE == . ) set LSM_CHOICE  = 1
     if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 ) then
         echo
-        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} or ${C2}2${CN}!"
+        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1${CN} or ${C2}2${CN}!"
         goto LSM_CHOICE
     else
         echo

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1534,26 +1534,22 @@ endif
 # ----------------------
 if( $LSM_BCS == "Icarus-NLv3" ) then
     LSM_CHOICE:
-    echo "Enter the choice of ${C1} Land Surface Model${CN} using: ${C2}1${CN} (Default: Catchment), ${C2}2${CN} (CatchmentCN-CLM4.0 (CN_CLM40)), ${C2}3${CN} (CatchmentCN-CLM4.5 (CN_CLM45))"
+    echo "Enter the choice of ${C1} Land Surface Model${CN} using: ${C2}1${CN} (Default: Catchment) or ${C2}2${CN} (CatchmentCN-CLM4.0 (CN_CLM40))"
     set   LSM_CHOICE = $<
     if( .$LSM_CHOICE == . ) set LSM_CHOICE  = 1
-    if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 &  $LSM_CHOICE != 3 ) then
+    if(  $LSM_CHOICE != 1   &  $LSM_CHOICE != 2 ) then
         echo
-        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} , ${C2}2${CN} or ${C2}3${CN}!"
+        echo "${C1} Catchment Model${CN} must be set equal to ${C2}1{CN} or ${C2}2${CN}!"
         goto LSM_CHOICE
     else
         echo
     endif
     if( $LSM_CHOICE == 1 ) set HIST_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set HIST_CATCHCN = ""
-    if( $LSM_CHOICE == 3 ) set HIST_CATCHCN = ""
     if( $LSM_CHOICE == 1 ) set GCMRUN_CATCHCN = "#DELETE"
     if( $LSM_CHOICE == 2 ) set GCMRUN_CATCHCN = ""
-    if( $LSM_CHOICE == 3 ) set GCMRUN_CATCHCN = ""
     if( $LSM_CHOICE == 2 ) then
       echo "IMPORTANT: please set LAND_PARAMS: to CN_CLM40 in RC/GEOS_SurfaceGridComp.rc in the experiment directory."
-    else if ( $LSM_CHOICE == 3 ) then
-      echo "IMPORTANT: please set LAND_PARAMS: to CN_CLM45 in RC/GEOS_SurfaceGridComp.rc in the experiment directory."
     endif
 else
     set LSM_CHOICE = 1


### PR DESCRIPTION
This PR disables the option for using the Catchment-CN4.5 land model (LSM_CHOICE=3) in GCM simulations. The PR also fixes a minor typo that was present in the error message displayed for invalid values of LSM_CHOICE.

This PR is zero-diff.

Related PRs:
https://github.com/GEOS-ESM/GEOSldas/pull/707
https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/900

cc: @gmao-rreichle , @biljanaorescanin 