### PR TITLE
v12: Add two scm cases

### DIFF
--- a/scm_setup
+++ b/scm_setup
@@ -66,6 +66,8 @@ allowed_cases+=("bomex")
 allowed_cases+=("dycoms_rf01")
 allowed_cases+=("arm_97jun")
 allowed_cases+=("dry_cbl")
+allowed_cases+=("rico")
+allowed_cases+=("gabls1")
 
 sorted_cases=($(for each in ${allowed_cases[@]}; do echo $each; done | sort))
 
@@ -362,6 +364,12 @@ case $selected_case in
       ;;
    "LASIC_aug2016")
       DATFILE="merra2_lasic_aug2016.dat"
+      ;;
+   "rico")
+      DATFILE="rico.dat"
+      ;;
+   "gabls1")
+      DATFILE="gabls1.dat"
       ;;
    *)
       echo "You should not be here!"


### PR DESCRIPTION
@narnold1 sent me a couple cases: `rico` and `gabls1`.

`rico` works for me, but not `gabls1`, but without this PR, you can't really even test easily since they aren't recognized.