### PR TITLE
add checking and setting restart flag in CICE6 config file in gcm_run

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -836,6 +836,16 @@ endif
 #ln -sf $SSTDIR/dataoceanfile_MERRA2_SST.${OGCM_IM}x${OGCM_JM}.${yy}.data sst.data
 #ln -sf $SSTDIR/dataoceanfile_MERRA2_ICE.${OGCM_IM}x${OGCM_JM}.${yy}.data fraci.data
 
+@CICE6 #detect exisistence of certain fields in CICE6 restart
+@CICE6 ncdump -h INPUT/iced.nc | grep 'apnd' > /dev/null
+@CICE6 if( $status == 0 ) then
+@CICE6    echo 'pond state in restart, turn on restart flag if not already'
+@CICE6    sed -i -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.false\./    restart_pond_lvl  = .true./' ice_in
+@CICE6 else
+@CICE6    echo 'pond state NOT in restart, turn off restart flag if already on'
+@CICE6    sed -i -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.true\./    restart_pond_lvl  = .false./' ice_in
+@CICE6 endif
+
 #######################################################################
 #                Split Saltwater Restart if detected
 #######################################################################


### PR DESCRIPTION
This PR added a step of restart checking and config updating if certain field exist in CICE6 restart file.
This is necessary due to change in https://github.com/GEOS-ESM/GEOSgcm_GridComp/pull/1101
 