### PR TITLE
v12: Update regress, fix bug in gcm_run for OpenMP

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,7 +21,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, '0 diff trivial')"
     runs-on: ubuntu-24.04
     container:
-      image: gmao/ubuntu24-geos-env:v7.32.0-intelmpi_2021.13-ifort_2021.13
+      image: gmao/ubuntu24-geos-env:v8.14.0-intelmpi_2021.13-ifort_2021.13
       # Per https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495
       # It seems like we might not need secrets on GitHub Actions which is good for forked
       # pull requests

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -443,8 +443,8 @@ set OGCM_NY0 = `grep "^ *OGCM.NY:" AGCM.rc.orig | cut -d':' -f2`
 # We can generically set the lengths of startstop and layout tests
 # and use those values to set the test durations for the various steps
 
-set length_of_startstop_test = 240000
-set length_of_layout_test    = 060000
+set length_of_startstop_test = 120000
+set length_of_layout_test    = 030000
 
 # Now for safety, we need to make sure that the test durations
 # are divisible by 3 hours due to a limitation in GOCART. We'll use modulo
@@ -475,7 +475,7 @@ set test_duration_step5 = $test_duration_step2
 ##################################################################
 ######
 ######               Perform Regression Test # 1
-######                (1-Day Using NX:NY Layout)
+######               (12-Hour Using NX:NY Layout)
 ######
 ##################################################################
 
@@ -530,7 +530,7 @@ endif
 ##################################################################
 ######
 ######               Perform Regression Test # 2
-######               (6-Hour Using NX:NY Layout)
+######               (3-Hour Using NX:NY Layout)
 ######
 ##################################################################
 
@@ -634,7 +634,7 @@ end
 ##################################################################
 ######
 ######               Perform Regression Test # 3
-######               (18-Hour Using NX:NY Layout)
+######               (9-Hour Using NX:NY Layout)
 ######
 ##################################################################
 
@@ -710,7 +710,7 @@ endif
 ##################################################################
 ######
 ######               Perform Regression Test # 4
-######               (6-Hour Using 1:6 Layout)
+######               (3-Hour Using NX:NY/2 Layout)
 ######
 ##################################################################
 
@@ -718,8 +718,12 @@ endif
 
 if ( $RUN_LAYOUT == TRUE) then
 
-   set test_NX = 1
-   set test_NY = 6
+   set test_NX = ${NX0}
+   @ test_NY = ${NY0} / 2
+
+   if ($test_NY < 6) then
+      set test_NY = 6
+   endif
 
    # Copy Original Restarts to Regress directory
    # -------------------------------------------
@@ -833,7 +837,7 @@ endif
 ##################################################################
 ######
 ######               Perform Regression Test # 5
-######               (6-Hour OpenMP:2)
+######               (3-Hour OpenMP:2)
 ######
 ##################################################################
 

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -763,15 +763,20 @@ if ( $RUN_LAYOUT == TRUE) then
    /bin/mv AGCM.rc AGCM.tmp
    cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
 
-   # Set the new number of writers and readers
-   set oldstring = `cat AGCM.rc | grep "^ *NUM_WRITERS:"`
-   set newstring = "NUM_WRITERS: 6"
-   /bin/mv AGCM.rc AGCM.tmp
-   cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
-   set oldstring = `cat AGCM.rc | grep "^ *NUM_READERS:"`
-   set newstring = "NUM_READERS: 6"
-   /bin/mv AGCM.rc AGCM.tmp
-   cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
+   # MAT: Turning this off for now as it seems to cause
+   #      crazy slowness at times. Will re-enable if cause
+   #      is found and fixed.
+   ###############################################################
+   # # Set the new number of writers and readers                 #
+   # set oldstring = `cat AGCM.rc | grep "^ *NUM_WRITERS:"`      #
+   # set newstring = "NUM_WRITERS: 6"                            #
+   # /bin/mv AGCM.rc AGCM.tmp                                    #
+   # cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc #
+   # set oldstring = `cat AGCM.rc | grep "^ *NUM_READERS:"`      #
+   # set newstring = "NUM_READERS: 6"                            #
+   # /bin/mv AGCM.rc AGCM.tmp                                    #
+   # cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc #
+   ###############################################################
 
    @COUPLED set oldstring = `cat AGCM.rc | grep "^ *OGCM.NX:"`
    @COUPLED set newstring = "OGCM.NX: ${test_NY}"
@@ -893,16 +898,6 @@ if ( $RUN_OPENMP == TRUE) then
    cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
    set oldstring = `cat AGCM.rc | grep "^ *NY:"`
    set newstring = "NY: ${NY0}"
-   /bin/mv AGCM.rc AGCM.tmp
-   cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
-
-   # Set the new number of writers and readers
-   set oldstring = `cat AGCM.rc | grep "^ *NUM_WRITERS:"`
-   set newstring = "NUM_WRITERS: 6"
-   /bin/mv AGCM.rc AGCM.tmp
-   cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
-   set oldstring = `cat AGCM.rc | grep "^ *NUM_READERS:"`
-   set newstring = "NUM_READERS: 6"
    /bin/mv AGCM.rc AGCM.tmp
    cat AGCM.tmp | sed -e "s?$oldstring?$newstring?g" > AGCM.rc
 

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -1109,6 +1109,8 @@ if ($OMP_NUM_THREADS > 1) then
   setenv KMP_AFFINITY compact
   echo OMP_STACKSIZE    $OMP_STACKSIZE
   echo KMP_AFFINITY     $KMP_AFFINITY
+  ./strip GWD_GridComp.rc
+  sed -i -e "s|FALSE|TRUE|g" GWD_GridComp.rc
 endif
 echo OMP_NUM_THREADS $OMP_NUM_THREADS
 
@@ -1135,6 +1137,11 @@ else
    set rc = -1
 endif
 echo GEOSgcm Run Status: $rc
+
+# Reset OpenMP Threads to 1
+setenv OMP_NUM_THREADS 1
+./strip GWD_GridComp.rc
+sed -i -e "s|TRUE|FALSE|g" GWD_GridComp.rc
 
 @MIT # ---------------------------------------------------
 @MIT # For MITgcm restarts - after running GEOSgcm.x


### PR DESCRIPTION
This PR has two purposes.

1. Fix a bug in `gcm_run.j` when running with more than one OpenMP thread. This fix was already in `gcm_regress.j` but apparently was not ported to `gcm_run.j`
2. Update the `gcm_regress.j` script to use less resources
   1. We now do 12 hour runs with a 3+9 for start-stop and 3 hr for layout and OpenMP
   2. Change the layout run from 1-by-6 to NX-by-(NY/2)

I've also removed the `NUM_WRITERS` change in steps 4 and 5. It's causing some sort of issue, see https://github.com/GEOS-ESM/MAPL/issues/3687
