### PR TITLE
v12: Fixes for scm_setup

### DIFF
--- a/scm_setup
+++ b/scm_setup
@@ -95,7 +95,7 @@ usage ()
    echo "    --account: account under which to run the job"
    echo
    echo "  Optional argument: "
-   echo "    --num_levels: number of levels (default: 181; 72, 71, 91, 132, 137, and 181 allowed)."
+   echo "    --num_levels: number of levels (default: 181; 72, 91, 137, and 181 allowed)."
    echo
    echo "  Optional env vars: "
    echo "    When running on the TBC data, you can set TINYBCS_PATH to point to the dataset or you can answer the prompt."
@@ -177,9 +177,9 @@ then
    exit 1
 fi
 
-if [[ $nlev -ne 72 ]]  &&  [[ $nlev -ne 132 ]] && [[ $nlev -ne 91 ]] && [[ $nlev -ne 137 ]] && [[ $nlev -ne 181 ]] && [[ $nlev -ne 71 ]]
+if [[ $nlev -ne 72 ]]  &&  [[ $nlev -ne 91 ]] && [[ $nlev -ne 137 ]] && [[ $nlev -ne 181 ]]
 then
-   echo "ERROR: nlev needs to be 72, 71, 91, 132, 137, or 181"
+   echo "ERROR: nlev needs to be 72, 91, 137, or 181"
    usage
    exit 1
 fi
@@ -538,6 +538,26 @@ then
   /bin/mv $expdir/moist_internal_rst.r0001x0001x${padlev} $expdir/moist_internal_rst
 
 fi
+
+# We need to handle KLID like gcm_setup does
+## First, initialize to 0
+KLID="0.0"
+
+## Now, we need to set KLID based on the number of levels
+if [ $nlev -ge 181 ]
+then
+   KLID="19.0"
+elif [ $nlev -eq 137 ]
+then
+   KLID="14.0"
+elif [ $nlev -eq 91 ]
+then
+   KLID="13.0"
+elif [ $nlev -eq 72 ]
+then
+   KLID="14.0"
+fi
+$ISED "s#@KLID#$KLID#g" $expdir/AGCM.rc
 
 /bin/ln -s $CHMDIR/g5chem $expdir/ExtData
 /bin/ln -s $CHMDIR/PIESA $expdir/ExtData


### PR DESCRIPTION
This PR has fixes for `scm_setup` which brings over changes from @wmputman for setting `KLID`, see https://github.com/GEOS-ESM/GEOSgcm_App/commit/b1a901bf8c739ef81c64f0ac8c222fc47817cbbe

NOTE: to @narnold1 and @FlorianDeconinck , I had to cut down the allowed vertical resolutions because I didn't have valid `KLID` values for some LM.