### PR TITLE
v12: Fix lazy sed for RRTMGP

### DIFF
--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -667,7 +667,7 @@ endif
 set instance_files = `/bin/ls -1 *_instance*.rc`
 foreach instance ($instance_files)
    /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/RRTMG/ s#RRTMG#RRTMGP#' > $instance
+   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
    /bin/rm $instance.tmp
 end
 

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -399,7 +399,7 @@ endif
 set instance_files = `/bin/ls -1 *_instance*.rc`
 foreach instance ($instance_files)
    /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/RRTMG/ s#RRTMG#RRTMGP#' > $instance
+   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
    /bin/rm $instance.tmp
 end
 

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -854,7 +854,7 @@ endif
 set instance_files = `/bin/ls -1 *_instance*.rc`
 foreach instance ($instance_files)
    /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/RRTMG/ s#RRTMG#RRTMGP#' > $instance
+   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
    /bin/rm $instance.tmp
 end
 

--- a/gcm_run.j-new_rst_approach
+++ b/gcm_run.j-new_rst_approach
@@ -589,7 +589,7 @@ if($numrs == 0) then
          set ext  = bin
       else
          set ext  = nc4
-      endif 
+      endif
       if( -e $rst & ! -e ${EXPDIR}/restarts/$EXPID.${rst}.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}.$ext ) then
             cp $rst ${EXPDIR}/restarts/$EXPID.${rst}.${edate}.${GCMVER}.${BCTAG}_${BCRSLV}.$ext &
       endif
@@ -851,7 +851,7 @@ endif
 set instance_files = `/bin/ls -1 *_instance*.rc`
 foreach instance ($instance_files)
    /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/RRTMG/ s#RRTMG#RRTMGP#' > $instance
+   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
    /bin/rm $instance.tmp
 end
 
@@ -1098,7 +1098,7 @@ endif
 echo OMP_NUM_THREADS $OMP_NUM_THREADS
 
 ~/bin/strip GWD_GridComp.rc
-if (${OMP_NUM_THREADS} > 1) then 
+if (${OMP_NUM_THREADS} > 1) then
   sed -i -e "s|FALSE|TRUE|g" GWD_GridComp.rc
 endif
 
@@ -1228,7 +1228,7 @@ echo "RH_WEIGHTS_DIR: $RH_WEIGHTS_DIR"
 if (! -e $RH_WEIGHTS_DIR ) mkdir -p $RH_WEIGHTS_DIR
 set rh_files = `/bin/ls -1 *rh_*method*`
 foreach rh_file ($rh_files)
-  if (! -e $RH_WEIGHTS_DIR/$rh_file) /bin/mv $rh_file $RH_WEIGHTS_DIR/$rh_file 
+  if (! -e $RH_WEIGHTS_DIR/$rh_file) /bin/mv $rh_file $RH_WEIGHTS_DIR/$rh_file
 end
 
 #######################################################################

--- a/gcm_run_benchmark.j
+++ b/gcm_run_benchmark.j
@@ -702,7 +702,7 @@ endif
 set instance_files = `/bin/ls -1 *_instance*.rc`
 foreach instance ($instance_files)
    /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/RRTMG/ s#RRTMG#RRTMGP#' > $instance
+   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
    /bin/rm $instance.tmp
 end
 


### PR DESCRIPTION
As found by @michellefrazer, the sed in our runscripts was not quite good. This code:
```csh
   cat $instance.tmp | sed -e '/RRTMG/ s#RRTMG#RRTMGP#' > $instance
```
works great the first time around. But if you run multiple segments with the same scratch dir, well, you go from `RRTMG` to `RRTMGP` to `RRTMGPP` and boom, crash.

So we add word boundary markers to the sed to look only for the complete word `RRTMG`.

NOTE: The correct fix is to change the files in GOCART or do something smarter.