### PR TITLE
v11: Set OMP_NUM_THREADS=1 explicitly in scm_run.j

### DIFF
--- a/scm_run.j
+++ b/scm_run.j
@@ -37,4 +37,6 @@ $GEOSBIN/construct_extdata_yaml_list.py GEOS_ChemGridComp.rc
 # investigate further.
 echo "file_weights: @FILE_WEIGHTS" >> extdata.yaml
 
+setenv OMP_NUM_THREADS 1
+
 $RUN_CMD 1 ./GEOSgcm.x --logging_config 'logging.yaml'


### PR DESCRIPTION
In testing the SCM on macOS with spack, it was found we need to explicitly set `OMP_NUM_THREADS=1` or things fall apart in gwd reading the Beres file:

```
Real*4 Resource Parameter: NCAR_DC_BERES_SRC_LEVEL:70000.000000, (default value)
Logical Resource Parameter: NCAR_DC_BERES:T, (default value)

Program received signal SIGILL: Illegal instruction.

Backtrace for this error:

Could not print backtrace: executable file is not an executable

Could not print backtrace: executable file is not an executable

Could not print backtrace: executable file is not an executable

Could not print backtrace: executable file is not an executable
#0  0x11235a103
#1  0x112359083
#2  0x18ad696a3
```

Looks like by default, in a spack environment everything is apparently all threads