### PR TITLE
v12: Try to detect NCPUS_PER_NODE if we can

### DIFF
--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -183,7 +183,19 @@ endif
 
 @ MODEL_NPES = $NX * $NY
 
-set NCPUS_PER_NODE = @NCPUS_PER_NODE
+if ($?SLURM_NTASKS_PER_NODE) then
+   set NCPUS_PER_NODE = $SLURM_NTASKS_PER_NODE
+else if ($?SLURM_CPUS_ON_NODE) then
+   set NCPUS_PER_NODE = $SLURM_CPUS_ON_NODE
+else if ($?PBS_NODEFILE) then
+   # Get CPU count for the first node (assuming homogeneous cluster)
+   set NCPUS_PER_NODE = `sort $PBS_NODEFILE | uniq -c | head -1 | awk '{print $1}'`
+else
+   # This is the default value if nothing is specified that is used
+   # for desktops and laptops from gcm_setup
+   set NCPUS_PER_NODE = @NCPUS_PER_NODE
+endif
+
 set NUM_MODEL_NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
 if ( $NCPUS != NULL ) then

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -169,7 +169,19 @@ endif
 
 @ MODEL_NPES = $NX * $NY
 
-set NCPUS_PER_NODE = @NCPUS_PER_NODE
+if ($?SLURM_NTASKS_PER_NODE) then
+   set NCPUS_PER_NODE = $SLURM_NTASKS_PER_NODE
+else if ($?SLURM_CPUS_ON_NODE) then
+   set NCPUS_PER_NODE = $SLURM_CPUS_ON_NODE
+else if ($?PBS_NODEFILE) then
+   # Get CPU count for the first node (assuming homogeneous cluster)
+   set NCPUS_PER_NODE = `sort $PBS_NODEFILE | uniq -c | head -1 | awk '{print $1}'`
+else
+   # This is the default value if nothing is specified that is used
+   # for desktops and laptops from gcm_setup
+   set NCPUS_PER_NODE = @NCPUS_PER_NODE
+endif
+
 set NUM_MODEL_NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`
 
 if ( $NCPUS != NULL ) then

--- a/gcm_run.j-new_rst_approach
+++ b/gcm_run.j-new_rst_approach
@@ -128,7 +128,7 @@ else
          setenv SCRDIR $EXPDIR/$SCRDIR_NAME
          if (-e $SCRDIR ) /bin/rm -rf $SCRDIR
          mkdir -p $SCRDIR
-       endif 
+       endif
     endif
 endif
 
@@ -172,15 +172,16 @@ endif
 @ MODEL_NPES = $NX * $NY
 
 if ($?SLURM_NTASKS_PER_NODE) then
-    set NCPUS_PER_NODE = $SLURM_NTASKS_PER_NODE
+   set NCPUS_PER_NODE = $SLURM_NTASKS_PER_NODE
 else if ($?SLURM_CPUS_ON_NODE) then
-    set NCPUS_PER_NODE = $SLURM_CPUS_ON_NODE
+   set NCPUS_PER_NODE = $SLURM_CPUS_ON_NODE
 else if ($?PBS_NODEFILE) then
-    # Get CPU count for the first node (assuming homogeneous cluster)
-    set NCPUS_PER_NODE = `sort $PBS_NODEFILE | uniq -c | head -1 | awk '{print $1}'`
+   # Get CPU count for the first node (assuming homogeneous cluster)
+   set NCPUS_PER_NODE = `sort $PBS_NODEFILE | uniq -c | head -1 | awk '{print $1}'`
 else
-    echo "NCPUS_PER_NODE is Not Defined!!"
-    exit 0
+   # This is the default value if nothing is specified that is used
+   # for desktops and laptops from gcm_setup
+   set NCPUS_PER_NODE = @NCPUS_PER_NODE
 endif
 
 set NUM_MODEL_NODES=`echo "scale=6;($MODEL_NPES / $NCPUS_PER_NODE)" | bc | awk 'function ceil(x, y){y=int(x); return(x>y?y+1:y)} {print ceil($1)}'`


### PR DESCRIPTION
This was inspired by @sinakhani who I asked to try using 80 tasks per node in a run he was doing and he hit the "`NCPUS_PER_NODE` is hardcoded to 120" issue.

So we borrow from `gcm_run.j-new_rst_approach` and tweak a bit. now we do:
```csh
if ($?SLURM_NTASKS_PER_NODE) then
   set NCPUS_PER_NODE = $SLURM_NTASKS_PER_NODE
else if ($?SLURM_CPUS_ON_NODE) then
   set NCPUS_PER_NODE = $SLURM_CPUS_ON_NODE
else if ($?PBS_NODEFILE) then
   # Get CPU count for the first node (assuming homogeneous cluster)
   set NCPUS_PER_NODE = `sort $PBS_NODEFILE | uniq -c | head -1 | awk '{print $1}'`
else
   # This is the default value if nothing is specified that is used
   # for desktops and laptops from gcm_setup
   set NCPUS_PER_NODE = @NCPUS_PER_NODE
endif
```

Now, that second one `SLURM_CPUS_ON_NODE` probably never will be hit as I always get `SLURM_NTASKS_PER_NODE` on discover, but it is a good fallback. 

We also fail over to `set NCPUS_PER_NODE = @NCPUS_PER_NODE` as `gcm_setup` does check and use the number of cores on desktops and laptops.