### PR TITLE
Do not link unnecessary files!

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -385,7 +385,6 @@ cat << _EOF_ > $FILE
 # ----------------------------------------------------------
 @MERRA2OX_SPECIES/bin/ln -sf $BCSDIR/Shared/pchem.species.CMIP-5.MERRA2OX.197902-201706.z_91x72.nc4 species.data
 
-/bin/ln -sf $BCSDIR/Shared/*bin .
 /bin/ln -sf $BCSDIR/Shared/*c2l*.nc4 .
 
 @DATAOCEAN/bin/ln -sf $BCSDIR/$BCRSLV/visdf_@RES_DATELINE.dat visdf.dat


### PR DESCRIPTION
Welp, my renaming of the branch closed #574 . So I repeat it here:

---

This PR gets rid of unnecessary linking of files, which have this pattern: `*CF0180x6C_TM1440xTM1080_CF0180x6C_DE0360xPE0180.bin`

These files are not needed anymore and removing their links, DOES NOT impact coupled .and. uncoupled runs.
With those links gone, the gcm_run.j generated `scratch` dir is really small (file count!).

Thanks to @atrayano for helping.

cc: @mathomp4, @sdrabenh 