### PR TITLE
Added LWC and IWC to HISTORY_R21C

### DIFF
--- a/HISTORY_R21C.rc.tmpl
+++ b/HISTORY_R21C.rc.tmpl
@@ -252,6 +252,8 @@ COLLECTIONS: 'asm_inst_1hr_glo_L@HIST_IMx@HIST_JM_p48'
                                                             'TQV'            , 'AGCM'     ,
                                                             'TQI'            , 'AGCM'     ,
                                                             'TQL'            , 'AGCM'     ,
+                                                            'IWC'            , 'MOIST'    ,
+                                                            'LWC'            , 'MOIST'    ,
                                                             'TOX'            , 'AGCM'     ,
                                                             'TO3'            , 'PCHEM'    ,
                                                             'HOURNORAIN'     , 'MOIST'    ,


### PR DESCRIPTION
The current HISTORY_R21C includes the column integrated total liquid and ice variables, TQL and TQI, which include both cloud and falling rain.  This PR adds the cloud-only variables, LWC and IWC, to collection asm_inst_1hr_glo_L@HIST_IMx@HIST_JM_slv.