### PR TITLE
v11: Fix for gcm_regress.j for MAPL 2.60

### DIFF
--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -216,7 +216,7 @@ endif
 set         FILE = HISTORY.rc0
 /bin/rm -f $FILE
 cat << _EOF_ > $FILE
-
+VERSION: 1
 EXPID:  ${EXPID}
 EXPDSC: ${EXPID}_Regression_Test
 


### PR DESCRIPTION
This PR is a bugfix for `gcm_regress.j` needed for MAPL 2.60. In MAPL 2.60, the default history version was "bumped" from `0` to `1`. But `VERSION: 1` of `HISTORY.rc` requires a `GRID_LABELS:` section, and the test history in `gcm_regress.j` didn't have that!

This fixes that by just using the latlon grid for c48.