### PR TITLE
v12: Update NX, NY, DT, Intel MPI Flags, OpenMP regress

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# Global Editor Config for MAPL
+#
+# This is an ini style configuration. See http://editorconfig.org/ for more information on this file.
+#
+# Top level editor config.
+root = true
+
+# Always use Unix style new lines with new line ending on every file and trim whitespace
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Python: PEP8 defines 4 spaces for indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# YAML format, 2 spaces
+[{*.yaml,*.yml}]
+indent_style = space
+indent_size = 2
+
+# CMake (from KitWare: https://github.com/Kitware/CMake/blob/master/.editorconfig)
+[{CMakeLists.txt,*.cmake,*.rst}]
+indent_style = space
+indent_size = 2
+
+# Markdown
+[*.md]
+trim_trailing_whitespace = true
+indent_style = space

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -1041,6 +1041,13 @@ endif
 # Set OMP_NUM_THREADS
 # -------------------
 setenv OMP_NUM_THREADS 1
+if ($OMP_NUM_THREADS > 1) then
+  setenv OMP_STACKSIZE 16M
+  setenv KMP_AFFINITY compact
+  echo OMP_STACKSIZE    $OMP_STACKSIZE
+  echo KMP_AFFINITY     $KMP_AFFINITY
+endif
+echo OMP_NUM_THREADS $OMP_NUM_THREADS
 
 # Run GEOSgcm.x
 # -------------

--- a/gcm_setup
+++ b/gcm_setup
@@ -1120,8 +1120,8 @@ if( $AGCM_IM == "c360" ) then
      set POST_NDS = 12
 endif
 if( $AGCM_IM == "c720" ) then
-     set       DT = 360
-     set  LONG_DT = 720
+     set       DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
@@ -1147,7 +1147,7 @@ if( $AGCM_IM == "c1120" ) then
      set OCEAN_DT = 3600
      set AGCM_IM  = 1120
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 80
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1167,7 +1167,7 @@ if( $AGCM_IM == "c1440" ) then
      set OCEAN_DT = 1800
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 60
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1295,9 +1295,9 @@ endif
 if( $AGCM_IM == "c1536" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set AGCM_IM  = 1536
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 60
@@ -1317,9 +1317,9 @@ endif
 if( $AGCM_IM == "c2160" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set AGCM_IM  = 2160
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 80
@@ -1339,9 +1339,9 @@ endif
 if( $AGCM_IM == "c4320" ) then
      set       DT = 30
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set AGCM_IM  = 4320
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 80

--- a/gcm_setup
+++ b/gcm_setup
@@ -1492,10 +1492,10 @@ if(  $LSM_CHOICE != 1 & $LSM_CHOICE != 2 ) then
 else
     echo
 endif
-if( $LSM_CHOICE == 1 ) then 
+if( $LSM_CHOICE == 1 ) then
     set HIST_CATCHCN   = "#DELETE"
     set GCMRUN_CATCHCN = "#DELETE"
-else if( $LSM_CHOICE == 2 ) then 
+else if( $LSM_CHOICE == 2 ) then
     set HIST_CATCHCN   = ""
     set GCMRUN_CATCHCN = ""
 endif
@@ -1706,6 +1706,12 @@ else
    set NUM_BACKEND_PES   = 0
 endif
 
+# For OpenMP regression testing, we need a variable that is half
+# the number of CPUs per node and also two times the number of nodes
+set NODES_TWICE = `expr $NODES \* 2`
+set NCPUS_PER_NODE_HALF = `expr $NCPUS_PER_NODE / 2`
+
+
 # Here we need to convert POST_NDS to total tasks. Using 16 cores
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
@@ -1742,6 +1748,7 @@ if( $SITE == 'NAS' ) then
               setenv     RUN_Q  "PBS -q ${QTYPE}"                                                                          # batch queue name for gcm_run.j
               setenv     RUN_P  "PBS -l select=${NODES}:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}" # PE Configuration for gcm_run.j
               setenv    RUN_FP  "PBS -l select=24:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}"       # PE Configuration for gcm_forecast.j
+              setenv REGRESS_P  "PBS -l select=${NODES_TWICE}:ncpus=${NCPUS_PER_NODE_HALF}:mpiprocs=${NCPUS_PER_NODE_HALF}:model=${MODEL}" # PE Configuration for gcm_regress.j
               setenv    POST_Q  "PBS -q normal"                                                                            # batch queue name for gcm_post.j
               setenv    PLOT_Q  "PBS -q normal"                                                                            # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "PBS -q normal"                                                                            # batch queue name for gcm_moveplot.j
@@ -1789,6 +1796,7 @@ else if( $SITE == 'NCCS' ) then
               setenv    RUN_Q   "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_run.j
               setenv    RUN_P   "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_run.j
               setenv    RUN_FP  "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_forecast.j
+              setenv    REGRESS_P   "SBATCH --nodes=${NODES_TWICE} --ntasks-per-node=${NCPUS_PER_NODE_HALF}" # PE Configuration for gcm_regress.j
               setenv    POST_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_post.j
               setenv    PLOT_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_moveplot.j
@@ -1833,6 +1841,7 @@ else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
               setenv RUN_Q     "SBATCH --constraint=${MODEL}"                              # batch queue name for gcm_run.j
               setenv RUN_P   "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_run.j
               setenv RUN_FP  "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_forecast.j
+              setenv REGRESS_P   "SBATCH --nodes=${NODES_TWICE} --ntasks-per-node=${NCPUS_PER_NODE_HALF}" # PE Configuration for gcm_regress.j
               setenv POST_Q  NULL                                                          # batch queue name for gcm_post.j
               setenv PLOT_Q  NULL                                                          # batch queue name for gcm_plot.j
               setenv MOVE_Q  NULL                                                          # batch queue name for gcm_moveplot.j
@@ -1871,6 +1880,7 @@ else
               setenv  RUN_Q     NULL                                                   # batch queue name for gcm_run.j
               setenv  RUN_P     NULL                                                   # PE Configuration for gcm_run.j
               setenv  RUN_FP    NULL                                                   # PE Configuration for gcm_forecast.j
+              setenv  REGRESS_P NULL                                                   # PE Configuration for gcm_regress.j
               setenv    POST_Q  NULL                                                   # batch queue name for gcm_post.j
               setenv    PLOT_Q  NULL                                                   # batch queue name for gcm_plot.j
               setenv    MOVE_Q  NULL                                                   # batch queue name for gcm_moveplot.j
@@ -2295,6 +2305,7 @@ s?@RUN_T?$RUN_T?g
 s?@RUN_P?$RUN_P?g
 s?@RUN_FP?$RUN_FP?g
 s?@RUN_Q?$RUN_Q?g
+s?@REGRESS_P?$REGRESS_P?g
 s?@POST_N?$POST_N?g
 s?@POST_T?$POST_T?g
 s?@POST_P?$POST_P?g

--- a/gcm_setup
+++ b/gcm_setup
@@ -436,8 +436,8 @@ if ( $SITE == 'NCCS' ) then
       if( $MODEL != 'mil' ) goto ASKPROC
 
       if ($MODEL == 'mil') then
-         # We save a couple processes for the kernel
-         set NCPUS_PER_NODE = 126
+         # For even division, we use 120 cores per node
+         set NCPUS_PER_NODE = 120
       endif
    else
       echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
@@ -456,13 +456,8 @@ if ( $SITE == 'NCCS' ) then
       if ($MODEL == 'sky') then
          set NCPUS_PER_NODE = 40
       else if ($MODEL == 'cas') then
-         # NCCS currently recommends that users do not run with
-         # 48 cores per node on SCU16 due to OS issues and
-         # recommends that CPU-intensive works run with 46 or less
-         # cores. As 45 is a multiple of 3, it's the best value
-         # that doesn't waste too much
-         #set NCPUS_PER_NODE = 48
-         set NCPUS_PER_NODE = 45
+         # We use 40 of 46 cores per node for even division
+         set NCPUS_PER_NODE = 40
       endif
    endif
 
@@ -508,15 +503,18 @@ else if ( $SITE == 'NAS' ) then
    if ($MODEL == 'has') then
       set NCPUS_PER_NODE = 24
    else if ($MODEL == 'bro') then
-      set NCPUS_PER_NODE = 28
+      # we use 24 of 28 cores per node for even division
+      set NCPUS_PER_NODE = 24
    else if ($MODEL == 'sky_ele') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'cas_ait') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'rom_ait') then
