### PR TITLE
v12: Fixes for v13 gwd_internal_rst handling

### DIFF
--- a/.github/workflows/validate_yaml_files.yml
+++ b/.github/workflows/validate_yaml_files.yml
@@ -15,7 +15,11 @@ jobs:
   validate-YAML:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
       - id: yaml-lint
         name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
@@ -24,7 +28,7 @@ jobs:
           format: colored
           config_file: .yamllint.yml
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: yamllint-logfile

--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -487,30 +487,6 @@ end
           # /bin/rm irrad_internal_rst
 endif
 
-# Get proper ridge scheme GWD internal restart
-# --------------------------------------------
-# We want to look for the existence of a gwd_internal_rst file
-# as not all resolutions have them (yet). If it exists, we copy
-# it to the scratch directory. If it doesn't exist, we need to
-# add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
-# trying to use it.
-
-if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
-  echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
-  /bin/rm gwd_internal_rst
-  /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
-else
-  echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
-  # Now, if the user has already set an NCAR_NRDG value, we need to
-  # change it to 0. If they haven't set it, we need to add it to the
-  # AGCM.rc file.
-  if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
-    echo "NCAR_NRDG: 0" >> AGCM.rc
-  else
-    sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
-  endif
-endif
-
 # Re-Create Proper CAP.rc
 # -----------------------
 cp CAP.rc CAP.rc.orig
@@ -699,6 +675,18 @@ end
 # ---------------------------------------------
 setenv YEAR $yearc
 ./linkbcs
+
+if ( ! -e gwd_internal_rst ) then
+  echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+  # Now, if the user has already set an NCAR_NRDG value, we need to
+  # change it to 0. If they haven't set it, we need to add it to the
+  # AGCM.rc file.
+  if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+    echo "NCAR_NRDG: 0" >> AGCM.rc
+  else
+    sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+  endif
+endif
 
 if (! -e tile.bin) then
 $GEOSBIN/binarytile.x tile.data tile.bin

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -178,19 +178,13 @@ foreach rst ( $rst_file_names )
 end
 cp $EXPDIR/cap_restart $EXPDIR/regress
 
