### PR TITLE
Use CMake to determine MPI Stack

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -175,26 +175,8 @@ endif
 #                 Test for Compiler and MPI Setup
 #######################################################################
 
-setenv BASEDIR `awk '{print $2}' $ETCDIR/BASEDIR.rc`
-
-     if ( `echo $BASEDIR | grep -i mvapich`  != '') then
-   set MPI = mvapich
-else if ( `echo $BASEDIR | grep -i mpich`    != '') then
-   set MPI = mpich
-else if ( `echo $BASEDIR | grep -i openmpi`  != '') then
-   set MPI = openmpi
-else if ( `echo $BASEDIR | grep -i hpcx`     != '') then
-   set MPI = openmpi
-else if ( `echo $BASEDIR | grep -i impi`     != '') then
-   set MPI = intelmpi
-else if ( `echo $BASEDIR | grep -i intelmpi` != '') then
-   set MPI = intelmpi
-else if ( `echo $BASEDIR | grep -i mpt`      != '') then
-   set MPI = mpt
-else
-   # Assume default is Intel MPI in case of older baselibs
-   set MPI = intelmpi
-endif
+# Get MPI stack from CMake
+set MPI_STACK = @MPI_STACK@
 
 #######################################################################
 #               Enter Experiment Specific Run Parameters
@@ -2188,7 +2170,7 @@ set RESTART_BY_OSERVER = NO
 /bin/rm -f $HOMDIR/SETENV.commands
 
 
-if( $MPI == openmpi ) then
+if( $MPI_STACK == openmpi ) then
 
 # Open MPI and GEOS has issues with restart writing. Having the
 # oserver write them can be orders of magnitude faster
@@ -2221,7 +2203,7 @@ EOF
 # The below settings seem to be recommended for hybrid
 # systems using MVAPICH but could change
 
-else if( $MPI == mvapich ) then
+else if( $MPI_STACK == mvapich ) then
 
 # MVAPICH and GEOS has issues with restart writing. Having the
 # oserver write them seems to...work
@@ -2234,7 +2216,7 @@ setenv MV2_MPIRUN_TIMEOUT 100
 setenv MV2_GATHERV_SSEND_THRESHOLD 256
 EOF
 
