### PR TITLE
v11: Fixes for SCM

### DIFF
--- a/scm_run.j
+++ b/scm_run.j
@@ -32,4 +32,6 @@ cd $EXPDIR
 
 $GEOSBIN/construct_extdata_yaml_list.py GEOS_ChemGridComp.rc
 
+echo "file_weights: true" >> extdata.yaml
+
 $RUN_CMD 1 ./GEOSgcm.x --logging_config 'logging.yaml'

--- a/scm_setup
+++ b/scm_setup
@@ -233,9 +233,13 @@ then
       SED="$(command -v sed) "
       ISED="$SED -i.macbak "
    fi
+   PRELOAD_COMMAND='DYLD_INSERT_LIBRARIES'
+   LD_LIBRARY_PATH_CMD='DYLD_LIBRARY_PATH'
 else
    SED="$(command -v sed) "
    ISED="$SED -i "
+   PRELOAD_COMMAND='LD_PRELOAD'
+   LD_LIBRARY_PATH_CMD='LD_LIBRARY_PATH'
 fi
 
 case $selected_case in
@@ -513,6 +517,8 @@ s?@BATCH_TASKS?$BATCH_TASKS?g
 s?@BATCH_TIME?$BATCH_TIME?g
 s?@BATCH_GROUP?$BATCH_GROUP?g
 s?@BATCH_JOBNAME?$BATCH_JOBNAME?g
+s?@PRELOAD_COMMAND?$PRELOAD_COMMAND?g
+s?@LD_LIBRARY_PATH_CMD?$LD_LIBRARY_PATH_CMD?g
 EOF
 
 $ISED -f $expdir/sedfile $expdir/scm_run.j


### PR DESCRIPTION
The SCM was broken in `develop` recently. Some fixes are done in the SCM datafile area, but this change needs to be in code.

It also turns on reading ExtData weights (if present). NOTE: This will *write* weights if not, but I hope to add the weights to all the SCM cases.