### PR TITLE
v12: Updates and fixes for SCM

### DIFF
--- a/scm_run.j
+++ b/scm_run.j
@@ -32,4 +32,6 @@ cd $EXPDIR
 
 $GEOSBIN/construct_extdata_yaml_list.py GEOS_ChemGridComp.rc
 
+cp fvcore_layout.rc input.nml
+
 $RUN_CMD 1 ./GEOSgcm.x --logging_config 'logging.yaml'

--- a/scm_setup
+++ b/scm_setup
@@ -376,17 +376,17 @@ BCSTAG="Icarus_Reynolds"
 
 case $SITE in
    NCCS)
-   SCMDIR="/discover/swdev/gmao_SIteam/scm/scminfiles/git-v11.1/"
+   SCMDIR="/discover/swdev/gmao_SIteam/scm/scminfiles/git-v12.0/"
    BCSDIR="/discover/nobackup/projects/gmao/share/gmao_ops/fvInput/g5gcm/bcs/Icarus/$BCSTAG"
    CHMDIR="/discover/nobackup/projects/gmao/share/gmao_ops/fvInput_nc3"
    ;;
    NAS)
-   SCMDIR="/nobackup/gmao_SIteam/ModelData/scminfiles/git-v11.1/"
+   SCMDIR="/nobackup/gmao_SIteam/ModelData/scminfiles/git-v12.0/"
    BCSDIR="/nobackup/gmao_SIteam/ModelData/bcs/Icarus/$BCSTAG"
    CHMDIR="/nobackup/gmao_SIteam/ModelData/fvInput_nc3"
    ;;
    GMAO*)
-   SCMDIR="/ford1/share/gmao_SIteam/ModelData/scminfiles/git-v11.1/"
+   SCMDIR="/ford1/share/gmao_SIteam/ModelData/scminfiles/git-v12.0/"
    BCSDIR="/ford1/share/gmao_SIteam/ModelData/bcs/Icarus/$BCSTAG"
    CHMDIR="/ford1/share/gmao_SIteam/ModelData/fvInput_nc3"
    ;;

--- a/scm_setup
+++ b/scm_setup
@@ -93,7 +93,7 @@ usage ()
    echo "    --account: account under which to run the job"
    echo
    echo "  Optional argument: "
-   echo "    --num_levels: number of levels (72, 71, 91, 132, 137, and 181 allowed)."
+   echo "    --num_levels: number of levels (default: 181; 72, 71, 91, 132, 137, and 181 allowed)."
    echo
    echo
 }
@@ -104,7 +104,7 @@ usage ()
 selected_case=NULL
 expdir=NULL
 account=NULL
-nlev=72
+nlev=181
 
 while [ "${1+defined}" ]
 do
@@ -233,9 +233,13 @@ then
       SED="$(command -v sed) "
       ISED="$SED -i.macbak "
    fi
+   PRELOAD_COMMAND='DYLD_INSERT_LIBRARIES'
+   LD_LIBRARY_PATH_CMD='DYLD_LIBRARY_PATH'
 else
    SED="$(command -v sed) "
    ISED="$SED -i "
+   PRELOAD_COMMAND='LD_PRELOAD'
+   LD_LIBRARY_PATH_CMD='LD_LIBRARY_PATH'
 fi
 
 case $selected_case in
@@ -513,6 +517,8 @@ s?@BATCH_TASKS?$BATCH_TASKS?g
 s?@BATCH_TIME?$BATCH_TIME?g
 s?@BATCH_GROUP?$BATCH_GROUP?g
 s?@BATCH_JOBNAME?$BATCH_JOBNAME?g
+s?@PRELOAD_COMMAND?$PRELOAD_COMMAND?g
+s?@LD_LIBRARY_PATH_CMD?$LD_LIBRARY_PATH_CMD?g
 EOF
 
 $ISED -f $expdir/sedfile $expdir/scm_run.j


### PR DESCRIPTION
This is a PR with fixes for the SCM in v12. 

The changes are:

1. Use the git-v12.0 scm inputfiles which moves to GFDL microphysics by default
2. Move to 181 levels by default
3. Set some new sed bits
4. Copy over `fvcore_layout.rc` into `input.nml`

---

I'm keeping this draft until @narnold1 can test. It works for me in one case at least. If successful for him, we can merge and I can try it out in my nightly testing suite which runs all the cases