### PR TITLE
v11: Add better exit control for gcm_run.j

### DIFF
--- a/gcm_run.j
+++ b/gcm_run.j
@@ -857,7 +857,7 @@ endif
 #ln -sf $SSTDIR/dataoceanfile_MERRA2_SST.${OGCM_IM}x${OGCM_JM}.${yy}.data sst.data
 #ln -sf $SSTDIR/dataoceanfile_MERRA2_ICE.${OGCM_IM}x${OGCM_JM}.${yy}.data fraci.data
 
-@CICE6 #detect exisistence of certain fields in CICE6 restart
+@CICE6 #detect existence of certain fields in CICE6 restart
 @CICE6 ncdump -h INPUT/iced.nc | grep 'apnd' > /dev/null
 @CICE6 if( $status == 0 ) then
 @CICE6    echo 'pond state in restart, turn on restart flag if not already'
@@ -1092,12 +1092,18 @@ endif
 @SINGULARITY_BUILD @OCEAN_PRELOAD $RUN_CMD $TOTAL_PES $SINGULARITY_RUN $GEOSEXE $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 @NATIVE_BUILD @OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $TOTAL_PES $GEOSEXE $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 
+if ($status != 0) then
+   echo "GEOSgcm.x failed with return code $status"
+   exit $status
+endif
+
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 
 if( -e EGRESS ) then
    set rc = 0
 else
-   set rc = -1
+   echo "EGRESS file not found, GEOSgcm.x likely failed"
+   exit 9
 endif
 echo GEOSgcm Run Status: $rc
 

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -1092,9 +1092,13 @@ endif
 @SINGULARITY_BUILD @OCEAN_PRELOAD $RUN_CMD $TOTAL_PES $SINGULARITY_RUN $GEOSEXE $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 @NATIVE_BUILD @OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $TOTAL_PES $GEOSEXE $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 
-if ($status != 0) then
-   echo "GEOSgcm.x failed with return code $status"
-   exit $status
+# Capture the return code from GEOSgcm.x
+# --------------------------------------
+set run_status = $status
+
+if ($run_status != 0) then
+   echo "GEOSgcm.x failed with return code $run_status"
+   exit $run_status
 endif
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -133,7 +133,7 @@ if ( $NCPUS != NULL ) then
          echo "Specified model nodes: $NUM_MODEL_NODES"
          echo "Specified oserver nodes: $NUM_OSERVER_NODES"
          echo "Specified cores per node: $NCPUS_PER_NODE"
-         exit
+         exit 1
       endif
 
    else
@@ -151,7 +151,7 @@ if ( $NCPUS != NULL ) then
          echo ""
          echo "Specified model nodes: $NUM_MODEL_NODES"
          echo "Specified cores per node: $NCPUS_PER_NODE"
-         exit
+         exit 1
       endif
 
    endif
@@ -271,7 +271,7 @@ if (-z input.nml) then
 endif
 if (-z input.nml) then
    echo "input.nml is zero-length"
-   exit 0
+   exit 2
 endif
 
 @MOM6cp -f  $HOMDIR/MOM_input .
@@ -368,7 +368,7 @@ chmod +x linkbcs
 @SINGULARITY_BUILD # Error out if SINGULARITY_SANDBOX is not set
 @SINGULARITY_BUILD if( $SINGULARITY_SANDBOX == "" ) then
 @SINGULARITY_BUILD    echo "ERROR: You must set SINGULARITY_SANDBOX to the path to your Singularity sandbox"
-@SINGULARITY_BUILD    exit 1
+@SINGULARITY_BUILD    exit 3
 @SINGULARITY_BUILD endif
 @SINGULARITY_BUILD
 @SINGULARITY_BUILD # If SINGULARITY_SANDBOX is non-empty, then run executable in singularity sandbox
@@ -423,7 +423,7 @@ chmod +x linkbcs
 @NATIVE_BUILD    /bin/cp $EXPDIR/GEOSgcm.x $SCRDIR/GEOSgcm.x
 @NATIVE_BUILD else
 @NATIVE_BUILD    echo "$EXPDIR/GEOSgcm.x not found. Please link or copy the executable to the experiment directory."
-@NATIVE_BUILD    exit 1
+@NATIVE_BUILD    exit 4
 @NATIVE_BUILD endif
 @NATIVE_BUILD setenv GEOSEXE $SCRDIR/GEOSgcm.x
 
@@ -453,7 +453,7 @@ if( $GCMEMIP == TRUE ) then
      foreach rst ( $tile_rsts )
         echo ${rst}_internal_rst
      end
-     exit
+     exit 5
    endif
    if(-e $EXPDIR/restarts/$RSTDATE/fvcore_internal_face_1_rst) then
      set rst_by_face = YES
@@ -465,7 +465,7 @@ else
      foreach rst ( $tile_rsts )
         echo ${rst}_internal_rst
      end
-     exit
+     exit 5
    endif
    if(-e $EXPDIR/fvcore_internal_face_1_rst) then
      set rst_by_face = YES
@@ -959,7 +959,7 @@ if ( $PCHEM_CLIM_YEARS == 39 ) then
    # String comparison seems to work here...
    if ( $YEARMON > $MERRA2OX_END_DATE ) then
       echo "You seem to be using MERRA2OX pchem species file, but your simulation date [${YEARMON}] is after 201706. This file is only valid until this time."
-      exit 2
+      exit 8
    endif
 endif
 
@@ -1062,7 +1062,7 @@ endif
 @MIT     echo "If this is a new initialized experiment, delete:"
 @MIT     echo "${EXPDIR}/restarts/MITgcm_restart_dates.txt"
 @MIT     echo "and restart"
-@MIT     exit
+@MIT     exit 9
 @MIT   else
 @MIT     sed -i "s/nIter0.*/ nIter0           = ${nIter0},/" data
 @MIT   endif
@@ -1107,7 +1107,7 @@ if( -e EGRESS ) then
    set rc = 0
 else
    echo "EGRESS file not found, GEOSgcm.x likely failed"
-   exit 9
+   exit 10
 endif
 echo GEOSgcm Run Status: $rc
 


### PR DESCRIPTION
Closes #774

This is an attempt to try to have better exit control from `gcm_run.j`

---

Closes #818 

In re #818, this PR tries to update all the "bad" `exit` calls in `gcm_run.j` to have a non-zero status. Hopefully this leads to better trapping with cylc, et al.

cc: @Dooruk 