### PR TITLE
v12: Support for easy Jemalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,8 @@ ecbuild_add_executable (
 # To fix this, we explicitly set the linker language to Fortran.
 set_target_properties (GEOSgcm.x PROPERTIES LINKER_LANGUAGE Fortran)
 
-# Using JeMalloc will be optional, default OFF
-option (USE_JEMALLOC "Use JeMalloc" OFF)
-if (USE_JEMALLOC)
-  find_package (JeMalloc REQUIRED)
-  target_link_libraries (GEOSgcm.x JeMalloc::JeMalloc)
-endif ()
+find_package (JeMalloc)
+target_link_libraries (GEOSgcm.x PRIVATE $<$<BOOL:${JeMalloc_FOUND}>:JeMalloc::JeMalloc>)
 
 ecbuild_add_executable (
   TARGET idfupd.x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,10 @@ ecbuild_add_executable (
 set_target_properties (GEOSgcm.x PROPERTIES LINKER_LANGUAGE Fortran)
 
 find_package (JeMalloc)
-target_link_libraries (GEOSgcm.x PRIVATE $<$<BOOL:${JeMalloc_FOUND}>:JeMalloc::JeMalloc>)
+if(JeMalloc_FOUND)
+  message(STATUS "JeMalloc found, using for GEOSgcm.x")
+  target_link_libraries (GEOSgcm.x JeMalloc::JeMalloc)
+endif()
 
 ecbuild_add_executable (
   TARGET idfupd.x


### PR DESCRIPTION
Rather than make a user set a CMake option to use JeMalloc, let's just use CMake the way we should.

This should allow for easy use of JeMalloc if it's found.

Should be used in concert with https://github.com/GEOS-ESM/ESMA_env/pull/116

All tests show it zero-diff JeMalloc is enabled or not. Also, `gcm_regress.j` passes

---

Here is a chart of runs at `gcm_setup` defaults charting the Mem Comm number from the `AGCM Date` lines:

| Res  | Stock | Jemalloc |
|------|-------|----------|
| C24  | 42.5% | 26.1%    |
| C48  | 57.7% | 30.6%    |
| C90  | 53.8% | 31.0%    |
| C180 | 54.1% | 31.2%    | 
