### PR TITLE
v11: Fix for lnfm.data symlink

### DIFF
--- a/linkbcs.tmpl
+++ b/linkbcs.tmpl
@@ -56,7 +56,7 @@ setenv BCRSLV    @ATMOStag_@OCEANtag
 /bin/ln -sf $BCSDIR/land/$BCRSLV/green_clim_@AGCM_IMx@AGCM_JM.data green.data
 /bin/ln -sf $BCSDIR/land/$BCRSLV/ndvi_clim_@AGCM_IMx@AGCM_JM.data ndvi.data
 
-@GCMRUN_CATCHCNif ( -f $BCSDIR/$BCRSLV/lnfm_clim_@AGCM_IMx@AGCM_JM.data  ) /bin/ln -sf $BCSDIR/$BCRSLV/lnfm_clim_@AGCM_IMx@AGCM_JM.data lnfm.data
+@GCMRUN_CATCHCNif ( -f $BCSDIR/land/$BCRSLV/lnfm_clim_@AGCM_IMx@AGCM_JM.data  ) /bin/ln -sf $BCSDIR/land/$BCRSLV/lnfm_clim_@AGCM_IMx@AGCM_JM.data lnfm.data
 @GCMRUN_CATCHCN/bin/ln -s $BCSDIR/land/shared/CO2_MonthlyMean_DiurnalCycle.nc4
 
 


### PR DESCRIPTION
@sshakoor1 found a bug in linkbcs where if CatchCN was on a symlink was incorrect:
```
> lt /discover/nobackup/projects/gmao/bcs_shared/fvInput/ExtData/esm/tiles/v11/CF0024x6C_DE1440xPE0720/lnfm_clim_24x144.data
"/discover/nobackup/projects/gmao/bcs_shared/fvInput/ExtData/esm/tiles/v11/CF0024x6C_DE1440xPE0720/lnfm_clim_24x144.data": No such file or directory (os error 2)
```
the line was missing the `land/`:
```
> lt /discover/nobackup/projects/gmao/bcs_shared/fvInput/ExtData/esm/tiles/v11/land/CF0024x6C_DE1440xPE0720/lnfm_clim_24x144.data
Permissions Size User     Group  Date Modified    Name
.r-xrwxr-x   19M borescan bcsgen 2023-10-12 15:27  /discover/nobackup/projects/gmao/bcs_shared/fvInput/ExtData/esm/tiles/v11/land/CF0024x6C_DE1440xPE0720/lnfm_clim_24x144.data*
```

This fixes that path.