### PR TITLE
v11: Copy over weight files for SCM

### DIFF
--- a/scm_setup
+++ b/scm_setup
@@ -458,6 +458,9 @@ cat $expdir/WSUB_ExtData.tmp | sed '/collection:/ s#WSUB_SWclim.*#/dev/null#' > 
 /bin/cp $SOURCEDIR/sedfile.CASE $expdir
 /bin/cp $SOURCEDIR/AGCM.CASE.txt $expdir
 
+# These are the weights files
+/bin/cp $SOURCEDIR/rh_* $expdir
+
 # MAT These sed commands have to be done in the experiment directory.
 #     This should probably be fixed at some point
 


### PR DESCRIPTION
As part of #676, the ability to read file weights for ExtData was added.

What I unfortunately forgot to do was actually copy those weights into the experiments.