### PR TITLE
Updates for non-Baselibs runs

### DIFF
--- a/gcm_archive.j
+++ b/gcm_archive.j
@@ -33,7 +33,10 @@ setenv SITE             @SITE
 setenv GEOSBIN          @GEOSBIN
 
 source $GEOSBIN/g5_modules
-setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}
+if ( $?BASEDIR ) then
+    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 #######################################################################
 #                         Archive Commands

--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -31,8 +31,11 @@ setenv GEOSBIN          @GEOSBIN
 setenv GEOSETC          @GEOSETC
 setenv GEOSUTIL         @GEOSSRC
 
-@NATIVE_BUILD source $GEOSBIN/g5_modules
-@NATIVE_BUILD setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib:${GEOSDIR}/lib
+source $GEOSBIN/g5_modules
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${GEOSDIR}/lib
+if ( $?BASEDIR ) then
+   setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 setenv RUN_CMD "@RUN_CMD"
 

--- a/gcm_moveplot.j
+++ b/gcm_moveplot.j
@@ -34,7 +34,10 @@ setenv GEOSBIN          @GEOSBIN
 setenv GEOSUTIL         @GEOSSRC
 
 source $GEOSBIN/g5_modules
-setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}
+if ( $?BASEDIR ) then
+    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 #######################################################################
 #             Experiment Specific Environment Variables

--- a/gcm_plot.tmpl
+++ b/gcm_plot.tmpl
@@ -34,7 +34,10 @@ setenv GEOSBIN          @GEOSBIN
 setenv GEOSUTIL         @GEOSSRC
 
 source $GEOSBIN/g5_modules
-setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}
+if ( $?BASEDIR ) then
+    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 #######################################################################
 #             Experiment Specific Environment Variables

--- a/gcm_post.j
+++ b/gcm_post.j
@@ -36,7 +36,10 @@ setenv GEOSUTIL         @GEOSSRC
 setenv BATCHNAME       "@POST_N"
 
 source $GEOSBIN/g5_modules
-setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}
+if ( $?BASEDIR ) then
+    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 if( $?SLURM_NTASKS ) then
       setenv RUN_CMD "@RUN_CMD"

--- a/gcm_quickstat.j
+++ b/gcm_quickstat.j
@@ -29,7 +29,10 @@ setenv GEOSBIN          @GEOSBIN
 setenv GEOSUTIL         @GEOSSRC
 
 source $GEOSBIN/g5_modules
-setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}
+if ( $?BASEDIR ) then
+    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 #######################################################################
 #                         Quickstat Commands

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -90,7 +90,11 @@ setenv GEOSDIR @GEOSDIR
 setenv GEOSBIN @GEOSBIN
 
 source $GEOSBIN/g5_modules
-setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib:${GEOSDIR}/lib
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${GEOSDIR}/lib
+# We only add BASEDIR to the @LD_LIBRARY_PATH_CMD if BASEDIR is defined (i.e., not running with Spack)
+if ( $?BASEDIR ) then
+    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 setenv RUN_CMD "@RUN_CMD"
 

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -33,7 +33,11 @@ setenv GEOSETC          @GEOSETC
 setenv GEOSUTIL         @GEOSSRC
 
 source $GEOSBIN/g5_modules
-setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib:${GEOSDIR}/lib
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${GEOSDIR}/lib
+# We only add BASEDIR to the @LD_LIBRARY_PATH_CMD if BASEDIR is defined (i.e., not running with Spack)
+if ( $?BASEDIR ) then
+    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 setenv RUN_CMD "@RUN_CMD"
 

--- a/gcm_run_benchmark.j
+++ b/gcm_run_benchmark.j
@@ -33,7 +33,11 @@ setenv GEOSETC          @GEOSETC
 setenv GEOSUTIL         @GEOSSRC
 
 source $GEOSBIN/g5_modules
-setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib:${GEOSDIR}/lib
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${GEOSDIR}/lib
+# We only add BASEDIR to the @LD_LIBRARY_PATH_CMD if BASEDIR is defined (i.e., not running with Spack)
+if ( $?BASEDIR ) then
+    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 setenv RUN_CMD "@RUN_CMD"
 

--- a/scm_run.j
+++ b/scm_run.j
@@ -15,7 +15,11 @@ setenv GEOSETC          @INSTALLDIR/etc
 setenv GEOSUTIL         @INSTALLDIR
 
 source $GEOSBIN/g5_modules
-setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib:${GEOSDIR}/lib
+setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${GEOSDIR}/lib
+# We only add BASEDIR to the @LD_LIBRARY_PATH_CMD if BASEDIR is defined (i.e., not running with Spack)
+if ( $?BASEDIR ) then
+    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+endif
 
 setenv RUN_CMD "$GEOSBIN/esma_mpirun -np "
 


### PR DESCRIPTION
In testing building and running GEOSgcm with Spack as libraries instead of Baselibs, it was found that you can't do things like:

```
setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${BASEDIR}/${ARCH}/lib:${GEOSDIR}/lib
```

if `BASEDIR` is not defined.

So, we only add `BASEDIR` if it is defined in the environment.