### PR TITLE
v12: Add setting of NCAR_NRDG for resolutions without ridge files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.23.0
-#bcs_version: &bcs_version v11.5.0
+#baselibs_version: &baselibs_version v8.6.0
+#bcs_version: &bcs_version v12.0.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   build-test:
@@ -45,7 +45,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort]
+              compiler: [ifort]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -422,8 +422,35 @@ endif
 
 # Get proper ridge scheme GWD internal restart
 # --------------------------------------------
-/bin/rm gwd_internal_rst
-/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+if ( $rst_by_face == YES ) then
+  echo "WARNING: The generated gwd_internal_face_x_rst are used"
+  #foreach n (1 2 3 4 5 6)
+    #/bin/rm gwd_internal_face_${n}_rst
+    #/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM}_face_${n} gwd_internal_face_${n}_rst
+  #end
+else
+  # We want to look for the existence of a gwd_internal_rst file
+  # as not all resolutions have them (yet). If it exists, we copy
+  # it to the scratch directory. If it doesn't exist, we need to
+  # add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
+  # trying to use it.
+
+  if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
+    echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
+    /bin/rm gwd_internal_rst
+    /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+  else
+    echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+    # Now, if the user has already set an NCAR_NRDG value, we need to
+    # change it to 0. If they haven't set it, we need to add it to the
+    # AGCM.rc file.
+    if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+      echo "NCAR_NRDG: 0" >> AGCM.rc
+    else
+      sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+    endif
+  endif
+endif
 
 # Re-Create Proper CAP.rc
 # -----------------------

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -180,8 +180,35 @@ cp $EXPDIR/cap_restart $EXPDIR/regress
 
 # Get proper ridge scheme GWD internal restart
 # --------------------------------------------
