### PR TITLE
Fix up stretched grid tags

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1224,7 +1224,7 @@ if( $AGCM_IM == "c270" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF0270x6C
+     set ATMOS_RES = CF0270x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1246,7 +1246,7 @@ if( $AGCM_IM == "c540" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF0540x6C
+     set ATMOS_RES = CF0540x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1268,7 +1268,7 @@ if( $AGCM_IM == "c1080" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF1080x6C
+     set ATMOS_RES = CF1080x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1290,7 +1290,7 @@ if( $AGCM_IM == "c1536" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000005
      set NUM_SGMT = 1
-     set ATMOS_RES = CF1536x6C
+     set ATMOS_RES = CF1536x6C-SG002
      set POST_NDS = 16
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1312,7 +1312,7 @@ if( $AGCM_IM == "c2160" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF2160x6C
+     set ATMOS_RES = CF2160x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1235,7 +1235,7 @@ if( $AGCM_IM == "c270" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF0270x6C
+     set ATMOS_RES = CF0270x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1258,7 +1258,7 @@ if( $AGCM_IM == "c540" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF0540x6C
+     set ATMOS_RES = CF0540x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1281,7 +1281,7 @@ if( $AGCM_IM == "c1080" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF1080x6C
+     set ATMOS_RES = CF1080x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1304,7 +1304,7 @@ if( $AGCM_IM == "c1536" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000005
      set NUM_SGMT = 1
-     set ATMOS_RES = CF1536x6C
+     set ATMOS_RES = CF1536x6C-SG002
      set POST_NDS = 16
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1327,7 +1327,7 @@ if( $AGCM_IM == "c2160" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF2160x6C
+     set ATMOS_RES = CF2160x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1332,7 +1332,7 @@ if( $AGCM_IM == "c270" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF0270x6C
+     set ATMOS_RES = CF0270x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1355,7 +1355,7 @@ if( $AGCM_IM == "c540" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF0540x6C
+     set ATMOS_RES = CF0540x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1378,7 +1378,7 @@ if( $AGCM_IM == "c1080" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF1080x6C
+     set ATMOS_RES = CF1080x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1401,7 +1401,7 @@ if( $AGCM_IM == "c1536" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000005
      set NUM_SGMT = 1
-     set ATMOS_RES = CF1536x6C
+     set ATMOS_RES = CF1536x6C-SG002
      set POST_NDS = 16
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1424,7 +1424,7 @@ if( $AGCM_IM == "c2160" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF2160x6C
+     set ATMOS_RES = CF2160x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1235,7 +1235,7 @@ if( $AGCM_IM == "c270" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF0270x6C
+     set ATMOS_RES = CF0270x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1258,7 +1258,7 @@ if( $AGCM_IM == "c540" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF0540x6C
+     set ATMOS_RES = CF0540x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1281,7 +1281,7 @@ if( $AGCM_IM == "c1080" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF1080x6C
+     set ATMOS_RES = CF1080x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1304,7 +1304,7 @@ if( $AGCM_IM == "c1536" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000005
      set NUM_SGMT = 1
-     set ATMOS_RES = CF1536x6C
+     set ATMOS_RES = CF1536x6C-SG002
      set POST_NDS = 16
      set USE_SHMEM = 1
      set CONUS = ''
@@ -1327,7 +1327,7 @@ if( $AGCM_IM == "c2160" ) then
      set NUM_READERS = 6
      set JOB_SGMT = 00000001
      set NUM_SGMT = 1
-     set ATMOS_RES = CF2160x6C
+     set ATMOS_RES = CF2160x6C-SG001
      set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''


### PR DESCRIPTION
In doing some testing of the stretched grid, I found that the tags set by the setup scripts weren't quite right. Turns out it was fairly simple to fix up once I figured out where to look.