-else if( $MPI == mpt ) then
+else if( $MPI_STACK == mpt ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 
@@ -2274,7 +2256,7 @@ if( $OGCM == TRUE ) then
    set MPT_SHEPHERD = "setenv MPI_SHEPHERD true"
 endif
 
-else if( $MPI == intelmpi ) then
+else if( $MPI_STACK == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_ADJUST_ALLREDUCE 12

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -175,26 +175,8 @@ endif
 #                 Test for Compiler and MPI Setup
 #######################################################################
 
-setenv BASEDIR `awk '{print $2}' $ETCDIR/BASEDIR.rc`
-
-     if ( `echo $BASEDIR | grep -i mvapich`  != '') then
-   set MPI = mvapich
-else if ( `echo $BASEDIR | grep -i mpich`    != '') then
-   set MPI = mpich
-else if ( `echo $BASEDIR | grep -i openmpi`  != '') then
-   set MPI = openmpi
-else if ( `echo $BASEDIR | grep -i hpcx`     != '') then
-   set MPI = openmpi
-else if ( `echo $BASEDIR | grep -i impi`     != '') then
-   set MPI = intelmpi
-else if ( `echo $BASEDIR | grep -i intelmpi` != '') then
-   set MPI = intelmpi
-else if ( `echo $BASEDIR | grep -i mpt`      != '') then
-   set MPI = mpt
-else
-   # Assume default is Intel MPI in case of older baselibs
-   set MPI = intelmpi
-endif
+# Get MPI stack from CMake
+set MPI_STACK = @MPI_STACK@
 
 #######################################################################
 #               Enter Experiment Specific Run Parameters
@@ -457,7 +439,7 @@ if ( $SITE == 'NCCS' ) then
    else
       echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
       echo "   ${C2}sky  (Skylake)${CN}"
-      echo "   ${C2}cas  (Cascade Lake)${CN} (default)"
+      echo "   ${C2}cas  (Cascade Lake) (default)${CN}"
       echo " "
       set MODEL = `echo $<`
       set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
@@ -2218,7 +2200,7 @@ set RESTART_BY_OSERVER = NO
 /bin/rm -f $HOMDIR/SETENV.commands
 
 
-if( $MPI == openmpi ) then
+if( $MPI_STACK == openmpi ) then
 
 # Open MPI and GEOS has issues with restart writing. Having the
 # oserver write them can be orders of magnitude faster
@@ -2251,7 +2233,7 @@ EOF
 # The below settings seem to be recommended for hybrid
 # systems using MVAPICH but could change
 
-else if( $MPI == mvapich ) then
+else if( $MPI_STACK == mvapich ) then
 
 # MVAPICH and GEOS has issues with restart writing. Having the
 # oserver write them seems to...work
@@ -2264,7 +2246,7 @@ setenv MV2_MPIRUN_TIMEOUT 100
 setenv MV2_GATHERV_SSEND_THRESHOLD 256
 EOF
 
-else if( $MPI == mpt ) then
+else if( $MPI_STACK == mpt ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 
@@ -2304,7 +2286,7 @@ if( $OGCM == TRUE ) then
    set MPT_SHEPHERD = "setenv MPI_SHEPHERD true"
 endif
 
-else if( $MPI == intelmpi ) then
+else if( $MPI_STACK == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_ADJUST_ALLREDUCE 12

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -175,26 +175,8 @@ endif
 #                 Test for Compiler and MPI Setup
 #######################################################################
 
-setenv BASEDIR `awk '{print $2}' $ETCDIR/BASEDIR.rc`
-
-     if ( `echo $BASEDIR | grep -i mvapich`  != '') then
-   set MPI = mvapich
-else if ( `echo $BASEDIR | grep -i mpich`    != '') then
-   set MPI = mpich
-else if ( `echo $BASEDIR | grep -i openmpi`  != '') then
-   set MPI = openmpi
-else if ( `echo $BASEDIR | grep -i hpcx`     != '') then
-   set MPI = openmpi
-else if ( `echo $BASEDIR | grep -i impi`     != '') then
-   set MPI = intelmpi
-else if ( `echo $BASEDIR | grep -i intelmpi` != '') then
-   set MPI = intelmpi
-else if ( `echo $BASEDIR | grep -i mpt`      != '') then
-   set MPI = mpt
-else
-   # Assume default is Intel MPI in case of older baselibs
-   set MPI = intelmpi
-endif
+# Get MPI stack from CMake
+set MPI_STACK = @MPI_STACK@
 
 #######################################################################
 #               Enter Experiment Specific Run Parameters

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -457,7 +457,7 @@ if ( $SITE == 'NCCS' ) then
    else
       echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
       echo "   ${C2}sky  (Skylake)${CN}"
-      echo "   ${C2}cas  (Cascade Lake)${CN} (default)"
+      echo "   ${C2}cas  (Cascade Lake) (default)${CN}"
       echo " "
       set MODEL = `echo $<`
       set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
@@ -2389,7 +2389,7 @@ set RESTART_BY_OSERVER = NO
 /bin/rm -f $HOMDIR/SETENV.commands
 
 
-if( $MPI == openmpi ) then
+if( $MPI_STACK == openmpi ) then
 
 # Open MPI and GEOS has issues with restart writing. Having the
 # oserver write them can be orders of magnitude faster
@@ -2422,7 +2422,7 @@ EOF
 # The below settings seem to be recommended for hybrid
 # systems using MVAPICH but could change
 
-else if( $MPI == mvapich ) then
+else if( $MPI_STACK == mvapich ) then
 
 # MVAPICH and GEOS has issues with restart writing. Having the
 # oserver write them seems to...work
@@ -2435,7 +2435,7 @@ setenv MV2_MPIRUN_TIMEOUT 100
 setenv MV2_GATHERV_SSEND_THRESHOLD 256
 EOF
 
-else if( $MPI == mpt ) then
+else if( $MPI_STACK == mpt ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 
@@ -2475,7 +2475,7 @@ if( $OGCM == TRUE ) then
    set MPT_SHEPHERD = "setenv MPI_SHEPHERD true"
 endif
 
-else if( $MPI == intelmpi ) then
+else if( $MPI_STACK == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_ADJUST_ALLREDUCE 12

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -175,26 +175,8 @@ endif
 #                 Test for Compiler and MPI Setup
 #######################################################################
 
-setenv BASEDIR `awk '{print $2}' $ETCDIR/BASEDIR.rc`
-
-     if ( `echo $BASEDIR | grep -i mvapich`  != '') then
-   set MPI = mvapich
-else if ( `echo $BASEDIR | grep -i mpich`    != '') then
-   set MPI = mpich
-else if ( `echo $BASEDIR | grep -i openmpi`  != '') then
-   set MPI = openmpi
-else if ( `echo $BASEDIR | grep -i hpcx`     != '') then
-   set MPI = openmpi
-else if ( `echo $BASEDIR | grep -i impi`     != '') then
-   set MPI = intelmpi
-else if ( `echo $BASEDIR | grep -i intelmpi` != '') then
-   set MPI = intelmpi
-else if ( `echo $BASEDIR | grep -i mpt`      != '') then
-   set MPI = mpt
-else
-   # Assume default is Intel MPI in case of older baselibs
-   set MPI = intelmpi
-endif
+# Get MPI stack from CMake
+set MPI_STACK = @MPI_STACK@
 
 #######################################################################
 #               Enter Experiment Specific Run Parameters
@@ -457,7 +439,7 @@ if ( $SITE == 'NCCS' ) then
    else
       echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
       echo "   ${C2}sky  (Skylake)${CN}"
-      echo "   ${C2}cas  (Cascade Lake)${CN} (default)"
+      echo "   ${C2}cas  (Cascade Lake) (default)${CN}"
       echo " "
       set MODEL = `echo $<`
       set MODEL = `echo $MODEL | tr "[:upper:]" "[:lower:]"`
@@ -2203,7 +2185,7 @@ set RESTART_BY_OSERVER = NO
 /bin/rm -f $HOMDIR/SETENV.commands
 
 
-if( $MPI == openmpi ) then
+if( $MPI_STACK == openmpi ) then
 
 # Open MPI and GEOS has issues with restart writing. Having the
 # oserver write them can be orders of magnitude faster
@@ -2236,7 +2218,7 @@ EOF
 # The below settings seem to be recommended for hybrid
 # systems using MVAPICH but could change
 
-else if( $MPI == mvapich ) then
+else if( $MPI_STACK == mvapich ) then
 
 # MVAPICH and GEOS has issues with restart writing. Having the
 # oserver write them seems to...work
@@ -2249,7 +2231,7 @@ setenv MV2_MPIRUN_TIMEOUT 100
 setenv MV2_GATHERV_SSEND_THRESHOLD 256
 EOF
 
-else if( $MPI == mpt ) then
+else if( $MPI_STACK == mpt ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 
@@ -2289,7 +2271,7 @@ if( $OGCM == TRUE ) then
    set MPT_SHEPHERD = "setenv MPI_SHEPHERD true"
 endif
 
-else if( $MPI == intelmpi ) then
+else if( $MPI_STACK == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_ADJUST_ALLREDUCE 12


### PR DESCRIPTION
This PR uses CMake to determine the MPI stack rather than looking at the content of `$BASEDIR` which builds that use Spack will never fill. 

NOTE 1: This requires ESMA_cmake v3.41.0 which is now in GEOSgcm (see https://github.com/GEOS-ESM/GEOSgcm/pull/752)

NOTE 2: There is still a *lot* of `BASEDIR` hanging around, but this is at least a first step.