### PR TITLE
Minor update to GMI and StratChem setup scripts

### DIFF
--- a/gmichem_setup
+++ b/gmichem_setup
@@ -3035,6 +3035,10 @@ cat           $HOMDIR/dummy | sed -e "/SATSIM_DT/a GMICHEM_DT: $GMICHEM_DT" > $f
 /bin/mv $file $HOMDIR/dummy
 cat           $HOMDIR/dummy | sed -e "/GMICHEM_DT/a $USE_AEROSOL_NN" > $file
 
+# Comment out a PCHEM reference
+/bin/mv $file $HOMDIR/dummy
+cat           $HOMDIR/dummy | sed -e "s/PCHEM::OX/#PCHEM::OX/" > $file
+
 ## Change from GF to RAS for now:
 #/bin/mv $file $HOMDIR/dummy
 #cat           $HOMDIR/dummy | sed -e "s/CONVPAR_OPTION: GF/CONVPAR_OPTION: RAS/" > $file

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -2761,9 +2761,14 @@ if( $OGCM == TRUE ) if(! -e $EXPDIR/RESTART ) mkdir -p $EXPDIR/RESTART
 
 if( $OGCM == TRUE  & "$OCNMODEL" != "MIT" ) /bin/mv $HOMDIR/plotocn.j       $EXPDIR/plot
 
-## Modify AGCM.rc
-## --------------
-#set file = $HOMDIR/AGCM.rc
+# Modify AGCM.rc
+# --------------
+set file = $HOMDIR/AGCM.rc
+
+# Comment out a PCHEM reference
+/bin/mv $file $HOMDIR/dummy
+cat           $HOMDIR/dummy | sed -e "s/PCHEM::OX/#PCHEM::OX/" > $file
+
 #
 ## Change from GF to RAS for now:
 #/bin/mv $file $HOMDIR/dummy
@@ -2780,7 +2785,7 @@ if( $OGCM == TRUE  & "$OCNMODEL" != "MIT" ) /bin/mv $HOMDIR/plotocn.j       $EXP
 ## For future:  sed commands to insert important GF flags:
 ##/CONVPAR_OPTION/a USE_TRACER_TRANSP: 1
 ##/CONVPAR_OPTION/a USE_TRACER_SCAVEN: 0
-#/bin/rm -f    $HOMDIR/dummy
+/bin/rm -f    $HOMDIR/dummy
 
 #######################################################################
 #       Modify RC Directory for LM and GOCART.data/GOCART Options


### PR DESCRIPTION
Comment out a reference to PCHEM::OX MOIST tendency, in AGCM.rc, when setting up a GMI or StratChem experiment.
(When the tendency term is present, and PCHEM is not running, the model crashes.)

Currently GMI and StratChem do not use the scavenging functionality of MOIST.
If GMI uses it in the future, we will change the reference PCHEM::OX to GMICHEM::OX .