-/bin/rm gwd_internal_rst
-/bin/cp @GWDRSDIR/gwd_internal_c${IM} gwd_internal_rst
+if ( $rst_by_face == YES ) then
+  echo "WARNING: The generated gwd_internal_face_x_rst are used"
+  #foreach n (1 2 3 4 5 6)
+    #/bin/rm gwd_internal_face_${n}_rst
+    #/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM}_face_${n} gwd_internal_face_${n}_rst
+  #end
+else
+  # We want to look for the existence of a gwd_internal_rst file
+  # as not all resolutions have them (yet). If it exists, we copy
+  # it to the scratch directory. If it doesn't exist, we need to
+  # add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
+  # trying to use it.
+
+  if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
+    echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
+    /bin/rm gwd_internal_rst
+    /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+  else
+    echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+    # Now, if the user has already set an NCAR_NRDG value, we need to
+    # change it to 0. If they haven't set it, we need to add it to the
+    # AGCM.rc file.
+    if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+      echo "NCAR_NRDG: 0" >> AGCM.rc
+    else
+      sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+    endif
+  endif
+endif
 
 @COUPLED /bin/mkdir INPUT
 @COUPLED cp $EXPDIR/RESTART/* INPUT
@@ -688,8 +715,35 @@ if ( $RUN_LAYOUT == TRUE) then
 
    # Get proper ridge scheme GWD internal restart
    # --------------------------------------------
-   /bin/rm gwd_internal_rst
-   /bin/cp @GWDRSDIR/gwd_internal_c${IM} gwd_internal_rst
+   if ( $rst_by_face == YES ) then
+     echo "WARNING: The generated gwd_internal_face_x_rst are used"
+     #foreach n (1 2 3 4 5 6)
+       #/bin/rm gwd_internal_face_${n}_rst
+       #/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM}_face_${n} gwd_internal_face_${n}_rst
+     #end
+   else
+     # We want to look for the existence of a gwd_internal_rst file
+     # as not all resolutions have them (yet). If it exists, we copy
+     # it to the scratch directory. If it doesn't exist, we need to
+     # add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
+     # trying to use it.
+
+     if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
+       echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
+       /bin/rm gwd_internal_rst
+       /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+     else
+       echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+       # Now, if the user has already set an NCAR_NRDG value, we need to
+       # change it to 0. If they haven't set it, we need to add it to the
+       # AGCM.rc file.
+       if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+         echo "NCAR_NRDG: 0" >> AGCM.rc
+       else
+         sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+       endif
+     endif
+   endif
 
    @COUPLED /bin/rm -rf INPUT
    @COUPLED /bin/mkdir INPUT
@@ -813,8 +867,35 @@ if ( $RUN_OPENMP == TRUE) then
 
    # Get proper ridge scheme GWD internal restart
    # --------------------------------------------
-   /bin/rm gwd_internal_rst
-   /bin/cp @GWDRSDIR/gwd_internal_c${IM} gwd_internal_rst
+   if ( $rst_by_face == YES ) then
+     echo "WARNING: The generated gwd_internal_face_x_rst are used"
+     #foreach n (1 2 3 4 5 6)
+       #/bin/rm gwd_internal_face_${n}_rst
+       #/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM}_face_${n} gwd_internal_face_${n}_rst
+     #end
+   else
+     # We want to look for the existence of a gwd_internal_rst file
+     # as not all resolutions have them (yet). If it exists, we copy
+     # it to the scratch directory. If it doesn't exist, we need to
+     # add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
+     # trying to use it.
+
+     if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
+       echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
+       /bin/rm gwd_internal_rst
+       /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+     else
+       echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+       # Now, if the user has already set an NCAR_NRDG value, we need to
+       # change it to 0. If they haven't set it, we need to add it to the
+       # AGCM.rc file.
+       if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+         echo "NCAR_NRDG: 0" >> AGCM.rc
+       else
+         sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+       endif
+     endif
+   endif
 
    @COUPLED /bin/rm -rf INPUT
    @COUPLED /bin/mkdir INPUT

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -550,9 +550,29 @@ if ( $rst_by_face == YES ) then
     #/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM}_face_${n} gwd_internal_face_${n}_rst
   #end
 else
-  /bin/rm gwd_internal_rst
-  /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+  # We want to look for the existence of a gwd_internal_rst file
+  # as not all resolutions have them (yet). If it exists, we copy
+  # it to the scratch directory. If it doesn't exist, we need to
+  # add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
+  # trying to use it.
+
+  if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
+    echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
+    /bin/rm gwd_internal_rst
+    /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+  else
+    echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+    # Now, if the user has already set an NCAR_NRDG value, we need to
+    # change it to 0. If they haven't set it, we need to add it to the
+    # AGCM.rc file.
+    if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+      echo "NCAR_NRDG: 0" >> AGCM.rc
+    else
+      sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+    endif
+  endif
 endif
+
 @COUPLED /bin/mkdir INPUT
 @COUPLED cp $EXPDIR/RESTART/* INPUT
 
@@ -1259,7 +1279,7 @@ end
 @MOM5     if(! -e $EXPDIR/MOM_Output) mkdir -p $EXPDIR/MOM_Output
 @MOM5     /bin/mv $SCRDIR/$dset.nc $EXPDIR/MOM_Output/$dset.${edate}.nc
 @MOM5  endif
-@MOM5  end 
+@MOM5  end
 @MOM6  foreach dset ( $dsets )
 @MOM6  set num = `/bin/ls -1 $dset.nc | wc -l`
 @MOM6  if($num != 0) then

--- a/gcm_run_benchmark.j
+++ b/gcm_run_benchmark.j
@@ -458,8 +458,35 @@ wait
 
 # Get proper ridge scheme GWD internal restart
 # --------------------------------------------
-/bin/rm gwd_internal_rst
-/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+if ( $rst_by_face == YES ) then
+  echo "WARNING: The generated gwd_internal_face_x_rst are used"
+  #foreach n (1 2 3 4 5 6)
+    #/bin/rm gwd_internal_face_${n}_rst
+    #/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM}_face_${n} gwd_internal_face_${n}_rst
+  #end
+else
+  # We want to look for the existence of a gwd_internal_rst file
+  # as not all resolutions have them (yet). If it exists, we copy
+  # it to the scratch directory. If it doesn't exist, we need to
+  # add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
+  # trying to use it.
+
+  if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
+    echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
+    /bin/rm gwd_internal_rst
+    /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+  else
+    echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+    # Now, if the user has already set an NCAR_NRDG value, we need to
+    # change it to 0. If they haven't set it, we need to add it to the
+    # AGCM.rc file.
+    if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+      echo "NCAR_NRDG: 0" >> AGCM.rc
+    else
+      sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+    endif
+  endif
+endif
 
 @COUPLED /bin/mkdir INPUT
 @COUPLED cp $EXPDIR/RESTART/* INPUT


### PR DESCRIPTION
Recently, attempts to run v12 with the stretched grid failed (see https://github.com/GEOS-ESM/GEOSgcm/issues/824). Thanks to @wmputman he noticed that the run was trying to use the GWD ridge scheme (`NCAR_NRDG: 16`) but we don't have a C540 ridge file yet[^1], so we should use `NCAR_NRDG: 0` in that case.

This PR adds a run time "fix". When we try and copy over the ridge file, if it exists, we copy. If it doesn't, we change/append `NCAR_NRDG: 0` to the `AGCM.rc` in `scratch/`. 

[^1]: I believe @bena-nasa is trying to figure out how to get ridge files for all our other resolutions. When that happens, this code becomes moot.