### PR TITLE
Add label, @LDAS_INCR, to AGCM.rc.tmpl

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -543,7 +543,7 @@ LSM_CHOICE: @LSM_CHOICE
 #      0 : no  (default)
 #      1 : yes
 # ------------------------------------------------------------
-#LDAS_INCR: 0
+#LDAS_INCR: @LDAS_INCR
 
 # Name of file containing Surface GridComp resource parameters
 # ------------------------------------------------------------


### PR DESCRIPTION
The @LDAS_INCR label is uncommented and set during setup for an LDAS/ADAS run.