### PR TITLE
Set GAAS offset to CHEMISTRY_DT

### DIFF
--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -749,6 +749,26 @@ if( $REPLAY_MODE == 'Exact' | $REPLAY_MODE == 'Regular' ) then
 
 endif
 
+# Update GAAS_GridComp_ExtData.yaml with CHEMISTRY_DT
+# ---------------------------------------------------
+
+# NOTE: Even though GAAS is disabled above, we keep this code here in case this changes
+
+# We need to make sure GAAS has an offset that matches CHEMISTRY_DT from CAP.rc
+# We also need to take that CHEMISTRY_DT and convert it to ISO duration format in seconds
+# So, if CHEMISTRY_DT is 1800, we need to convert it to PT1800S
+# Then in GAAS_GridComp_ExtData.yaml, we need to find:
+#     update_offset: PT450S
+# and replace it with:
+#     update_offset: PT1800S
+# NOTE: Since it is YAML, we need to make sure the indentation is correct
+# 1. First we grab the CHEMISTRY_DT from CAP.rc
+CAPRC_CHEMISTRY_DT=`grep '^\s*CHEMISTRY_DT:' CAP.rc | cut -d: -f2 | awk '{print $1}'`
+# 2. Then we convert it to ISO duration format
+CHEMDT_ISO_DURATION=`echo "PT${CAPRC_CHEMISTRY_DT}S"`
+# 3. Then we replace the update_offset in GAAS_GridComp_ExtData.yaml
+sed -i "s/update_offset: .*/update_offset: ${CHEMDT_ISO_DURATION}/" GAAS_GridComp_ExtData.yaml
+
 # Establish safe default number of OpenMP threads
 # -----------------------------------------------
 setenv OMP_NUM_THREADS 1

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -966,6 +966,24 @@ if( $REPLAY_MODE == 'Exact' | $REPLAY_MODE == 'Regular' ) then
 
 endif
 
+# Update GAAS_GridComp_ExtData.yaml with CHEMISTRY_DT
+# ---------------------------------------------------
+
+# We need to make sure GAAS has an offset that matches CHEMISTRY_DT from CAP.rc
+# We also need to take that CHEMISTRY_DT and convert it to ISO duration format in seconds
+# So, if CHEMISTRY_DT is 1800, we need to convert it to PT1800S
+# Then in GAAS_GridComp_ExtData.yaml, we need to find:
+#     update_offset: PT450S
+# and replace it with:
+#     update_offset: PT1800S
+# NOTE: Since it is YAML, we need to make sure the indentation is correct
+# 1. First we grab the CHEMISTRY_DT from CAP.rc
+CAPRC_CHEMISTRY_DT=`grep '^\s*CHEMISTRY_DT:' CAP.rc | cut -d: -f2 | awk '{print $1}'`
+# 2. Then we convert it to ISO duration format
+CHEMDT_ISO_DURATION=`echo "PT${CAPRC_CHEMISTRY_DT}S"`
+# 3. Then we replace the update_offset in GAAS_GridComp_ExtData.yaml
+sed -i "s/update_offset: .*/update_offset: ${CHEMDT_ISO_DURATION}/" GAAS_GridComp_ExtData.yaml
+
 # Establish safe default number of OpenMP threads
 # -----------------------------------------------
 @MIT # ---------------------------------------------------

--- a/gcm_run_benchmark.j
+++ b/gcm_run_benchmark.j
@@ -827,6 +827,9 @@ if( $REPLAY_MODE == 'Exact' | $REPLAY_MODE == 'Regular' ) then
 
      # Modify GAAS_GridComp.rc and Link REPLAY files
      # ---------------------------------------------
+     /bin/mv -f GAAS_GridComp_ExtData.yaml GAAS_GridComp_ExtData.yaml.tmpl
+     cat GAAS_GridComp_ExtData.yaml.tmpl | sed -e "s?das.aod_?chem/Y%y4/M%m2/${ANA_EXPID}.aod_?g" > GAAS_GridComp_ExtData.yaml
+
      /bin/mv -f GAAS_GridComp.rc GAAS_GridComp.tmp
      cat GAAS_GridComp.tmp | sed -e "s?aod/Y%y4/M%m2/${ANA_EXPID}.?aod/Y%y4/M%m2/${ANA_EXPID}.?g" > GAAS_GridComp.rc
 
@@ -835,6 +838,24 @@ if( $REPLAY_MODE == 'Exact' | $REPLAY_MODE == 'Regular' ) then
      /bin/ln -sf ${ANA_LOCATION}/${REPLAY_FILE09_TYPE} .
 
 endif
+
+# Update GAAS_GridComp_ExtData.yaml with CHEMISTRY_DT
+# ---------------------------------------------------
+
+# We need to make sure GAAS has an offset that matches CHEMISTRY_DT from CAP.rc
+# We also need to take that CHEMISTRY_DT and convert it to ISO duration format in seconds
+# So, if CHEMISTRY_DT is 1800, we need to convert it to PT1800S
+# Then in GAAS_GridComp_ExtData.yaml, we need to find:
+#     update_offset: PT450S
+# and replace it with:
+#     update_offset: PT1800S
+# NOTE: Since it is YAML, we need to make sure the indentation is correct
+# 1. First we grab the CHEMISTRY_DT from CAP.rc
+CAPRC_CHEMISTRY_DT=`grep '^\s*CHEMISTRY_DT:' CAP.rc | cut -d: -f2 | awk '{print $1}'`
+# 2. Then we convert it to ISO duration format
+CHEMDT_ISO_DURATION=`echo "PT${CAPRC_CHEMISTRY_DT}S"`
+# 3. Then we replace the update_offset in GAAS_GridComp_ExtData.yaml
+sed -i "s/update_offset: .*/update_offset: ${CHEMDT_ISO_DURATION}/" GAAS_GridComp_ExtData.yaml
 
 # Establish safe default number of OpenMP threads
 # -----------------------------------------------


### PR DESCRIPTION
NOTE: PR summary below thanks to Copilot :)

---

This pull request includes updates to ensure the `GAAS_GridComp_ExtData.yaml` file's `update_offset` matches the `CHEMISTRY_DT` value from `CAP.rc`. The changes involve extracting `CHEMISTRY_DT`, converting it to ISO duration format, and updating the `update_offset` in the YAML file accordingly.

Updates to GAAS_GridComp_ExtData.yaml:

* Added code to extract `CHEMISTRY_DT` from `CAP.rc`, convert it to ISO duration format, and update the `update_offset` in `GAAS_GridComp_ExtData.yaml` in `gcm_run.j`.
* Added similar code for updating `GAAS_GridComp_ExtData.yaml` in `gcm_forecast.tmpl`.
* Added code to move and modify `GAAS_GridComp_ExtData.yaml` in `gcm_run_benchmark.j`.
* Added code to update `GAAS_GridComp_ExtData.yaml` with `CHEMISTRY_DT` in `gcm_run_benchmark.j`.