-# Get proper ridge scheme GWD internal restart
-# --------------------------------------------
-# We want to look for the existence of a gwd_internal_rst file
-# as not all resolutions have them (yet). If it exists, we copy
-# it to the scratch directory. If it doesn't exist, we need to
-# add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
-# trying to use it.
+@COUPLED /bin/mkdir INPUT
+@COUPLED cp $EXPDIR/RESTART/* INPUT
 
-if (-e @GWDRSDIR/gwd_internal_c${IM}) then
-  echo "Found gwd_internal_c${IM}. Copying to scratch directory"
-  /bin/rm gwd_internal_rst
-  /bin/cp @GWDRSDIR/gwd_internal_c${IM} gwd_internal_rst
-else
+setenv YEAR `cat cap_restart | cut -c1-4`
+./linkbcs
+
+if ( ! -e gwd_internal_rst ) then
   echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
   # Now, if the user has already set an NCAR_NRDG value, we need to
   # change it to 0. If they haven't set it, we need to add it to the
@@ -202,11 +196,7 @@ else
   endif
 endif
 
-@COUPLED /bin/mkdir INPUT
-@COUPLED cp $EXPDIR/RESTART/* INPUT
 
-setenv YEAR `cat cap_restart | cut -c1-4`
-./linkbcs
 if(! -e tile.bin) $GEOSBIN/binarytile.x tile.data tile.bin
 
 #######################################################################
@@ -667,6 +657,19 @@ if ($RUN_STARTSTOP == TRUE) then
 
    setenv YEAR `cat cap_restart | cut -c1-4`
    ./linkbcs
+
+   if ( ! -e gwd_internal_rst ) then
+      echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+      # Now, if the user has already set an NCAR_NRDG value, we need to
+      # change it to 0. If they haven't set it, we need to add it to the
+      # AGCM.rc file.
+      if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+         echo "NCAR_NRDG: 0" >> AGCM.rc
+      else
+         sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+      endif
+   endif
+
    set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
    set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
    @ NPES = $NX * $NY
@@ -725,30 +728,6 @@ if ( $RUN_LAYOUT == TRUE) then
       cp $EXPDIR/$rst $EXPDIR/regress
    end
 
-   # Get proper ridge scheme GWD internal restart
-   # --------------------------------------------
-   # We want to look for the existence of a gwd_internal_rst file
-   # as not all resolutions have them (yet). If it exists, we copy
-   # it to the scratch directory. If it doesn't exist, we need to
-   # add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
-   # trying to use it.
-
-   if (-e @GWDRSDIR/gwd_internal_c${IM}) then
-     echo "Found gwd_internal_c${IM}. Copying to scratch directory"
-     /bin/rm gwd_internal_rst
-     /bin/cp @GWDRSDIR/gwd_internal_c${IM} gwd_internal_rst
-   else
-     echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
-     # Now, if the user has already set an NCAR_NRDG value, we need to
-     # change it to 0. If they haven't set it, we need to add it to the
-     # AGCM.rc file.
-     if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
-       echo "NCAR_NRDG: 0" >> AGCM.rc
-     else
-       sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
-     endif
-   endif
-
    @COUPLED /bin/rm -rf INPUT
    @COUPLED /bin/mkdir INPUT
    @COUPLED cp $EXPDIR/RESTART/* INPUT
@@ -804,6 +783,19 @@ if ( $RUN_LAYOUT == TRUE) then
 
    setenv YEAR `cat cap_restart | cut -c1-4`
    ./linkbcs
+
+   if ( ! -e gwd_internal_rst ) then
+      echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+      # Now, if the user has already set an NCAR_NRDG value, we need to
+      # change it to 0. If they haven't set it, we need to add it to the
+      # AGCM.rc file.
+      if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+         echo "NCAR_NRDG: 0" >> AGCM.rc
+      else
+         sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+      endif
+   endif
+
    set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
    set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
    @ NPES = $NX * $NY
@@ -869,30 +861,6 @@ if ( $RUN_OPENMP == TRUE) then
       cp $EXPDIR/$rst $EXPDIR/regress
    end
 
-   # Get proper ridge scheme GWD internal restart
-   # --------------------------------------------
-   # We want to look for the existence of a gwd_internal_rst file
-   # as not all resolutions have them (yet). If it exists, we copy
-   # it to the scratch directory. If it doesn't exist, we need to
-   # add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
-   # trying to use it.
-
-   if (-e @GWDRSDIR/gwd_internal_c${IM}) then
-     echo "Found gwd_internal_c${IM}. Copying to scratch directory"
-     /bin/rm gwd_internal_rst
-     /bin/cp @GWDRSDIR/gwd_internal_c${IM} gwd_internal_rst
-   else
-     echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
-     # Now, if the user has already set an NCAR_NRDG value, we need to
-     # change it to 0. If they haven't set it, we need to add it to the
-     # AGCM.rc file.
-     if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
-       echo "NCAR_NRDG: 0" >> AGCM.rc
-     else
-       sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
-     endif
-   endif
-
    @COUPLED /bin/rm -rf INPUT
    @COUPLED /bin/mkdir INPUT
    @COUPLED cp $EXPDIR/RESTART/* INPUT
@@ -948,6 +916,19 @@ if ( $RUN_OPENMP == TRUE) then
 
    setenv YEAR `cat cap_restart | cut -c1-4`
    ./linkbcs
+
+   if ( ! -e gwd_internal_rst ) then
+      echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+      # Now, if the user has already set an NCAR_NRDG value, we need to
+      # change it to 0. If they haven't set it, we need to add it to the
+      # AGCM.rc file.
+      if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+         echo "NCAR_NRDG: 0" >> AGCM.rc
+      else
+         sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+      endif
+   endif
+
    set NX = `grep "^ *NX": AGCM.rc | cut -d':' -f2`
    set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
    @ NPES = $NX * $NY

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -589,38 +589,6 @@ else
 endif
 wait
 
-# Get proper ridge scheme GWD internal restart
-# --------------------------------------------
-if ( $rst_by_face == YES ) then
-  echo "WARNING: The generated gwd_internal_face_x_rst are used"
-  #foreach n (1 2 3 4 5 6)
-    #/bin/rm gwd_internal_face_${n}_rst
-    #/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM}_face_${n} gwd_internal_face_${n}_rst
-  #end
-else
-  # We want to look for the existence of a gwd_internal_rst file
-  # as not all resolutions have them (yet). If it exists, we copy
-  # it to the scratch directory. If it doesn't exist, we need to
-  # add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
-  # trying to use it.
-
-  if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
-    echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
-    /bin/rm gwd_internal_rst
-    /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
-  else
-    echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
-    # Now, if the user has already set an NCAR_NRDG value, we need to
-    # change it to 0. If they haven't set it, we need to add it to the
-    # AGCM.rc file.
-    if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
-      echo "NCAR_NRDG: 0" >> AGCM.rc
-    else
-      sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
-    endif
-  endif
-endif
-
 @COUPLED /bin/mkdir INPUT
 @COUPLED cp $EXPDIR/RESTART/* INPUT
 
@@ -890,6 +858,28 @@ end
 # ---------------------------------------------
 setenv YEAR $yearc
 ./linkbcs
+
+# Get proper ridge scheme GWD internal restart
+# --------------------------------------------
+if ( $rst_by_face == YES ) then
+  echo "WARNING: The generated gwd_internal_face_x_rst are used"
+  #foreach n (1 2 3 4 5 6)
+    #/bin/rm gwd_internal_face_${n}_rst
+    #/bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM}_face_${n} gwd_internal_face_${n}_rst
+  #end
+else
+  if (! -e gwd_internal_rst) then
+    echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+    # Now, if the user has already set an NCAR_NRDG value, we need to
+    # change it to 0. If they haven't set it, we need to add it to the
+    # AGCM.rc file.
+    if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+      echo "NCAR_NRDG: 0" >> AGCM.rc
+    else
+      sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+    endif
+  endif
+endif
 
 if (! -e tile.bin) then
 $GEOSBIN/binarytile.x tile.data tile.bin

--- a/gcm_run_benchmark.j
+++ b/gcm_run_benchmark.j
@@ -456,30 +456,6 @@ else
 endif
 wait
 
-# Get proper ridge scheme GWD internal restart
-# --------------------------------------------
-# We want to look for the existence of a gwd_internal_rst file
-# as not all resolutions have them (yet). If it exists, we copy
-# it to the scratch directory. If it doesn't exist, we need to
-# add "NCAR_NRDG: 0" to the AGCM.rc file to prevent the model from
-# trying to use it.
-
-if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
-  echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
-  /bin/rm gwd_internal_rst
-  /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
-else
-  echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
-  # Now, if the user has already set an NCAR_NRDG value, we need to
-  # change it to 0. If they haven't set it, we need to add it to the
-  # AGCM.rc file.
-  if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
-    echo "NCAR_NRDG: 0" >> AGCM.rc
-  else
-    sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
-  endif
-endif
-
 @COUPLED /bin/mkdir INPUT
 @COUPLED cp $EXPDIR/RESTART/* INPUT
 
@@ -734,6 +710,18 @@ end
 # ---------------------------------------------
 setenv YEAR $yearc
 ./linkbcs
+
+if (! -e gwd_internal_rst ) then
+  echo "WARNING: gwd_internal_rst not found. Setting NCAR_NRDG to 0"
+  # Now, if the user has already set an NCAR_NRDG value, we need to
+  # change it to 0. If they haven't set it, we need to add it to the
+  # AGCM.rc file.
+  if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
+    echo "NCAR_NRDG: 0" >> AGCM.rc
+  else
+    sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+  endif
+endif
 
 if (! -e tile.bin) then
 $GEOSBIN/binarytile.x tile.data tile.bin

--- a/gcm_setup
+++ b/gcm_setup
@@ -435,7 +435,7 @@ else if ( $SITE == 'NAS' ) then
    echo "   ${C2}bro (Broadwell)${CN}"
    echo "   ${C2}sky (Skylake)${CN}"
    echo "   ${C2}cas (Cascade Lake)${CN}"
-   echo "   ${C2}rom (AMD Rome)${CN} (default)"
+   echo "   ${C2}rom (AMD Rome)${CN} (Default)"
    echo "   ${C2}mil (AMD Milan)${CN}"
    echo " "
    echo " NOTE Due to how FV3 is compiled by default, Sandy Bridge"

--- a/gcm_setup
+++ b/gcm_setup
@@ -1413,6 +1413,7 @@ if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "ica" ) then
     set EMIP_OLDLAND = ""
     set EMIP_NEWLAND = "#DELETE"
     set EMIP_MERRA2  = "MERRA2"
+    set GWD_IN_BCS   = "FALSE"
 else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "nl3" ) then
     set LSM_BCS      = "NL3"
     set LSM_PARMS    = ""
@@ -1420,6 +1421,7 @@ else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "nl3" ) then
     set EMIP_OLDLAND = "#DELETE"
     set EMIP_NEWLAND = ""
     set EMIP_MERRA2  = "MERRA2_NewLand"
+    set GWD_IN_BCS   = "FALSE"
 else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "v13" ) then
     set LSM_BCS      = "v13"
     set LSM_PARMS    = ""
@@ -1427,6 +1429,7 @@ else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "v13" ) then
     set EMIP_OLDLAND = "#DELETE"
     set EMIP_NEWLAND = ""
     set EMIP_MERRA2  = "MERRA2_NewLand"
+    set GWD_IN_BCS   = "TRUE"
 else
     echo
     echo "${C1} Land Surface Boundary Conditions${CN} must be set equal to ${C2}ICA (Icarus)${CN}, ${C2}NL3 (Icarus-NLv3)${CN}, or ${C2}v13${CN}!"
@@ -2240,8 +2243,13 @@ endif # if NCCS
 endif # if mpi
 
 # Check for gwd_internal for Ridge Scheme
-                                             set NCAR_NRDG = 0
-if ( -e $GWDRSDIR/gwd_internal_c${AGCM_IM} ) set NCAR_NRDG = 16
+
+# For ICA and NL3 the gwd files are in a non-bcs location
+# and may or may not exist. If they don't we set NCAR_NRDG to 0
+set NCAR_NRDG = 16
+if ( $GWD_IN_BCS == FALSE ) then
+  if ( ! -e $GWDRSDIR/gwd_internal_c${AGCM_IM} ) set NCAR_NRDG = 0
+endif
 
 #######################################################################
 #               Create Local Scripts and Resource Files

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -405,7 +405,6 @@ if ( $SITE == 'NCCS' ) then
 
       if ($MODEL == 'mil') then
          # For even division, we use 120 cores per node
-         # We save a couple processes for the kernel
          set NCPUS_PER_NODE = 120
       else if ($MODEL == 'cas') then
          # We use 40 of 46 cores per node for even division
@@ -1431,6 +1430,7 @@ if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "ica" ) then
     set EMIP_OLDLAND = ""
     set EMIP_NEWLAND = "#DELETE"
     set EMIP_MERRA2  = "MERRA2"
+    set GWD_IN_BCS   = "FALSE"
 else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "nl3" ) then
     set LSM_BCS      = "NL3"
     set LSM_PARMS    = ""
@@ -1438,6 +1438,7 @@ else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "nl3" ) then
     set EMIP_OLDLAND = "#DELETE"
     set EMIP_NEWLAND = ""
     set EMIP_MERRA2  = "MERRA2_NewLand"
+    set GWD_IN_BCS   = "FALSE"
 else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "v13" ) then
     set LSM_BCS      = "v13"
     set LSM_PARMS    = ""
@@ -1445,6 +1446,7 @@ else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "v13" ) then
     set EMIP_OLDLAND = "#DELETE"
     set EMIP_NEWLAND = ""
     set EMIP_MERRA2  = "MERRA2_NewLand"
+    set GWD_IN_BCS   = "TRUE"
 else
     echo
     echo "${C1} Land Surface Boundary Conditions${CN} must be set equal to ${C2}ICA (Icarus)${CN}, ${C2}NL3 (Icarus-NLv3)${CN}, or ${C2}v13${CN}!"
@@ -2273,8 +2275,13 @@ endif # if NCCS
 endif # if mpi
 
 # Check for gwd_internal for Ridge Scheme
-                                             set NCAR_NRDG = 0
-if ( -e $GWDRSDIR/gwd_internal_c${AGCM_IM} ) set NCAR_NRDG = 16
+
+# For ICA and NL3 the gwd files are in a non-bcs location
+# and may or may not exist. If they don't we set NCAR_NRDG to 0
+set NCAR_NRDG = 16
+if ( $GWD_IN_BCS == FALSE ) then
+  if ( ! -e $GWDRSDIR/gwd_internal_c${AGCM_IM} ) set NCAR_NRDG = 0
+endif
 
 #######################################################################
 #               Create Local Scripts and Resource Files

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -405,7 +405,6 @@ if ( $SITE == 'NCCS' ) then
 
       if ($MODEL == 'mil') then
          # For even division, we use 120 cores per node
-         # We save a couple processes for the kernel
          set NCPUS_PER_NODE = 120
       else if ($MODEL == 'cas') then
          # We use 40 of 46 cores per node for even division
@@ -1520,6 +1519,7 @@ if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "ica" ) then
     set EMIP_OLDLAND = ""
     set EMIP_NEWLAND = "#DELETE"
     set EMIP_MERRA2  = "MERRA2"
+    set GWD_IN_BCS   = "FALSE"
 else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "nl3" ) then
     set LSM_BCS      = "NL3"
     set LSM_PARMS    = ""
@@ -1527,6 +1527,7 @@ else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "nl3" ) then
     set EMIP_OLDLAND = "#DELETE"
     set EMIP_NEWLAND = ""
     set EMIP_MERRA2  = "MERRA2_NewLand"
+    set GWD_IN_BCS   = "FALSE"
 else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "v13" ) then
     set LSM_BCS      = "v13"
     set LSM_PARMS    = ""
@@ -1534,6 +1535,7 @@ else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "v13" ) then
     set EMIP_OLDLAND = "#DELETE"
     set EMIP_NEWLAND = ""
     set EMIP_MERRA2  = "MERRA2_NewLand"
+    set GWD_IN_BCS   = "TRUE"
 else
     echo
     echo "${C1} Land Surface Boundary Conditions${CN} must be set equal to ${C2}ICA (Icarus)${CN}, ${C2}NL3 (Icarus-NLv3)${CN}, or ${C2}v13${CN}!"
@@ -2436,8 +2438,13 @@ endif # if NCCS
 endif # if mpi
 
 # Check for gwd_internal for Ridge Scheme
-                                             set NCAR_NRDG = 0
-if ( -e $GWDRSDIR/gwd_internal_c${AGCM_IM} ) set NCAR_NRDG = 16
+
+# For ICA and NL3 the gwd files are in a non-bcs location
+# and may or may not exist. If they don't we set NCAR_NRDG to 0
+set NCAR_NRDG = 16
+if ( $GWD_IN_BCS == FALSE ) then
+  if ( ! -e $GWDRSDIR/gwd_internal_c${AGCM_IM} ) set NCAR_NRDG = 0
+endif
 
 #######################################################################
 #               Create Local Scripts and Resource Files

--- a/linkbcs.tmpl
+++ b/linkbcs.tmpl
@@ -68,10 +68,10 @@ set MERRA2OX_SPECIES = "#"
 if ( -e $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/gwd_internal_rst ) then
    echo "Found gwd_internal_rst in bcsdir. Copying to scratch directory"
    /bin/cp -vf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/gwd_internal_rst gwd_internal_rst
-else if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
-   echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
+else if (-e @GWDRSDIR/gwd_internal_c@AGCM_IM) then
+   echo "Found gwd_internal_c@AGCM_IM. Copying to scratch directory"
    /bin/rm gwd_internal_rst
-   /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+   /bin/cp @GWDRSDIR/gwd_internal_c@AGCM_IM gwd_internal_rst
 endif
 
 @COUPLEDcp $HOMDIR/*_table .

--- a/linkbcs.tmpl
+++ b/linkbcs.tmpl
@@ -63,7 +63,7 @@ set MERRA2OX_SPECIES = "#"
 /bin/ln -sf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/topo_DYN_ave_@AGCM_IMx@AGCM_JM.data topo_dynave.data
 /bin/ln -sf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/topo_GWD_var_@AGCM_IMx@AGCM_JM.data topo_gwdvar.data
 /bin/ln -sf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/topo_TRB_var_@AGCM_IMx@AGCM_JM.data topo_trbvar.data
-
+if ( -e $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/gwd_internal_rst ) /bin/cp -vf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/gwd_internal_rst gwd_internal_rst
 
 @COUPLEDcp $HOMDIR/*_table .
 @COUPLEDcp $CPLDIR/@OGCM_IMx@OGCM_JM/INPUT/* INPUT

--- a/linkbcs.tmpl
+++ b/linkbcs.tmpl
@@ -63,7 +63,16 @@ set MERRA2OX_SPECIES = "#"
 /bin/ln -sf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/topo_DYN_ave_@AGCM_IMx@AGCM_JM.data topo_dynave.data
 /bin/ln -sf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/topo_GWD_var_@AGCM_IMx@AGCM_JM.data topo_gwdvar.data
 /bin/ln -sf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/topo_TRB_var_@AGCM_IMx@AGCM_JM.data topo_trbvar.data
-if ( -e $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/gwd_internal_rst ) /bin/cp -vf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/gwd_internal_rst gwd_internal_rst
+
+# Handle gwd_internal_rst
+if ( -e $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/gwd_internal_rst ) then
+   echo "Found gwd_internal_rst in bcsdir. Copying to scratch directory"
+   /bin/cp -vf $BCSDIR/TOPO/TOPO_@ATMOStag/smoothed/gwd_internal_rst gwd_internal_rst
+else if (-e @GWDRSDIR/gwd_internal_c${AGCM_IM}) then
+   echo "Found gwd_internal_c${AGCM_IM}. Copying to scratch directory"
+   /bin/rm gwd_internal_rst
+   /bin/cp @GWDRSDIR/gwd_internal_c${AGCM_IM} gwd_internal_rst
+endif
 
 @COUPLEDcp $HOMDIR/*_table .
 @COUPLEDcp $CPLDIR/@OGCM_IMx@OGCM_JM/INPUT/* INPUT

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -405,7 +405,6 @@ if ( $SITE == 'NCCS' ) then
 
       if ($MODEL == 'mil') then
          # For even division, we use 120 cores per node
-         # We save a couple processes for the kernel
          set NCPUS_PER_NODE = 120
       else if ($MODEL == 'cas') then
          # We use 40 of 46 cores per node for even division
@@ -1431,6 +1430,7 @@ if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "ica" ) then
     set EMIP_OLDLAND = ""
     set EMIP_NEWLAND = "#DELETE"
     set EMIP_MERRA2  = "MERRA2"
+    set GWD_IN_BCS   = "FALSE"
 else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "nl3" ) then
     set LSM_BCS      = "NL3"
     set LSM_PARMS    = ""
@@ -1438,6 +1438,7 @@ else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "nl3" ) then
     set EMIP_OLDLAND = "#DELETE"
     set EMIP_NEWLAND = ""
     set EMIP_MERRA2  = "MERRA2_NewLand"
+    set GWD_IN_BCS   = "FALSE"
 else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "v13" ) then
     set LSM_BCS      = "v13"
     set LSM_PARMS    = ""
@@ -1445,6 +1446,7 @@ else if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "v13" ) then
     set EMIP_OLDLAND = "#DELETE"
     set EMIP_NEWLAND = ""
     set EMIP_MERRA2  = "MERRA2_NewLand"
+    set GWD_IN_BCS   = "TRUE"
 else
     echo
     echo "${C1} Land Surface Boundary Conditions${CN} must be set equal to ${C2}ICA (Icarus)${CN}, ${C2}NL3 (Icarus-NLv3)${CN}, or ${C2}v13${CN}!"
@@ -2258,8 +2260,13 @@ endif # if NCCS
 endif # if mpi
 
 # Check for gwd_internal for Ridge Scheme
-                                             set NCAR_NRDG = 0
-if ( -e $GWDRSDIR/gwd_internal_c${AGCM_IM} ) set NCAR_NRDG = 16
+
+# For ICA and NL3 the gwd files are in a non-bcs location
+# and may or may not exist. If they don't we set NCAR_NRDG to 0
+set NCAR_NRDG = 16
+if ( $GWD_IN_BCS == FALSE ) then
+  if ( ! -e $GWDRSDIR/gwd_internal_c${AGCM_IM} ) set NCAR_NRDG = 0
+endif
 
 #######################################################################
 #               Create Local Scripts and Resource Files


### PR DESCRIPTION
Per @biljanaorescanin, for v13 BCs `gwd_internal_rst` is now carried in the BCs itself (as I guess the topo scripting makes it? cc @bena-nasa)

So, we need to handle things differently. We move the "copy rst to scratch/" bits into `linkbcs` as it knows where BCs are.