### PR TITLE
Update ESMF CMake target to ESMF::ESMF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
 ecbuild_add_executable (
   TARGET GEOSgcm.x
   SOURCES GEOSgcm.F90
-  LIBS GEOSgcm_GridComp esmf OpenMP::OpenMP_Fortran
+  LIBS GEOSgcm_GridComp ESMF::ESMF OpenMP::OpenMP_Fortran
   )
 
 ecbuild_add_executable (
   TARGET idfupd.x
   SOURCES idfupd.F90
-  LIBS GEOSgcm_GridComp esmf
+  LIBS GEOSgcm_GridComp ESMF::ESMF
   )
 
 set (CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_FLAGS_VECT}")


### PR DESCRIPTION
This PR updates the ESMF CMake target to `ESMF::ESMF` which is the correct canonical target name for ESMF. This is necessary for Spack compatibility. NOTE: This requires ESMF 8.6.1 or later.