-      set NCPUS_PER_NODE = 128
+      # we use 120 of 128 cores per node for even division
+      set NCPUS_PER_NODE = 120
    else if ($MODEL == 'mil_ait') then
-      set NCPUS_PER_NODE = 128
+      # we use 120 of 128 cores per node for even division
+      set NCPUS_PER_NODE = 120
    endif
 
 else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
@@ -1006,7 +1004,7 @@ if( $AGCM_IM ==  "c12" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c24" ) then
-     set       DT = 3600
+     set       DT = 1800
      set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
@@ -1024,14 +1022,14 @@ if( $AGCM_IM ==  "c24" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c48" ) then
-     set       DT = 1800
-     set  LONG_DT = 1800
+     set       DT = 1200
+     set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set AGCM_IM  = 48
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 4
+     set       NX = 6
      set       NY = `expr $NX \* 6`
      set   HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = 180
@@ -1043,7 +1041,7 @@ if( $AGCM_IM ==  "c48" ) then
 endif
 if( $AGCM_IM ==  "c90" ) then
      set       DT = 900
-     set  LONG_DT = 900
+     set  LONG_DT = 1800
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set AGCM_IM  = 90
@@ -1062,7 +1060,7 @@ if( $AGCM_IM ==  "c90" ) then
         endif
         set OCEAN_DT = $DT
      else
-        set  NX = 3
+        set  NX = 10
         set  NY = `expr $NX \* 6`
         set OCEAN_DT = 3600
      endif
@@ -1076,7 +1074,7 @@ if( $AGCM_IM ==  "c90" ) then
 endif
 if( $AGCM_IM ==  "c180" ) then
      set       DT = 600
-     set  LONG_DT = 600
+     set  LONG_DT = 1200
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set AGCM_IM  = 180
@@ -1092,7 +1090,7 @@ if( $AGCM_IM ==  "c180" ) then
         endif
         set OCEAN_DT = $DT
      else
-        set  NX = 6
+        set  NX = 20
         set  NY = `expr $NX \* 6`
         set OCEAN_DT = 3600
      endif
@@ -1107,13 +1105,13 @@ if( $AGCM_IM ==  "c180" ) then
 endif
 if( $AGCM_IM == "c360" ) then
      set       DT = 450
-     set  LONG_DT = 450
+     set  LONG_DT = 900
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set AGCM_IM  = 360
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 12
+     set       NX = 30
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1126,13 +1124,13 @@ if( $AGCM_IM == "c360" ) then
 endif
 if( $AGCM_IM == "c720" ) then
      set       DT = 360
-     set  LONG_DT = 360
+     set  LONG_DT = 720
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set AGCM_IM  = 720
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 24
+     set       NX = 40
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1146,7 +1144,7 @@ if( $AGCM_IM == "c720" ) then
 endif
 if( $AGCM_IM == "c1120" ) then
      set       DT = 300
-     set  LONG_DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
@@ -1165,14 +1163,14 @@ if( $AGCM_IM == "c1120" ) then
      set USE_SHMEM = 1
 endif
 if( $AGCM_IM == "c1440" ) then
-     set       DT = 150
-     set  LONG_DT = 300
+     set       DT = 225
+     set  LONG_DT = 450
      set SOLAR_DT = 1800
      set IRRAD_DT = 1800
      set OCEAN_DT = 1800
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 48
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1185,14 +1183,14 @@ if( $AGCM_IM == "c1440" ) then
      set USE_SHMEM = 1
 endif
 if( $AGCM_IM == "c2880" ) then
-     set       DT = 75
+     set       DT = 150
      set  LONG_DT = 300
      set SOLAR_DT = 1800
      set IRRAD_DT = 1800
      set OCEAN_DT = 1800
      set AGCM_IM  = 2880
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 96
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1207,14 +1205,14 @@ if( $AGCM_IM == "c2880" ) then
      set CONVPAR_OPTION = NONE
 endif
 if( $AGCM_IM == "c5760" ) then
-     set       DT = 60
+     set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set AGCM_IM  = 5760
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 192
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1233,13 +1231,13 @@ set CONUS = '#'
 set STRETCH_FACTOR = ""
 if( $AGCM_IM == "c270" ) then
      set       DT = 600
-     set  LONG_DT = 600
+     set  LONG_DT = 1200
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set AGCM_IM  = 270
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 18
+     set       NX = 20
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1255,13 +1253,13 @@ if( $AGCM_IM == "c270" ) then
 endif
 if( $AGCM_IM == "c540" ) then
      set       DT = 300
-     set  LONG_DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set AGCM_IM  = 540
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 36
+     set       NX = 30
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1283,7 +1281,7 @@ if( $AGCM_IM == "c1080" ) then
      set OCEAN_DT = 1800
      set AGCM_IM  = 1080
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 72
+     set       NX = 40
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1300,12 +1298,12 @@ endif
 if( $AGCM_IM == "c1536" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set AGCM_IM  = 1536
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 96
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1322,13 +1320,13 @@ endif
 if( $AGCM_IM == "c2160" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set AGCM_IM  = 2160
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 120
-     set       NY = 864
+     set       NX = 80
+     set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -1344,12 +1342,12 @@ endif
 if( $AGCM_IM == "c4320" ) then
      set       DT = 30
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set AGCM_IM  = 4320
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 240
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -2226,9 +2224,6 @@ endif
 else if( $MPI_STACK == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
-setenv I_MPI_ADJUST_ALLREDUCE 12
-setenv I_MPI_ADJUST_GATHERV 3
-
 # This flag prints out the Intel MPI state. Uncomment if needed
 #setenv I_MPI_DEBUG 9
 EOF
@@ -2238,8 +2233,13 @@ EOF
 # specific compared to the above adjustments
 if ( $SITE == 'NCCS' ) then
 
-if ("$BUILT_ON_SLES15" == "TRUE") then
+# Some flags we know work on SLES15 and Milan (see below)
+# For safety, we keep the old SLES12 flags for that system
+#
+# NOTE: When Cascade Lake is on SLES15, the following flags
+# might need to be Milan only
 
+if ("$BUILT_ON_SLES15" == "TRUE") then
 cat >> $HOMDIR/SETENV.commands << EOF
 setenv I_MPI_FABRICS shm:ofi
 setenv I_MPI_OFI_PROVIDER psm3
@@ -2248,6 +2248,9 @@ EOF
 else
 
 cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
+
 setenv I_MPI_SHM_HEAP_VSIZE 512
 setenv PSM2_MEMORY large
 EOF

--- a/gcm_setup
+++ b/gcm_setup
@@ -37,20 +37,17 @@ setenv ARCH `uname -s`
 setenv NODE `uname -n`
 
 if ($ARCH == Darwin) then
-   set FINDPATH = realpath
    set PRELOAD_COMMAND = 'DYLD_INSERT_LIBRARIES'
    set LD_LIBRARY_PATH_CMD = 'DYLD_LIBRARY_PATH'
    # On macOS we seem to need to call mpirun directly and not use esma_mpirun
    # For some reason SIP does not let the libraries be preloaded
    set RUN_CMD = 'mpirun -np '
 else
-   set FINDPATH = 'readlink -f'
    set PRELOAD_COMMAND = 'LD_PRELOAD'
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
 endif
-set GCMSETUP = `$FINDPATH $0`
-set BINDIR   = `dirname $GCMSETUP`
+set BINDIR   = `pwd -L`
 set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -436,8 +436,8 @@ if ( $SITE == 'NCCS' ) then
       if( $MODEL != 'mil' ) goto ASKPROC
 
       if ($MODEL == 'mil') then
-         # We save a couple processes for the kernel
-         set NCPUS_PER_NODE = 126
+         # For even division, we use 120 cores per node
+         set NCPUS_PER_NODE = 120
       endif
    else
       echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
@@ -456,13 +456,8 @@ if ( $SITE == 'NCCS' ) then
       if ($MODEL == 'sky') then
          set NCPUS_PER_NODE = 40
       else if ($MODEL == 'cas') then
-         # NCCS currently recommends that users do not run with
-         # 48 cores per node on SCU16 due to OS issues and
-         # recommends that CPU-intensive works run with 46 or less
-         # cores. As 45 is a multiple of 3, it's the best value
-         # that doesn't waste too much
-         #set NCPUS_PER_NODE = 48
-         set NCPUS_PER_NODE = 45
+         # We use 40 of 46 cores per node for even division
+         set NCPUS_PER_NODE = 40
       endif
    endif
 
@@ -508,15 +503,18 @@ else if ( $SITE == 'NAS' ) then
    if ($MODEL == 'has') then
       set NCPUS_PER_NODE = 24
    else if ($MODEL == 'bro') then
-      set NCPUS_PER_NODE = 28
+      # we use 24 of 28 cores per node for even division
+      set NCPUS_PER_NODE = 24
    else if ($MODEL == 'sky_ele') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'cas_ait') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'rom_ait') then
-      set NCPUS_PER_NODE = 128
+      # we use 120 of 128 cores per node for even division
+      set NCPUS_PER_NODE = 120
    else if ($MODEL == 'mil_ait') then
-      set NCPUS_PER_NODE = 128
+      # we use 120 of 128 cores per node for even division
+      set NCPUS_PER_NODE = 120
    endif
 
 else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
@@ -1007,7 +1005,7 @@ if( $AGCM_IM ==  "c12" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c24" ) then
-     set       DT = 3600
+     set       DT = 1800
      set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
@@ -1026,15 +1024,15 @@ if( $AGCM_IM ==  "c24" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c48" ) then
-     set       DT = 1800
-     set  LONG_DT = 1800
+     set       DT = 1200
+     set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 48
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 4
+     set       NX = 6
      set       NY = `expr $NX \* 6`
      set   HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = 180
@@ -1046,7 +1044,7 @@ if( $AGCM_IM ==  "c48" ) then
 endif
 if( $AGCM_IM ==  "c90" ) then
      set       DT = 900
-     set  LONG_DT = 900
+     set  LONG_DT = 1800
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set AGCM_IM  = 90
@@ -1065,7 +1063,7 @@ if( $AGCM_IM ==  "c90" ) then
         endif
         set OCEAN_DT = $DT
      else
-        set  NX = 3
+        set  NX = 10
         set  NY = `expr $NX \* 6`
         set OCEAN_DT = 3600
      endif
@@ -1080,7 +1078,7 @@ if( $AGCM_IM ==  "c90" ) then
 endif
 if( $AGCM_IM ==  "c180" ) then
      set       DT = 600
-     set  LONG_DT = 600
+     set  LONG_DT = 1200
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
@@ -1097,7 +1095,7 @@ if( $AGCM_IM ==  "c180" ) then
         endif
         set OCEAN_DT = $DT
      else
-        set  NX = 6
+        set  NX = 20
         set  NY = `expr $NX \* 6`
         set OCEAN_DT = 3600
      endif
@@ -1112,14 +1110,14 @@ if( $AGCM_IM ==  "c180" ) then
 endif
 if( $AGCM_IM == "c360" ) then
      set       DT = 450
-     set  LONG_DT = 450
+     set  LONG_DT = 900
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 360
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 12
+     set       NX = 30
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1132,14 +1130,14 @@ if( $AGCM_IM == "c360" ) then
 endif
 if( $AGCM_IM == "c720" ) then
      set       DT = 360
-     set  LONG_DT = 360
+     set  LONG_DT = 720
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 720
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 24
+     set       NX = 40
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1153,7 +1151,7 @@ if( $AGCM_IM == "c720" ) then
 endif
 if( $AGCM_IM == "c1120" ) then
      set       DT = 300
-     set  LONG_DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
@@ -1173,15 +1171,15 @@ if( $AGCM_IM == "c1120" ) then
      set USE_SHMEM = 1
 endif
 if( $AGCM_IM == "c1440" ) then
-     set       DT = 150
-     set  LONG_DT = 300
+     set       DT = 225
+     set  LONG_DT = 450
      set SOLAR_DT = 1800
      set IRRAD_DT = 1800
      set OCEAN_DT = 1800
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 48
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1194,7 +1192,7 @@ if( $AGCM_IM == "c1440" ) then
      set USE_SHMEM = 1
 endif
 if( $AGCM_IM == "c2880" ) then
-     set       DT = 75
+     set       DT = 150
      set  LONG_DT = 300
      set SOLAR_DT = 1800
      set IRRAD_DT = 1800
@@ -1202,7 +1200,7 @@ if( $AGCM_IM == "c2880" ) then
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 2880
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 96
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1217,15 +1215,15 @@ if( $AGCM_IM == "c2880" ) then
      set CONVPAR_OPTION = NONE
 endif
 if( $AGCM_IM == "c5760" ) then
-     set       DT = 60
+     set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 5760
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 192
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1244,14 +1242,14 @@ set CONUS = '#'
 set STRETCH_FACTOR = ""
 if( $AGCM_IM == "c270" ) then
      set       DT = 600
-     set  LONG_DT = 600
+     set  LONG_DT = 1200
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 270
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 18
+     set       NX = 20
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1267,14 +1265,14 @@ if( $AGCM_IM == "c270" ) then
 endif
 if( $AGCM_IM == "c540" ) then
      set       DT = 300
-     set  LONG_DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 540
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 36
+     set       NX = 30
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1297,7 +1295,7 @@ if( $AGCM_IM == "c1080" ) then
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1080
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 72
+     set       NX = 40
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1314,13 +1312,13 @@ endif
 if( $AGCM_IM == "c1536" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1536
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 96
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1337,14 +1335,14 @@ endif
 if( $AGCM_IM == "c2160" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 2160
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 120
-     set       NY = 864
+     set       NX = 80
+     set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -1360,13 +1358,13 @@ endif
 if( $AGCM_IM == "c4320" ) then
      set       DT = 30
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 4320
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 240
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -2258,9 +2256,6 @@ endif
 else if( $MPI_STACK == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
-setenv I_MPI_ADJUST_ALLREDUCE 12
-setenv I_MPI_ADJUST_GATHERV 3
-
 # This flag prints out the Intel MPI state. Uncomment if needed
 #setenv I_MPI_DEBUG 9
 EOF
@@ -2270,7 +2265,24 @@ EOF
 # specific compared to the above adjustments
 if ( $SITE == 'NCCS' ) then
 
+# Some flags we know work on SLES15 and Milan (see below)
+# For safety, we keep the old SLES12 flags for that system
+#
+# NOTE: When Cascade Lake is on SLES15, the following flags
+# might need to be Milan only
+
+if ("$BUILT_ON_SLES15" == "TRUE") then
 cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_FABRICS shm:ofi
+setenv I_MPI_OFI_PROVIDER psm3
+EOF
+
+else
+
+cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
+
 setenv I_MPI_SHM_HEAP_VSIZE 512
 setenv PSM2_MEMORY large
 EOF
@@ -2285,34 +2297,6 @@ setenv I_MPI_EXTRA_FILESYSTEM_FORCE gpfs
 EOF
 
 endif # if NOT Singularity
-
-# Testing by Bill Putman found these to be
-# useful flags with Intel MPI on SLES15 on the
-# Milan nodes.
-# Note 1: Testing by NCCS shows the PSM3 provider
-# runs on the Infiniband fabric. Tests show it runs
-# up to C720.
-# Note 2: When the Cascade Lakes are moved to
-# SLES15, these will need to be Milan-only flags
-# as Intel MPI will probably work just fine with
-# Intel chips.
-if ("$BUILT_ON_SLES15" == "TRUE") then
-cat >> $HOMDIR/SETENV.commands << EOF
-setenv I_MPI_FALLBACK 0
-setenv I_MPI_FABRICS ofi
-setenv I_MPI_OFI_PROVIDER psm3
-setenv I_MPI_ADJUST_SCATTER 2
-setenv I_MPI_ADJUST_SCATTERV 2
-setenv I_MPI_ADJUST_GATHER 2
-setenv I_MPI_ADJUST_GATHERV 3
-setenv I_MPI_ADJUST_ALLGATHER 3
-setenv I_MPI_ADJUST_ALLGATHERV 3
-setenv I_MPI_ADJUST_ALLREDUCE 12
-setenv I_MPI_ADJUST_REDUCE 10
-setenv I_MPI_ADJUST_BCAST 11
-setenv I_MPI_ADJUST_REDUCE_SCATTER 4
-setenv I_MPI_ADJUST_BARRIER 9
-EOF
 
 endif # if SLES15
 

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1509,10 +1509,10 @@ if(  $LSM_CHOICE != 1 & $LSM_CHOICE != 2 ) then
 else
     echo
 endif
-if( $LSM_CHOICE == 1 ) then 
+if( $LSM_CHOICE == 1 ) then
     set HIST_CATCHCN   = "#DELETE"
     set GCMRUN_CATCHCN = "#DELETE"
-else if( $LSM_CHOICE == 2 ) then 
+else if( $LSM_CHOICE == 2 ) then
     set HIST_CATCHCN   = ""
     set GCMRUN_CATCHCN = ""
 endif
@@ -1738,6 +1738,12 @@ else
    set NUM_BACKEND_PES   = 0
 endif
 
+# For OpenMP regression testing, we need a variable that is half
+# the number of CPUs per node and also two times the number of nodes
+set NODES_TWICE = `expr $NODES \* 2`
+set NCPUS_PER_NODE_HALF = `expr $NCPUS_PER_NODE / 2`
+
+
 # Here we need to convert POST_NDS to total tasks. Using 16 cores
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
@@ -1774,6 +1780,7 @@ if( $SITE == 'NAS' ) then
               setenv     RUN_Q  "PBS -q ${QTYPE}"                                                                          # batch queue name for gcm_run.j
               setenv     RUN_P  "PBS -l select=${NODES}:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}" # PE Configuration for gcm_run.j
               setenv    RUN_FP  "PBS -l select=24:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}"       # PE Configuration for gcm_forecast.j
+              setenv REGRESS_P  "PBS -l select=${NODES_TWICE}:ncpus=${NCPUS_PER_NODE_HALF}:mpiprocs=${NCPUS_PER_NODE_HALF}:model=${MODEL}" # PE Configuration for gcm_regress.j
               setenv    POST_Q  "PBS -q normal"                                                                            # batch queue name for gcm_post.j
               setenv    PLOT_Q  "PBS -q normal"                                                                            # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "PBS -q normal"                                                                            # batch queue name for gcm_moveplot.j
@@ -1821,6 +1828,7 @@ else if( $SITE == 'NCCS' ) then
               setenv    RUN_Q   "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_run.j
               setenv    RUN_P   "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_run.j
               setenv    RUN_FP  "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_forecast.j
+              setenv    REGRESS_P   "SBATCH --nodes=${NODES_TWICE} --ntasks-per-node=${NCPUS_PER_NODE_HALF}" # PE Configuration for gcm_regress.j
               setenv    POST_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_post.j
               setenv    PLOT_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_moveplot.j
@@ -1865,6 +1873,7 @@ else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
               setenv RUN_Q     "SBATCH --constraint=${MODEL}"                              # batch queue name for gcm_run.j
               setenv RUN_P   "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_run.j
               setenv RUN_FP  "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_forecast.j
+              setenv REGRESS_P   "SBATCH --nodes=${NODES_TWICE} --ntasks-per-node=${NCPUS_PER_NODE_HALF}" # PE Configuration for gcm_regress.j
               setenv POST_Q  NULL                                                          # batch queue name for gcm_post.j
               setenv PLOT_Q  NULL                                                          # batch queue name for gcm_plot.j
               setenv MOVE_Q  NULL                                                          # batch queue name for gcm_moveplot.j
@@ -1903,6 +1912,7 @@ else
               setenv  RUN_Q     NULL                                                   # batch queue name for gcm_run.j
               setenv  RUN_P     NULL                                                   # PE Configuration for gcm_run.j
               setenv  RUN_FP    NULL                                                   # PE Configuration for gcm_forecast.j
+              setenv  REGRESS_P NULL                                                   # PE Configuration for gcm_regress.j
               setenv    POST_Q  NULL                                                   # batch queue name for gcm_post.j
               setenv    PLOT_Q  NULL                                                   # batch queue name for gcm_plot.j
               setenv    MOVE_Q  NULL                                                   # batch queue name for gcm_moveplot.j
@@ -2327,6 +2337,7 @@ s?@RUN_T?$RUN_T?g
 s?@RUN_P?$RUN_P?g
 s?@RUN_FP?$RUN_FP?g
 s?@RUN_Q?$RUN_Q?g
+s?@REGRESS_P?$REGRESS_P?g
 s?@POST_N?$POST_N?g
 s?@POST_T?$POST_T?g
 s?@POST_P?$POST_P?g

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1126,8 +1126,8 @@ if( $AGCM_IM == "c360" ) then
      set POST_NDS = 12
 endif
 if( $AGCM_IM == "c720" ) then
-     set       DT = 360
-     set  LONG_DT = 720
+     set       DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
@@ -1155,7 +1155,7 @@ if( $AGCM_IM == "c1120" ) then
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1120
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 80
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1176,7 +1176,7 @@ if( $AGCM_IM == "c1440" ) then
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 60
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1309,9 +1309,9 @@ endif
 if( $AGCM_IM == "c1536" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1536
      set AGCM_JM  = `expr $AGCM_IM \* 6`
@@ -1332,9 +1332,9 @@ endif
 if( $AGCM_IM == "c2160" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 2160
      set AGCM_JM  = `expr $AGCM_IM \* 6`
@@ -1355,9 +1355,9 @@ endif
 if( $AGCM_IM == "c4320" ) then
      set       DT = 30
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set GEOSCHEMCHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 4320
      set AGCM_JM  = `expr $AGCM_IM \* 6`

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -37,20 +37,17 @@ setenv ARCH `uname -s`
 setenv NODE `uname -n`
 
 if ($ARCH == Darwin) then
-   set FINDPATH = realpath
    set PRELOAD_COMMAND = 'DYLD_INSERT_LIBRARIES'
    set LD_LIBRARY_PATH_CMD = 'DYLD_LIBRARY_PATH'
    # On macOS we seem to need to call mpirun directly and not use esma_mpirun
    # For some reason SIP does not let the libraries be preloaded
    set RUN_CMD = 'mpirun -np '
 else
-   set FINDPATH = 'readlink -f'
    set PRELOAD_COMMAND = 'LD_PRELOAD'
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
 endif
-set GCMSETUP = `$FINDPATH $0`
-set BINDIR   = `dirname $GCMSETUP`
+set BINDIR   = `pwd -L`
 set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -436,8 +436,8 @@ if ( $SITE == 'NCCS' ) then
       if( $MODEL != 'mil' ) goto ASKPROC
 
       if ($MODEL == 'mil') then
-         # We save a couple processes for the kernel
-         set NCPUS_PER_NODE = 126
+         # For even division, we use 120 cores per node
+         set NCPUS_PER_NODE = 120
       endif
    else
       echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
@@ -456,13 +456,8 @@ if ( $SITE == 'NCCS' ) then
       if ($MODEL == 'sky') then
          set NCPUS_PER_NODE = 40
       else if ($MODEL == 'cas') then
-         # NCCS currently recommends that users do not run with
-         # 48 cores per node on SCU16 due to OS issues and
-         # recommends that CPU-intensive works run with 46 or less
-         # cores. As 45 is a multiple of 3, it's the best value
-         # that doesn't waste too much
-         #set NCPUS_PER_NODE = 48
-         set NCPUS_PER_NODE = 45
+         # We use 40 of 46 cores per node for even division
+         set NCPUS_PER_NODE = 40
       endif
    endif
 
@@ -508,15 +503,18 @@ else if ( $SITE == 'NAS' ) then
    if ($MODEL == 'has') then
       set NCPUS_PER_NODE = 24
    else if ($MODEL == 'bro') then
-      set NCPUS_PER_NODE = 28
+      # we use 24 of 28 cores per node for even division
+      set NCPUS_PER_NODE = 24
    else if ($MODEL == 'sky_ele') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'cas_ait') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'rom_ait') then
-      set NCPUS_PER_NODE = 128
+      # we use 120 of 128 cores per node for even division
+      set NCPUS_PER_NODE = 120
    else if ($MODEL == 'mil_ait') then
-      set NCPUS_PER_NODE = 128
+      # we use 120 of 128 cores per node for even division
+      set NCPUS_PER_NODE = 120
    endif
 
 else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
@@ -557,11 +555,6 @@ else
       exit 1
    endif
 endif
-
-# Per previous gmichem_setup, reduce cores-per-node by 1
-# ------------------------------------------------------
-
-@ NCPUS_PER_NODE = ${NCPUS_PER_NODE} - 1
 
 #######################################################################
 #                         Check for COUPLED Ocean
@@ -1104,7 +1097,7 @@ if( $AGCM_IM ==  "c12" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c24" ) then
-     set       DT = 3600
+     set       DT = 1800
      set SOLAR_DT  = `expr $DT \* 2`
      set IRRAD_DT  = `expr $DT \* 2`
      set OCEAN_DT = $IRRAD_DT
@@ -1123,7 +1116,7 @@ if( $AGCM_IM ==  "c24" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c48" ) then
-     set       DT = 1800
+     set       DT = 1200
      set SOLAR_DT  = `expr $DT \* 2`
      set IRRAD_DT  = `expr $DT \* 2`
      set OCEAN_DT = $IRRAD_DT
@@ -1161,7 +1154,7 @@ if( $AGCM_IM ==  "c90" ) then
         endif
         set OCEAN_DT = $DT
      else
-        set  NX = 3
+        set  NX = 10
         set  NY = `expr $NX \* 6`
         set OCEAN_DT = $IRRAD_DT
      endif
@@ -1194,7 +1187,7 @@ if( $AGCM_IM ==  "c180" ) then
         endif
         set OCEAN_DT = $DT
      else
-        set  NX = 6
+        set  NX = 20
         set  NY = `expr $NX \* 6`
         set OCEAN_DT = $IRRAD_DT
      endif
@@ -1216,7 +1209,7 @@ if( $AGCM_IM == "c360" ) then
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 360
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 12
+     set       NX = 30
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1236,7 +1229,7 @@ if( $AGCM_IM == "c720" ) then
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 720
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 24
+     set       NX = 40
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1250,10 +1243,11 @@ if( $AGCM_IM == "c720" ) then
 endif
 if( $AGCM_IM == "c1120" ) then
      set       DT = 300
-     set  LONG_DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
+     set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1120
      set AGCM_JM  = `expr $AGCM_IM \* 6`
      set       NX = 80
@@ -1269,7 +1263,7 @@ if( $AGCM_IM == "c1120" ) then
      set USE_SHMEM = 1
 endif
 if( $AGCM_IM == "c1440" ) then
-     set       DT = 150
+     set       DT = 225
      set SOLAR_DT  = `expr $DT \* 2`
      set IRRAD_DT  = `expr $DT \* 2`
      set OCEAN_DT = $IRRAD_DT
@@ -1277,7 +1271,7 @@ if( $AGCM_IM == "c1440" ) then
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 48
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1290,16 +1284,16 @@ if( $AGCM_IM == "c1440" ) then
      set USE_SHMEM = 1
 endif
 if( $AGCM_IM == "c2880" ) then
-     set       DT = 75
+     set       DT = 150
+     set  LONG_DT = 300
      set SOLAR_DT = 1800
      set IRRAD_DT = 1800
      set OCEAN_DT = $IRRAD_DT
-     set  LONG_DT = 300
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 2880
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 96
-     set       NY = `expr $NX \* 6 \* 2`
+     set       NX = 80
+     set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -1313,15 +1307,15 @@ if( $AGCM_IM == "c2880" ) then
      set CONVPAR_OPTION = NONE
 endif
 if( $AGCM_IM == "c5760" ) then
-     set       DT = 60
+     set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 5760
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 192
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1340,15 +1334,15 @@ set CONUS = '#'
 set STRETCH_FACTOR = ""
 if( $AGCM_IM == "c270" ) then
      set       DT = 600
+     set  LONG_DT = 1200
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = $IRRAD_DT
-     set  LONG_DT = $DT
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 270
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 8
-     set       NY = `expr $NX \* 6 \* 2`
+     set       NX = 20
+     set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -1363,15 +1357,15 @@ if( $AGCM_IM == "c270" ) then
 endif
 if( $AGCM_IM == "c540" ) then
      set       DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = $IRRAD_DT
-     set  LONG_DT = $DT
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 540
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 14
-     set       NY = `expr $NX \* 6 \* 2`
+     set       NX = 30
+     set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -1386,15 +1380,15 @@ if( $AGCM_IM == "c540" ) then
 endif
 if( $AGCM_IM == "c1080" ) then
      set       DT = 150
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = $IRRAD_DT
      set  LONG_DT = 300
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = $IRRAD_DT
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1080
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 22
-     set       NY = `expr $NX \* 6 \* 2`
+     set       NX = 40
+     set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -1409,38 +1403,38 @@ if( $AGCM_IM == "c1080" ) then
 endif
 if( $AGCM_IM == "c1536" ) then
      set       DT = 75
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = $IRRAD_DT
      set  LONG_DT = 300
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = $IRRAD_DT
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1536
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 36
-     set       NY = `expr $NX \* 6 \* 2`
+     set       NX = 60
+     set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
      set NUM_READERS = 6
-     set JOB_SGMT = 00000005
+     set JOB_SGMT = 00000001
      set NUM_SGMT = 1
      set ATMOS_RES = CF1536x6C-SG002
-     set POST_NDS = 16
+     set POST_NDS = 32
      set USE_SHMEM = 1
      set CONUS = ''
      set STRETCH_FACTOR = 3.0
 endif
 if( $AGCM_IM == "c2160" ) then
      set       DT = 75
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = $IRRAD_DT
      set  LONG_DT = 300
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = $IRRAD_DT
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 2160
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 40
-     set       NY = `expr $NX \* 6 \* 2`
+     set       NX = 80
+     set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -1456,12 +1450,13 @@ endif
 if( $AGCM_IM == "c4320" ) then
      set       DT = 30
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
+     set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 4320
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 240
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -2427,9 +2422,6 @@ endif
 else if( $MPI_STACK == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
-setenv I_MPI_ADJUST_ALLREDUCE 12
-setenv I_MPI_ADJUST_GATHERV 3
-
 # This flag prints out the Intel MPI state. Uncomment if needed
 #setenv I_MPI_DEBUG 9
 EOF
@@ -2439,7 +2431,24 @@ EOF
 # specific compared to the above adjustments
 if ( $SITE == 'NCCS' ) then
 
+# Some flags we know work on SLES15 and Milan (see below)
+# For safety, we keep the old SLES12 flags for that system
+#
+# NOTE: When Cascade Lake is on SLES15, the following flags
+# might need to be Milan only
+
+if ("$BUILT_ON_SLES15" == "TRUE") then
 cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_FABRICS shm:ofi
+setenv I_MPI_OFI_PROVIDER psm3
+EOF
+
+else
+
+cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
+
 setenv I_MPI_SHM_HEAP_VSIZE 512
 setenv PSM2_MEMORY large
 EOF
@@ -2454,34 +2463,6 @@ setenv I_MPI_EXTRA_FILESYSTEM_FORCE gpfs
 EOF
 
 endif # if NOT Singularity
-
-# Testing by Bill Putman found these to be
-# useful flags with Intel MPI on SLES15 on the
-# Milan nodes.
-# Note 1: Testing by NCCS shows the PSM3 provider
-# runs on the Infiniband fabric. Tests show it runs
-# up to C720.
-# Note 2: When the Cascade Lakes are moved to
-# SLES15, these will need to be Milan-only flags
-# as Intel MPI will probably work just fine with
-# Intel chips.
-if ("$BUILT_ON_SLES15" == "TRUE") then
-cat >> $HOMDIR/SETENV.commands << EOF
-setenv I_MPI_FALLBACK 0
-setenv I_MPI_FABRICS ofi
-setenv I_MPI_OFI_PROVIDER psm3
-setenv I_MPI_ADJUST_SCATTER 2
-setenv I_MPI_ADJUST_SCATTERV 2
-setenv I_MPI_ADJUST_GATHER 2
-setenv I_MPI_ADJUST_GATHERV 3
-setenv I_MPI_ADJUST_ALLGATHER 3
-setenv I_MPI_ADJUST_ALLGATHERV 3
-setenv I_MPI_ADJUST_ALLREDUCE 12
-setenv I_MPI_ADJUST_REDUCE 10
-setenv I_MPI_ADJUST_BCAST 11
-setenv I_MPI_ADJUST_REDUCE_SCATTER 4
-setenv I_MPI_ADJUST_BARRIER 9
-EOF
 
 endif # if SLES15
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1218,7 +1218,7 @@ if( $AGCM_IM == "c360" ) then
      set POST_NDS = 12
 endif
 if( $AGCM_IM == "c720" ) then
-     set       DT = 360
+     set       DT = 300
      set SOLAR_DT  = `expr $DT \* 2`
      set IRRAD_DT  = `expr $DT \* 2`
      set OCEAN_DT = $IRRAD_DT
@@ -1247,7 +1247,7 @@ if( $AGCM_IM == "c1120" ) then
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1120
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 80
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1268,7 +1268,7 @@ if( $AGCM_IM == "c1440" ) then
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 60
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1401,8 +1401,8 @@ endif
 if( $AGCM_IM == "c1536" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
      set OCEAN_DT = $IRRAD_DT
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 1536
@@ -1424,8 +1424,8 @@ endif
 if( $AGCM_IM == "c2160" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
      set OCEAN_DT = $IRRAD_DT
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 2160
@@ -1447,9 +1447,9 @@ endif
 if( $AGCM_IM == "c4320" ) then
      set       DT = 30
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set GMICHEM_DT = `expr $DT \* 2`
      set AGCM_IM  = 4320
      set AGCM_JM  = `expr $AGCM_IM \* 6`

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1601,10 +1601,10 @@ if(  $LSM_CHOICE != 1 & $LSM_CHOICE != 2 ) then
 else
     echo
 endif
-if( $LSM_CHOICE == 1 ) then 
+if( $LSM_CHOICE == 1 ) then
     set HIST_CATCHCN   = "#DELETE"
     set GCMRUN_CATCHCN = "#DELETE"
-else if( $LSM_CHOICE == 2 ) then 
+else if( $LSM_CHOICE == 2 ) then
     set HIST_CATCHCN   = ""
     set GCMRUN_CATCHCN = ""
 endif
@@ -1898,6 +1898,12 @@ else
    set NUM_BACKEND_PES   = 0
 endif
 
+# For OpenMP regression testing, we need a variable that is half
+# the number of CPUs per node and also two times the number of nodes
+set NODES_TWICE = `expr $NODES \* 2`
+set NCPUS_PER_NODE_HALF = `expr $NCPUS_PER_NODE / 2`
+
+
 # Here we need to convert POST_NDS to total tasks. Using 16 cores
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
@@ -1934,6 +1940,7 @@ if( $SITE == 'NAS' ) then
               setenv     RUN_Q  "PBS -q ${QTYPE}"                                                                          # batch queue name for gcm_run.j
               setenv     RUN_P  "PBS -l select=${NODES}:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}" # PE Configuration for gcm_run.j
               setenv    RUN_FP  "PBS -l select=24:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}"       # PE Configuration for gcm_forecast.j
+              setenv REGRESS_P  "PBS -l select=${NODES_TWICE}:ncpus=${NCPUS_PER_NODE_HALF}:mpiprocs=${NCPUS_PER_NODE_HALF}:model=${MODEL}" # PE Configuration for gcm_regress.j
               setenv    POST_Q  "PBS -q normal"                                                                            # batch queue name for gcm_post.j
               setenv    PLOT_Q  "PBS -q normal"                                                                            # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "PBS -q normal"                                                                            # batch queue name for gcm_moveplot.j
@@ -1981,6 +1988,7 @@ else if( $SITE == 'NCCS' ) then
               setenv    RUN_Q   "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_run.j
               setenv    RUN_P   "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_run.j
               setenv    RUN_FP  "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_forecast.j
+              setenv    REGRESS_P   "SBATCH --nodes=${NODES_TWICE} --ntasks-per-node=${NCPUS_PER_NODE_HALF}" # PE Configuration for gcm_regress.j
               setenv    POST_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_post.j
               setenv    PLOT_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_moveplot.j
@@ -2025,6 +2033,7 @@ else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
               setenv RUN_Q     "SBATCH --constraint=${MODEL}"                              # batch queue name for gcm_run.j
               setenv RUN_P   "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_run.j
               setenv RUN_FP  "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_forecast.j
+              setenv REGRESS_P   "SBATCH --nodes=${NODES_TWICE} --ntasks-per-node=${NCPUS_PER_NODE_HALF}" # PE Configuration for gcm_regress.j
               setenv POST_Q  NULL                                                          # batch queue name for gcm_post.j
               setenv PLOT_Q  NULL                                                          # batch queue name for gcm_plot.j
               setenv MOVE_Q  NULL                                                          # batch queue name for gcm_moveplot.j
@@ -2063,6 +2072,7 @@ else
               setenv  RUN_Q     NULL                                                   # batch queue name for gcm_run.j
               setenv  RUN_P     NULL                                                   # PE Configuration for gcm_run.j
               setenv  RUN_FP    NULL                                                   # PE Configuration for gcm_forecast.j
+              setenv  REGRESS_P NULL                                                   # PE Configuration for gcm_regress.j
               setenv    POST_Q  NULL                                                   # batch queue name for gcm_post.j
               setenv    PLOT_Q  NULL                                                   # batch queue name for gcm_plot.j
               setenv    MOVE_Q  NULL                                                   # batch queue name for gcm_moveplot.j
@@ -2493,6 +2503,7 @@ s?@RUN_T?$RUN_T?g
 s?@RUN_P?$RUN_P?g
 s?@RUN_FP?$RUN_FP?g
 s?@RUN_Q?$RUN_Q?g
+s?@REGRESS_P?$REGRESS_P?g
 s?@POST_N?$POST_N?g
 s?@POST_T?$POST_T?g
 s?@POST_P?$POST_P?g

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -37,20 +37,17 @@ setenv ARCH `uname -s`
 setenv NODE `uname -n`
 
 if ($ARCH == Darwin) then
-   set FINDPATH = realpath
    set PRELOAD_COMMAND = 'DYLD_INSERT_LIBRARIES'
    set LD_LIBRARY_PATH_CMD = 'DYLD_LIBRARY_PATH'
    # On macOS we seem to need to call mpirun directly and not use esma_mpirun
    # For some reason SIP does not let the libraries be preloaded
    set RUN_CMD = 'mpirun -np '
 else
-   set FINDPATH = 'readlink -f'
    set PRELOAD_COMMAND = 'LD_PRELOAD'
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
 endif
-set GCMSETUP = `$FINDPATH $0`
-set BINDIR   = `dirname $GCMSETUP`
+set BINDIR   = `pwd -L`
 set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -436,8 +436,8 @@ if ( $SITE == 'NCCS' ) then
       if( $MODEL != 'mil' ) goto ASKPROC
 
       if ($MODEL == 'mil') then
-         # We save a couple processes for the kernel
-         set NCPUS_PER_NODE = 126
+         # For even division, we use 120 cores per node
+         set NCPUS_PER_NODE = 120
       endif
    else
       echo "Enter the ${C1}Processor Type${CN} you wish to run on:"
@@ -456,13 +456,8 @@ if ( $SITE == 'NCCS' ) then
       if ($MODEL == 'sky') then
          set NCPUS_PER_NODE = 40
       else if ($MODEL == 'cas') then
-         # NCCS currently recommends that users do not run with
-         # 48 cores per node on SCU16 due to OS issues and
-         # recommends that CPU-intensive works run with 46 or less
-         # cores. As 45 is a multiple of 3, it's the best value
-         # that doesn't waste too much
-         #set NCPUS_PER_NODE = 48
-         set NCPUS_PER_NODE = 45
+         # We use 40 of 46 cores per node for even division
+         set NCPUS_PER_NODE = 40
       endif
    endif
 
@@ -508,15 +503,18 @@ else if ( $SITE == 'NAS' ) then
    if ($MODEL == 'has') then
       set NCPUS_PER_NODE = 24
    else if ($MODEL == 'bro') then
-      set NCPUS_PER_NODE = 28
+      # we use 24 of 28 cores per node for even division
+      set NCPUS_PER_NODE = 24
    else if ($MODEL == 'sky_ele') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'cas_ait') then
       set NCPUS_PER_NODE = 40
    else if ($MODEL == 'rom_ait') then
-      set NCPUS_PER_NODE = 128
+      # we use 120 of 128 cores per node for even division
+      set NCPUS_PER_NODE = 120
    else if ($MODEL == 'mil_ait') then
-      set NCPUS_PER_NODE = 128
+      # we use 120 of 128 cores per node for even division
+      set NCPUS_PER_NODE = 120
    endif
 
 else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
@@ -1007,7 +1005,7 @@ if( $AGCM_IM ==  "c12" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c24" ) then
-     set       DT = 3600
+     set       DT = 1800
      set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
@@ -1026,8 +1024,8 @@ if( $AGCM_IM ==  "c24" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c48" ) then
-     set       DT = 1800
-     set  LONG_DT = 1800
+     set       DT = 1200
+     set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = $IRRAD_DT
@@ -1046,7 +1044,7 @@ if( $AGCM_IM ==  "c48" ) then
 endif
 if( $AGCM_IM ==  "c90" ) then
      set       DT = 900
-     set  LONG_DT = 900
+     set  LONG_DT = 1800
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set AGCM_IM  = 90
@@ -1065,7 +1063,7 @@ if( $AGCM_IM ==  "c90" ) then
         endif
         set OCEAN_DT = $DT
      else
-        set  NX = 3
+        set  NX = 10
         set  NY = `expr $NX \* 6`
         set OCEAN_DT = 3600
      endif
@@ -1080,7 +1078,7 @@ if( $AGCM_IM ==  "c90" ) then
 endif
 if( $AGCM_IM ==  "c180" ) then
      set       DT = 600
-     set  LONG_DT = 600
+     set  LONG_DT = 1200
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set SC_SPLIT = 1
@@ -1097,7 +1095,7 @@ if( $AGCM_IM ==  "c180" ) then
         endif
         set OCEAN_DT = $DT
      else
-        set  NX = 6
+        set  NX = 20
         set  NY = `expr $NX \* 6`
         set OCEAN_DT = 3600
      endif
@@ -1112,14 +1110,14 @@ if( $AGCM_IM ==  "c180" ) then
 endif
 if( $AGCM_IM == "c360" ) then
      set       DT = 450
-     set  LONG_DT = 450
+     set  LONG_DT = 900
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = $IRRAD_DT
      set SC_SPLIT = 1
      set AGCM_IM  = 360
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 12
+     set       NX = 30
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1132,14 +1130,14 @@ if( $AGCM_IM == "c360" ) then
 endif
 if( $AGCM_IM == "c720" ) then
      set       DT = 360
-     set  LONG_DT = 360
+     set  LONG_DT = 720
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set SC_SPLIT = 1
      set AGCM_IM  = 720
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 24
+     set       NX = 40
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1153,7 +1151,7 @@ if( $AGCM_IM == "c720" ) then
 endif
 if( $AGCM_IM == "c1120" ) then
      set       DT = 300
-     set  LONG_DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
@@ -1173,15 +1171,15 @@ if( $AGCM_IM == "c1120" ) then
      set USE_SHMEM = 1
 endif
 if( $AGCM_IM == "c1440" ) then
-     set       DT = 150
-     set  LONG_DT = 300
+     set       DT = 225
+     set  LONG_DT = 450
      set SOLAR_DT = 1800
      set IRRAD_DT = 1800
      set OCEAN_DT = 1800
      set SC_SPLIT = 1
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 48
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1194,15 +1192,15 @@ if( $AGCM_IM == "c1440" ) then
      set USE_SHMEM = 1
 endif
 if( $AGCM_IM == "c2880" ) then
-     set       DT = 75
+     set       DT = 150
      set  LONG_DT = 300
      set SOLAR_DT = 1800
      set IRRAD_DT = 1800
-     set OCEAN_DT = 3600
+     set OCEAN_DT = 1800
      set SC_SPLIT = 1
      set AGCM_IM  = 2880
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 96
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1217,15 +1215,15 @@ if( $AGCM_IM == "c2880" ) then
      set CONVPAR_OPTION = NONE
 endif
 if( $AGCM_IM == "c5760" ) then
-     set       DT = 60
+     set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set SC_SPLIT = 1
      set AGCM_IM  = 5760
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 192
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1244,14 +1242,14 @@ set CONUS = '#'
 set STRETCH_FACTOR = ""
 if( $AGCM_IM == "c270" ) then
      set       DT = 600
-     set  LONG_DT = 600
+     set  LONG_DT = 1200
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set SC_SPLIT = 1
      set AGCM_IM  = 270
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 18
+     set       NX = 20
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1267,14 +1265,14 @@ if( $AGCM_IM == "c270" ) then
 endif
 if( $AGCM_IM == "c540" ) then
      set       DT = 300
-     set  LONG_DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
      set SC_SPLIT = 1
      set AGCM_IM  = 540
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 36
+     set       NX = 30
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1297,7 +1295,7 @@ if( $AGCM_IM == "c1080" ) then
      set SC_SPLIT = 1
      set AGCM_IM  = 1080
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 72
+     set       NX = 40
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1314,13 +1312,13 @@ endif
 if( $AGCM_IM == "c1536" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set SC_SPLIT = 1
      set AGCM_IM  = 1536
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 96
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1337,14 +1335,14 @@ endif
 if( $AGCM_IM == "c2160" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set SC_SPLIT = 1
      set AGCM_IM  = 2160
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 120
-     set       NY = 864
+     set       NX = 80
+     set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
      set HIST_JM  = `expr $AGCM_IM \* 2 + 1`
@@ -1360,13 +1358,13 @@ endif
 if( $AGCM_IM == "c4320" ) then
      set       DT = 30
      set  LONG_DT = 300
-     set SOLAR_DT = 900
-     set IRRAD_DT = 900
-     set OCEAN_DT = 900
+     set SOLAR_DT = 1800
+     set IRRAD_DT = 1800
+     set OCEAN_DT = 1800
      set SC_SPLIT = 1
      set AGCM_IM  = 4320
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 240
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -2243,9 +2241,6 @@ endif
 else if( $MPI_STACK == intelmpi ) then
 
 cat > $HOMDIR/SETENV.commands << EOF
-setenv I_MPI_ADJUST_ALLREDUCE 12
-setenv I_MPI_ADJUST_GATHERV 3
-
 # This flag prints out the Intel MPI state. Uncomment if needed
 #setenv I_MPI_DEBUG 9
 EOF
@@ -2255,7 +2250,24 @@ EOF
 # specific compared to the above adjustments
 if ( $SITE == 'NCCS' ) then
 
+# Some flags we know work on SLES15 and Milan (see below)
+# For safety, we keep the old SLES12 flags for that system
+#
+# NOTE: When Cascade Lake is on SLES15, the following flags
+# might need to be Milan only
+
+if ("$BUILT_ON_SLES15" == "TRUE") then
 cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_FABRICS shm:ofi
+setenv I_MPI_OFI_PROVIDER psm3
+EOF
+
+else
+
+cat >> $HOMDIR/SETENV.commands << EOF
+setenv I_MPI_ADJUST_ALLREDUCE 12
+setenv I_MPI_ADJUST_GATHERV 3
+
 setenv I_MPI_SHM_HEAP_VSIZE 512
 setenv PSM2_MEMORY large
 EOF
@@ -2270,34 +2282,6 @@ setenv I_MPI_EXTRA_FILESYSTEM_FORCE gpfs
 EOF
 
 endif # if NOT Singularity
-
-# Testing by Bill Putman found these to be
-# useful flags with Intel MPI on SLES15 on the
-# Milan nodes.
-# Note 1: Testing by NCCS shows the PSM3 provider
-# runs on the Infiniband fabric. Tests show it runs
-# up to C720.
-# Note 2: When the Cascade Lakes are moved to
-# SLES15, these will need to be Milan-only flags
-# as Intel MPI will probably work just fine with
-# Intel chips.
-if ("$BUILT_ON_SLES15" == "TRUE") then
-cat >> $HOMDIR/SETENV.commands << EOF
-setenv I_MPI_FALLBACK 0
-setenv I_MPI_FABRICS ofi
-setenv I_MPI_OFI_PROVIDER psm3
-setenv I_MPI_ADJUST_SCATTER 2
-setenv I_MPI_ADJUST_SCATTERV 2
-setenv I_MPI_ADJUST_GATHER 2
-setenv I_MPI_ADJUST_GATHERV 3
-setenv I_MPI_ADJUST_ALLGATHER 3
-setenv I_MPI_ADJUST_ALLGATHERV 3
-setenv I_MPI_ADJUST_ALLREDUCE 12
-setenv I_MPI_ADJUST_REDUCE 10
-setenv I_MPI_ADJUST_BCAST 11
-setenv I_MPI_ADJUST_REDUCE_SCATTER 4
-setenv I_MPI_ADJUST_BARRIER 9
-EOF
 
 endif # if SLES15
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1126,8 +1126,8 @@ if( $AGCM_IM == "c360" ) then
      set POST_NDS = 12
 endif
 if( $AGCM_IM == "c720" ) then
-     set       DT = 360
-     set  LONG_DT = 720
+     set       DT = 300
+     set  LONG_DT = 600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
      set OCEAN_DT = 3600
@@ -1155,7 +1155,7 @@ if( $AGCM_IM == "c1120" ) then
      set SC_SPLIT = 1
      set AGCM_IM  = 1120
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 80
+     set       NX = 60
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1176,7 +1176,7 @@ if( $AGCM_IM == "c1440" ) then
      set SC_SPLIT = 1
      set AGCM_IM  = 1440
      set AGCM_JM  = `expr $AGCM_IM \* 6`
-     set       NX = 60
+     set       NX = 80
      set       NY = `expr $NX \* 6`
      set HYDROSTATIC = $USE_HYDROSTATIC
      set HIST_IM  = `expr $AGCM_IM \* 4`
@@ -1309,9 +1309,9 @@ endif
 if( $AGCM_IM == "c1536" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set SC_SPLIT = 1
      set AGCM_IM  = 1536
      set AGCM_JM  = `expr $AGCM_IM \* 6`
@@ -1332,9 +1332,9 @@ endif
 if( $AGCM_IM == "c2160" ) then
      set       DT = 75
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set SC_SPLIT = 1
      set AGCM_IM  = 2160
      set AGCM_JM  = `expr $AGCM_IM \* 6`
@@ -1355,9 +1355,9 @@ endif
 if( $AGCM_IM == "c4320" ) then
      set       DT = 30
      set  LONG_DT = 300
-     set SOLAR_DT = 1800
-     set IRRAD_DT = 1800
-     set OCEAN_DT = 1800
+     set SOLAR_DT = 900
+     set IRRAD_DT = 900
+     set OCEAN_DT = 900
      set SC_SPLIT = 1
      set AGCM_IM  = 4320
      set AGCM_JM  = `expr $AGCM_IM \* 6`

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1509,10 +1509,10 @@ if(  $LSM_CHOICE != 1 & $LSM_CHOICE != 2 ) then
 else
     echo
 endif
-if( $LSM_CHOICE == 1 ) then 
+if( $LSM_CHOICE == 1 ) then
     set HIST_CATCHCN   = "#DELETE"
     set GCMRUN_CATCHCN = "#DELETE"
-else if( $LSM_CHOICE == 2 ) then 
+else if( $LSM_CHOICE == 2 ) then
     set HIST_CATCHCN   = ""
     set GCMRUN_CATCHCN = ""
 endif
@@ -1723,6 +1723,12 @@ else
    set NUM_BACKEND_PES   = 0
 endif
 
+# For OpenMP regression testing, we need a variable that is half
+# the number of CPUs per node and also two times the number of nodes
+set NODES_TWICE = `expr $NODES \* 2`
+set NCPUS_PER_NODE_HALF = `expr $NCPUS_PER_NODE / 2`
+
+
 # Here we need to convert POST_NDS to total tasks. Using 16 cores
 # per task as a good default
 @ POST_NPES = $POST_NDS * 16
@@ -1759,6 +1765,7 @@ if( $SITE == 'NAS' ) then
               setenv     RUN_Q  "PBS -q ${QTYPE}"                                                                          # batch queue name for gcm_run.j
               setenv     RUN_P  "PBS -l select=${NODES}:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}" # PE Configuration for gcm_run.j
               setenv    RUN_FP  "PBS -l select=24:ncpus=${NCPUS_PER_NODE}:mpiprocs=${NCPUS_PER_NODE}:model=${MODEL}"       # PE Configuration for gcm_forecast.j
+              setenv REGRESS_P  "PBS -l select=${NODES_TWICE}:ncpus=${NCPUS_PER_NODE_HALF}:mpiprocs=${NCPUS_PER_NODE_HALF}:model=${MODEL}" # PE Configuration for gcm_regress.j
               setenv    POST_Q  "PBS -q normal"                                                                            # batch queue name for gcm_post.j
               setenv    PLOT_Q  "PBS -q normal"                                                                            # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "PBS -q normal"                                                                            # batch queue name for gcm_moveplot.j
@@ -1806,6 +1813,7 @@ else if( $SITE == 'NCCS' ) then
               setenv    RUN_Q   "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_run.j
               setenv    RUN_P   "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_run.j
               setenv    RUN_FP  "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_forecast.j
+              setenv    REGRESS_P   "SBATCH --nodes=${NODES_TWICE} --ntasks-per-node=${NCPUS_PER_NODE_HALF}" # PE Configuration for gcm_regress.j
               setenv    POST_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_post.j
               setenv    PLOT_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_moveplot.j
@@ -1850,6 +1858,7 @@ else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
               setenv RUN_Q     "SBATCH --constraint=${MODEL}"                              # batch queue name for gcm_run.j
               setenv RUN_P   "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_run.j
               setenv RUN_FP  "SBATCH --nodes=${NODES} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_forecast.j
+              setenv REGRESS_P   "SBATCH --nodes=${NODES_TWICE} --ntasks-per-node=${NCPUS_PER_NODE_HALF}" # PE Configuration for gcm_regress.j
               setenv POST_Q  NULL                                                          # batch queue name for gcm_post.j
               setenv PLOT_Q  NULL                                                          # batch queue name for gcm_plot.j
               setenv MOVE_Q  NULL                                                          # batch queue name for gcm_moveplot.j
@@ -1888,6 +1897,7 @@ else
               setenv  RUN_Q     NULL                                                   # batch queue name for gcm_run.j
               setenv  RUN_P     NULL                                                   # PE Configuration for gcm_run.j
               setenv  RUN_FP    NULL                                                   # PE Configuration for gcm_forecast.j
+              setenv  REGRESS_P NULL                                                   # PE Configuration for gcm_regress.j
               setenv    POST_Q  NULL                                                   # batch queue name for gcm_post.j
               setenv    PLOT_Q  NULL                                                   # batch queue name for gcm_plot.j
               setenv    MOVE_Q  NULL                                                   # batch queue name for gcm_moveplot.j
@@ -2312,6 +2322,7 @@ s?@RUN_T?$RUN_T?g
 s?@RUN_P?$RUN_P?g
 s?@RUN_FP?$RUN_FP?g
 s?@RUN_Q?$RUN_Q?g
+s?@REGRESS_P?$REGRESS_P?g
 s?@POST_N?$POST_N?g
 s?@POST_T?$POST_T?g
 s?@POST_P?$POST_P?g

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -37,20 +37,17 @@ setenv ARCH `uname -s`
 setenv NODE `uname -n`
 
 if ($ARCH == Darwin) then
-   set FINDPATH = realpath
    set PRELOAD_COMMAND = 'DYLD_INSERT_LIBRARIES'
    set LD_LIBRARY_PATH_CMD = 'DYLD_LIBRARY_PATH'
    # On macOS we seem to need to call mpirun directly and not use esma_mpirun
    # For some reason SIP does not let the libraries be preloaded
    set RUN_CMD = 'mpirun -np '
 else
-   set FINDPATH = 'readlink -f'
    set PRELOAD_COMMAND = 'LD_PRELOAD'
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
 endif
-set GCMSETUP = `$FINDPATH $0`
-set BINDIR   = `dirname $GCMSETUP`
+set BINDIR   = `pwd -L`
 set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 


### PR DESCRIPTION
Supersedes #639 and #631 and #628 

---

Note: because this changes DT for some resolutions, it is non-zero-diff for that reason. For resolutions it doesn't change DT/LONG_DT for, it is probably zero-diff.

---

This PR updates NX, NY, and various DT per calculations by @wmputman

We also move to use even division on nodes at NCCS at NAS. This means 24, 40, and 120 cores per node on the various node types.

---

Testing by @wmputman and @pchakraborty on SLES15 at NCCS show that using:

```
setenv I_MPI_FABRICS shm:ofi
setenv I_MPI_OFI_PROVIDER psm3
```
is all that is needed. So this PR changes the flags on SLES15 to reflect this. For now it should keep the SLES12 flags as they were before.

This should be used only in concert with https://github.com/GEOS-ESM/GEOSgcm/pull/791 which moves GEOSgcm to Intel MPI 2021.13. It might work with older Intel MPI...but I've only tested with that version.

NOTE: Once Cascade Lake moves to SLES15, this might need to be revisited as perhaps these are Milan-only flags.

---

This PR is an attempt to add an OpenMP test to the `gcm_regress.j` script. It is based on work by @wmputman backengineered to a csh template.

---

In some cases on machines where builds might be in odd weird physical paths, the logical path can be more useful. So instead of using `readlink` or `realpath` we assume a user is running `gcm_setup` from the `install/bin` directory and use `pwd -L`.

This should be portable to Linux and macOS.

NOTE 1: This might break singularity, but then everything probably does. We deal with that when needed.

NOTE 2: No idea how the Python variant of `gcm_setup` will handly paths. I'll need to consult with @sshakoor1 on this to see what it is spitting out.