### PR TITLE
v12: Move to use generic RRTMGP data location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v8.6.0
+#baselibs_version: &baselibs_version v8.7.0
 #bcs_version: &bcs_version v12.0.0
 
 orbs:
@@ -21,7 +21,10 @@ workflows:
           #baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
-          mepodevelop: true
+          # V12 code uses a special branch for now.
+          fixture_branch: feature/sdrabenh/gcm_v12
+          # We comment out this as it will "undo" the fixture_branch
+          #mepodevelop: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
 
       # Run AMIP GCM (1 hour, no ExtData)

--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -3,7 +3,7 @@
 # ------------------------------------------
 
 # Some rules of thumb when changing processor counts:
-# 
+#
 # 1) Start from the NX/NY that come from gcm_setup
 # 2) The gcm will not run with AGCM_IM/NX or AGCM_JM/NY/6 less than or equal to 3
 # 3) if you want more cores, double NY (for 2x), then double NX(for 4x) and so on...
@@ -853,10 +853,10 @@ HCFC22_FRIENDLIES: DYNAMICS:TURBULENCE:MOIST
 # -------------------------------
 USE_RRTMGP_IRRAD: 1.0
 USE_RRTMGP_SORAD: 1.0
-RRTMGP_GAS_LW: /discover/nobackup/pnorris/RRTMGP-data.v1.8/rrtmgp-data/rrtmgp-gas-lw-g128.nc
-RRTMGP_GAS_SW: /discover/nobackup/pnorris/RRTMGP-data.v1.8/rrtmgp-data/rrtmgp-gas-sw-g112.nc
-RRTMGP_CLOUD_OPTICS_LW: /discover/nobackup/pnorris/RRTMGP-data.v1.8/rrtmgp-data/rrtmgp-clouds-lw.nc
-RRTMGP_CLOUD_OPTICS_SW: /discover/nobackup/pnorris/RRTMGP-data.v1.8/rrtmgp-data/rrtmgp-clouds-sw.nc
+RRTMGP_GAS_LW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-gas-lw-g128.nc
+RRTMGP_GAS_SW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-gas-sw-g112.nc
+RRTMGP_CLOUD_OPTICS_LW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-clouds-lw.nc
+RRTMGP_CLOUD_OPTICS_SW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-clouds-sw.nc
 
 SOLAR_LB_MAX_PASSES: 10
 ISOLVAR: 2


### PR DESCRIPTION
Closes #671 

This PR moves v12 to use a "generic" location for the RRTMGP files. 

Testing shows this works on bucy and at NAS.