### PR TITLE
v12: Update c12 and c24 timesteps

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -984,7 +984,7 @@ endif
 # Default Run Parameters
 # ----------------------
 if( $AGCM_IM ==  "c12" ) then
-     set       DT = 3600
+     set       DT = 1800
      set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
@@ -1006,7 +1006,7 @@ if( $AGCM_IM ==  "c12" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c24" ) then
-     set       DT = 1800
+     set       DT = 1200
      set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -984,7 +984,7 @@ endif
 # Default Run Parameters
 # ----------------------
 if( $AGCM_IM ==  "c12" ) then
-     set       DT = 3600
+     set       DT = 1800
      set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
@@ -1007,7 +1007,7 @@ if( $AGCM_IM ==  "c12" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c24" ) then
-     set       DT = 1800
+     set       DT = 1200
      set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1073,7 +1073,7 @@ endif
 # Default Run Parameters
 # ----------------------
 if( $AGCM_IM ==  "c12" ) then
-     set       DT = 3600
+     set       DT = 1800
      set SOLAR_DT  = `expr $DT \* 2`
      set IRRAD_DT  = `expr $DT \* 2`
      set OCEAN_DT = $IRRAD_DT
@@ -1096,7 +1096,7 @@ if( $AGCM_IM ==  "c12" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c24" ) then
-     set       DT = 1800
+     set       DT = 1200
      set SOLAR_DT  = `expr $DT \* 2`
      set IRRAD_DT  = `expr $DT \* 2`
      set OCEAN_DT = $IRRAD_DT

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -984,7 +984,7 @@ endif
 # Default Run Parameters
 # ----------------------
 if( $AGCM_IM ==  "c12" ) then
-     set       DT = 3600
+     set       DT = 1800
      set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600
@@ -1007,7 +1007,7 @@ if( $AGCM_IM ==  "c12" ) then
      set POST_NDS = 4
 endif
 if( $AGCM_IM ==  "c24" ) then
-     set       DT = 1800
+     set       DT = 1200
      set  LONG_DT = 3600
      set SOLAR_DT = 3600
      set IRRAD_DT = 3600


### PR DESCRIPTION
Recently, many of my nightly tests for c12 and c24 have been failing. Working with @atrayano, we found they all had hallmarks of "instability". So, in this PR we change the default time steps for c12 and c24:

* c12: 3600 → 1800
* c24: 1800 → 1200

More complete testing is ongoing, but this seems to fix the issues we are seeing.

I am marking non-zero-diff as it is for these resolutions, but only those.