### PR TITLE
Patch FP: add missing nitrate output

### DIFF
--- a/HISTORY_FP.rc.03z.tmpl
+++ b/HISTORY_FP.rc.03z.tmpl
@@ -3104,6 +3104,8 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                               'NIFLUXU'    , 'GOCART'  ,
                               'NIFLUXV'    , 'GOCART'  ,
                               'NICMASS'    , 'GOCART'  ,
+                              'NH4SMASS'   , 'GOCART'  ,
+                              'NH4CMASS'   , 'GOCART'  ,
                               ::
 
   inst_30mn_met_c0720sfc+-.format: 'CFIO' ,

--- a/HISTORY_FP.rc.09z.tmpl
+++ b/HISTORY_FP.rc.09z.tmpl
@@ -1778,6 +1778,8 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                               'NIFLUXU'    , 'GOCART'  ,
                               'NIFLUXV'    , 'GOCART'  ,
                               'NICMASS'    , 'GOCART'  ,
+                              'NH4SMASS'   , 'GOCART'  ,
+                              'NH4CMASS'   , 'GOCART'  ,
                               ::
 
   inst3_3d_aer_Nv-.format:     'CFIO' ,

--- a/HISTORY_FP.rc.15z.tmpl
+++ b/HISTORY_FP.rc.15z.tmpl
@@ -3104,6 +3104,8 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                               'NIFLUXU'    , 'GOCART'  ,
                               'NIFLUXV'    , 'GOCART'  ,
                               'NICMASS'    , 'GOCART'  ,
+                              'NH4SMASS'   , 'GOCART'  ,
+                              'NH4CMASS'   , 'GOCART'  ,
                               ::
 
   inst_30mn_met_c0720sfc+-.format: 'CFIO' ,

--- a/HISTORY_FP.rc.21z.tmpl
+++ b/HISTORY_FP.rc.21z.tmpl
@@ -3105,6 +3105,8 @@ COLLECTIONS: 'inst3_3d_asm_Np-'
                               'NIFLUXU'    , 'GOCART'  ,
                               'NIFLUXV'    , 'GOCART'  ,
                               'NICMASS'    , 'GOCART'  ,
+                              'NH4SMASS'   , 'GOCART'  ,
+                              'NH4CMASS'   , 'GOCART'  ,
                               ::
 
   inst_30mn_met_c0720sfc+-.format: 'CFIO' ,


### PR DESCRIPTION
this follows discussion w/ Allie and others about OpenDap missing output from forecasts.

This is aimed at the branch GEOS-FP.

Matt: could you please protect this branch.
Scott: I would like this to be tagged as follows:  v1.5.6.3-GEOS-FP-1  - since this is a v-tag; I am not sure I can myself tag it. Perhaps Matt can tell me.