### PR TITLE
v12: Set L72 parameters to match v11

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -87,6 +87,7 @@ ORBIT_ANAL2B: .TRUE.
 # BACM_1M microphysics options
 # ----------------------------------------
 @BACM_1M_CLDMICR_OPTION: BACM_1M
+@BACM_1M_USE_GF2020: 0
 ###########################################################
 
 ###########################################################
@@ -133,6 +134,11 @@ NCAR_NRDG: @NCAR_NRDG
 # The below settings are only for v14 BCs currently being tested
 #v14 NCAR_EFFGWORO: 0.35
 #v14 NCAR_ORO_TNDMAX: 250
+
+# For BACM_1M we revert to v11 TURB settings
+@BACM_1M_TURBULENCE_LAMBDAH: 160.0
+@BACM_1M_TURBULENCE_LAMBDAM: 160.0
+
 ###########################################################
 
 ###########################################################

--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -924,14 +924,17 @@ HCFC22_FRIENDLIES: DYNAMICS:TURBULENCE:MOIST
 
 # Set RADIATION Parameterizations
 # -------------------------------
-USE_RRTMGP_IRRAD: 1.0
-USE_RRTMGP_SORAD: 1.0
-RRTMGP_GAS_LW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-gas-lw-g128.nc
-RRTMGP_GAS_SW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-gas-sw-g112.nc
-RRTMGP_CLOUD_OPTICS_LW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-clouds-lw.nc
-RRTMGP_CLOUD_OPTICS_SW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-clouds-sw.nc
+@RRTMGP_RADIATION USE_RRTMGP_IRRAD: 1.0
+@RRTMGP_RADIATION USE_RRTMGP_SORAD: 1.0
+@RRTMGP_RADIATION RRTMGP_GAS_LW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-gas-lw-g128.nc
+@RRTMGP_RADIATION RRTMGP_GAS_SW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-gas-sw-g112.nc
+@RRTMGP_RADIATION RRTMGP_CLOUD_OPTICS_LW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-clouds-lw.nc
+@RRTMGP_RADIATION RRTMGP_CLOUD_OPTICS_SW: ExtData/g5gcm/radiation/RRTMGP/v1.8/rrtmgp-clouds-sw.nc
+@RRTMGP_RADIATION SOLAR_LB_MAX_PASSES: 10
 
-SOLAR_LB_MAX_PASSES: 10
+@RRTMG_RADIATION USE_RRTMG_IRRAD: 1.0
+@RRTMG_RADIATION USE_RRTMG_SORAD: 1.0
+
 ISOLVAR: 2
 USE_NRLSSI2: .TRUE.
 SOLAR_CYCLE_FILE_NAME: ExtData/g5gcm/solar/NRLSSI2.txt

--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -87,7 +87,6 @@ ORBIT_ANAL2B: .TRUE.
 # BACM_1M microphysics options
 # ----------------------------------------
 @BACM_1M_CLDMICR_OPTION: BACM_1M
-@BACM_1M_USE_GF2020: 0
 ###########################################################
 
 ###########################################################
@@ -114,6 +113,7 @@ SHALLOW_OPTION: UW
 # convection scheme options
 # ----------------------------------------
 CONVPAR_OPTION: @CONVPAR_OPTION
+@BACM_1M_USE_GF2020: 0
 # Convective plumes to be activated (1 true, 0 false)
 DEEP: 1
 SHALLOW: 0

--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -678,16 +678,14 @@ if( $EXTDATA2G_TRUE == 1 ) then
 
 endif
 
-# Move GOCART to use RRTMGP Bands
-# -------------------------------
-# UNCOMMENT THE LINES BELOW IF RUNNING RRTMGP
-#
-set instance_files = `/bin/ls -1 *_instance*.rc`
-foreach instance ($instance_files)
-   /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
-   /bin/rm $instance.tmp
-end
+@RRTMGP_RADIATION # Move GOCART to use RRTMGP Bands
+@RRTMGP_RADIATION # -------------------------------
+@RRTMGP_RADIATION set instance_files = `/bin/ls -1 *_instance*.rc`
+@RRTMGP_RADIATION foreach instance ($instance_files)
+   @RRTMGP_RADIATION /bin/mv $instance $instance.tmp
+   @RRTMGP_RADIATION cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
+   @RRTMGP_RADIATION /bin/rm $instance.tmp
+@RRTMGP_RADIATION end
 
 # Link Boundary Conditions for Appropriate Date
 # ---------------------------------------------

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -403,16 +403,14 @@ if( $LM  != 72 ) then
     endif
 endif
 
-# Move GOCART to use RRTMGP Bands
-# -------------------------------
-# UNCOMMENT THE LINES BELOW IF RUNNING RRTMGP
-#
-set instance_files = `/bin/ls -1 *_instance*.rc`
-foreach instance ($instance_files)
-   /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
-   /bin/rm $instance.tmp
-end
+@RRTMGP_RADIATION # Move GOCART to use RRTMGP Bands
+@RRTMGP_RADIATION # -------------------------------
+@RRTMGP_RADIATION set instance_files = `/bin/ls -1 *_instance*.rc`
+@RRTMGP_RADIATION foreach instance ($instance_files)
+   @RRTMGP_RADIATION /bin/mv $instance $instance.tmp
+   @RRTMGP_RADIATION cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
+   @RRTMGP_RADIATION /bin/rm $instance.tmp
+@RRTMGP_RADIATION end
 
 # If REPLAY, link necessary forcing files
 # ---------------------------------------

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -879,16 +879,14 @@ if( $EXTDATA2G_TRUE == 1 ) then
 
 endif
 
-# Move GOCART to use RRTMGP Bands
-# -------------------------------
-# UNCOMMENT THE LINES BELOW IF RUNNING RRTMGP
-#
-set instance_files = `/bin/ls -1 *_instance*.rc`
-foreach instance ($instance_files)
-   /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
-   /bin/rm $instance.tmp
-end
+@RRTMGP_RADIATION # Move GOCART to use RRTMGP Bands
+@RRTMGP_RADIATION # -------------------------------
+@RRTMGP_RADIATION set instance_files = `/bin/ls -1 *_instance*.rc`
+@RRTMGP_RADIATION foreach instance ($instance_files)
+   @RRTMGP_RADIATION /bin/mv $instance $instance.tmp
+   @RRTMGP_RADIATION cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
+   @RRTMGP_RADIATION /bin/rm $instance.tmp
+@RRTMGP_RADIATION end
 
 # Link Boundary Conditions for Appropriate Date
 # ---------------------------------------------

--- a/gcm_run.j-new_rst_approach
+++ b/gcm_run.j-new_rst_approach
@@ -805,16 +805,14 @@ if( $EXTDATA2G_TRUE == 1 ) then
 
 endif
 
-# Move GOCART to use RRTMGP Bands
-# -------------------------------
-# UNCOMMENT THE LINES BELOW IF RUNNING RRTMGP
-#
-set instance_files = `/bin/ls -1 *_instance*.rc`
-foreach instance ($instance_files)
-   /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
-   /bin/rm $instance.tmp
-end
+@RRTMGP_RADIATION # Move GOCART to use RRTMGP Bands
+@RRTMGP_RADIATION # -------------------------------
+@RRTMGP_RADIATION set instance_files = `/bin/ls -1 *_instance*.rc`
+@RRTMGP_RADIATION foreach instance ($instance_files)
+   @RRTMGP_RADIATION /bin/mv $instance $instance.tmp
+   @RRTMGP_RADIATION cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
+   @RRTMGP_RADIATION /bin/rm $instance.tmp
+@RRTMGP_RADIATION end
 
 # Link Boundary Conditions for Appropriate Date
 # ---------------------------------------------

--- a/gcm_run_benchmark.j
+++ b/gcm_run_benchmark.j
@@ -695,16 +695,14 @@ if( $EXTDATA2G_TRUE == 1 ) then
 
 endif
 
-# Move GOCART to use RRTMGP Bands
-# -------------------------------
-# UNCOMMENT THE LINES BELOW IF RUNNING RRTMGP
-#
-set instance_files = `/bin/ls -1 *_instance*.rc`
-foreach instance ($instance_files)
-   /bin/mv $instance $instance.tmp
-   cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
-   /bin/rm $instance.tmp
-end
+@RRTMGP_RADIATION # Move GOCART to use RRTMGP Bands
+@RRTMGP_RADIATION # -------------------------------
+@RRTMGP_RADIATION set instance_files = `/bin/ls -1 *_instance*.rc`
+@RRTMGP_RADIATION foreach instance ($instance_files)
+   @RRTMGP_RADIATION /bin/mv $instance $instance.tmp
+   @RRTMGP_RADIATION cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
+   @RRTMGP_RADIATION /bin/rm $instance.tmp
+@RRTMGP_RADIATION end
 
 # Link Boundary Conditions for Appropriate Date
 # ---------------------------------------------

--- a/gcm_setup
+++ b/gcm_setup
@@ -2483,6 +2483,7 @@ endif
 if( $AGCM_LM == 72 ) then
     /bin/mv $EXPDIR/RC/GEOS_SurfaceGridComp.rc $EXPDIR/RC/GEOS_SurfaceGridComp.tmp
     cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | sed -e '/^ *SNOW_ALBEDO_INFO:/ s/1/0/' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
+endif
 
 # Enable DATA_DRIVEN GOCART2G
 # ---------------------------

--- a/gcm_setup
+++ b/gcm_setup
@@ -299,11 +299,27 @@ set LATLON_AGCM = "#DELETE"
 set CUBE_AGCM = ""
 
 echo "Enter the Atmospheric Model ${C1}Vertical Resolution${CN}: ${C2}LM${CN} (Default: 181)"
+echo "   NOTE: If you choose 72 levels, your defaults will change to match GEOSgcm v11:"
+echo "         - Microphysics will change to BACM_1M"
+echo "         - Land surface model boundary conditions will change to NL3"
+echo "         - Radiation will be set to RRTMG"
+echo "         - Default heartbeat will be set to 450 seconds"
 set   AGCM_LM = $<
 if( .$AGCM_LM == . ) then
   set AGCM_LM = 181
 endif
 
+#######################################################################
+#                 Set Radiation model
+#######################################################################
+
+if ( $AGCM_LM == 72 ) then
+   set RRTMG_RADIATION = ""
+   set RRTMGP_RADIATION = "#DELETE"
+else
+   set RRTMG_RADIATION = "#DELETE"
+   set RRTMGP_RADIATION = ""
+endif
 
 #######################################################################
 #                 Choose microphysics option
@@ -311,13 +327,18 @@ endif
 
 ASKMP:
 
-echo "Enter Choice for Atmospheric Model ${C1}Microphysics${CN}: (Default: GFDL_1M)"
+set DEFAULT_CLDMICRO = "GFDL_1M"
+if ( $AGCM_LM == 72 ) then
+   set DEFAULT_CLDMICRO = "BACM_1M"
+endif
+
+echo "Enter Choice for Atmospheric Model ${C1}Microphysics${CN}: (Default: ${C2}$DEFAULT_CLDMICRO${CN})"
 echo "   ${C2}BACM_1M  --  3-phase 1-moment Bacmeister et al${CN}"
 echo "   ${C2}GFDL_1M  --  6-phase 1-moment Geophysical Fluid Dynamics Laboratory${CN}"
 echo "   ${C2}MGB2_2M  --  5 or 6-phase 2-moment Morrison & Gettleman${CN}"
 set   CLDMICRO = $<
 if( .$CLDMICRO == . ) then
-   set CLDMICRO = "GFDL_1M"
+   set CLDMICRO = $DEFAULT_CLDMICRO
 else
    set CLDMICRO = `echo $CLDMICRO | tr "[:lower:]" "[:upper:]"`
    if( "$CLDMICRO" != "BACM_1M" & \
@@ -1072,9 +1093,18 @@ if ($DATA_ATMOS == TRUE) then
   set GWD_IN_BCS   = "FALSE"
 else
 
-echo "Enter the choice of ${C1}Land Surface Boundary Conditions${CN} using: ${C2}ICA${CN} (Icarus), ${C2}NL3${CN} (Icarus-NLv3), ${C2}v14${CN} (v14_BETA) or ${C2}v12${CN} (Default)"
+set DEFAULT_LSM_BCS = "v12"
+set LSM_BCS_V12_DEFAULT_STR = "${C2}v12${CN} (Default)"
+set LSM_BCS_NL3_DEFAULT_STR = "${C2}NL3${CN} (Icarus-NLv3)"
+if ( $AGCM_LM == 72 ) then
+   set DEFAULT_LSM_BCS = "NL3"
+   set LSM_BCS_V12_DEFAULT_STR = "${C2}v12${CN}"
+   set LSM_BCS_NL3_DEFAULT_STR = "${C2}NL3${CN} (Icarus-NLv3, Default)"
+endif
+
+echo "Enter the choice of ${C1}Land Surface Boundary Conditions${CN} using: ${C2}ICA${CN} (Icarus), ${LSM_BCS_NL3_DEFAULT_STR}, ${C2}v14${CN} (v14_BETA) or ${LSM_BCS_V12_DEFAULT_STR}"
 set   LSM_BCS  = $<
-if( .$LSM_BCS == . ) set LSM_BCS = "v12"
+if( .$LSM_BCS == . ) set LSM_BCS = ${DEFAULT_LSM_BCS}
 if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "ica" ) then
     set LSM_BCS      = "ICA"
     set LSM_PARMS    = "#DELETE"
@@ -2190,7 +2220,7 @@ s?@BACM_1M_?$BACM_1M_?g
 s?@GFDL_1M_?$GFDL_1M_?g
 s?@MGB2_2M_?$MGB2_2M_?g
 
-s?@KLID?$KLID?g 
+s?@KLID?$KLID?g
 
 s?@PRELOAD_COMMAND?$PRELOAD_COMMAND?g
 s?@LD_LIBRARY_PATH_CMD?$LD_LIBRARY_PATH_CMD?g
@@ -2198,6 +2228,9 @@ s?@RUN_CMD?$RUN_CMD?g
 
 s?@MODELATM?$MODELATM?g
 s?@USE_DATA_ATM4OCN?$USE_DATA_ATM4OCN?g
+
+s?@RRTMG_RADIATION?$RRTMG_RADIATION?g
+s?@RRTMGP_RADIATION?$RRTMGP_RADIATION?g
 
 EOF
 
@@ -2446,6 +2479,10 @@ if( $LSM_BCS == "ICA" ) then
     cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | \
     awk '{ if ($1~"Z0_FORMULATION:") { sub(/4/,"2") }; print }' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
 endif
+
+if( $AGCM_LM == 72 ) then
+    /bin/mv $EXPDIR/RC/GEOS_SurfaceGridComp.rc $EXPDIR/RC/GEOS_SurfaceGridComp.tmp
+    cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | sed -e '/^ *SNOW_ALBEDO_INFO:/ s/1/0/' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
 
 # Enable DATA_DRIVEN GOCART2G
 # ---------------------------

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -299,11 +299,27 @@ set LATLON_AGCM = "#DELETE"
 set CUBE_AGCM = ""
 
 echo "Enter the Atmospheric Model ${C1}Vertical Resolution${CN}: ${C2}LM${CN} (Default: 181)"
+echo "   NOTE: If you choose 72 levels, your defaults will change to match GEOSgcm v11:"
+echo "         - Microphysics will change to BACM_1M"
+echo "         - Land surface model boundary conditions will change to NL3"
+echo "         - Radiation will be set to RRTMG"
+echo "         - Default heartbeat will be set to 450 seconds"
 set   AGCM_LM = $<
 if( .$AGCM_LM == . ) then
   set AGCM_LM = 181
 endif
 
+#######################################################################
+#                 Set Radiation model
+#######################################################################
+
+if ( $AGCM_LM == 72 ) then
+   set RRTMG_RADIATION = ""
+   set RRTMGP_RADIATION = "#DELETE"
+else
+   set RRTMG_RADIATION = "#DELETE"
+   set RRTMGP_RADIATION = ""
+endif
 
 #######################################################################
 #                 Choose microphysics option
@@ -311,13 +327,18 @@ endif
 
 ASKMP:
 
-echo "Enter Choice for Atmospheric Model ${C1}Microphysics${CN}: (Default: GFDL_1M)"
+set DEFAULT_CLDMICRO = "GFDL_1M"
+if ( $AGCM_LM == 72 ) then
+   set DEFAULT_CLDMICRO = "BACM_1M"
+endif
+
+echo "Enter Choice for Atmospheric Model ${C1}Microphysics${CN}: (Default: ${C2}$DEFAULT_CLDMICRO${CN})"
 echo "   ${C2}BACM_1M  --  3-phase 1-moment Bacmeister et al${CN}"
 echo "   ${C2}GFDL_1M  --  6-phase 1-moment Geophysical Fluid Dynamics Laboratory${CN}"
 echo "   ${C2}MGB2_2M  --  5 or 6-phase 2-moment Morrison & Gettleman${CN}"
 set   CLDMICRO = $<
 if( .$CLDMICRO == . ) then
-   set CLDMICRO = "GFDL_1M"
+   set CLDMICRO = $DEFAULT_CLDMICRO
 else
    set CLDMICRO = `echo $CLDMICRO | tr "[:lower:]" "[:upper:]"`
    if( "$CLDMICRO" != "BACM_1M" & \
@@ -1026,8 +1047,13 @@ if ( "$CLDMICRO" == "BACM_1M" ) then
 endif
 
 set GFDL_1M_ = "#"
+set KLID = "0.0"
 if ( "$CLDMICRO" == "GFDL_1M" ) then
    set GFDL_1M_ = ""
+   if ($AGCM_LM >= 181) set KLID = "19.0"
+   if ($AGCM_LM == 137) set KLID = "14.0"
+   if ($AGCM_LM ==  91) set KLID = "13.0"
+   if ($AGCM_LM ==  72) set KLID = "14.0"
 endif
 
 set MGB2_2M_ = "#"
@@ -1067,9 +1093,18 @@ if ($DATA_ATMOS == TRUE) then
   set GWD_IN_BCS   = "FALSE"
 else
 
-echo "Enter the choice of ${C1}Land Surface Boundary Conditions${CN} using: ${C2}ICA${CN} (Icarus), ${C2}NL3${CN} (Icarus-NLv3), ${C2}v14${CN} (v14_BETA) or ${C2}v12${CN} (Default)"
+set DEFAULT_LSM_BCS = "v12"
+set LSM_BCS_V12_DEFAULT_STR = "${C2}v12${CN} (Default)"
+set LSM_BCS_NL3_DEFAULT_STR = "${C2}NL3${CN} (Icarus-NLv3)"
+if ( $AGCM_LM == 72 ) then
+   set DEFAULT_LSM_BCS = "NL3"
+   set LSM_BCS_V12_DEFAULT_STR = "${C2}v12${CN}"
+   set LSM_BCS_NL3_DEFAULT_STR = "${C2}NL3${CN} (Icarus-NLv3, Default)"
+endif
+
+echo "Enter the choice of ${C1}Land Surface Boundary Conditions${CN} using: ${C2}ICA${CN} (Icarus), ${LSM_BCS_NL3_DEFAULT_STR}, ${C2}v14${CN} (v14_BETA) or ${LSM_BCS_V12_DEFAULT_STR}"
 set   LSM_BCS  = $<
-if( .$LSM_BCS == . ) set LSM_BCS = "v12"
+if( .$LSM_BCS == . ) set LSM_BCS = ${DEFAULT_LSM_BCS}
 if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "ica" ) then
     set LSM_BCS      = "ICA"
     set LSM_PARMS    = "#DELETE"
@@ -2202,12 +2237,17 @@ s?@BACM_1M_?$BACM_1M_?g
 s?@GFDL_1M_?$GFDL_1M_?g
 s?@MGB2_2M_?$MGB2_2M_?g
 
+s?@KLID?$KLID?g
+
 s?@PRELOAD_COMMAND?$PRELOAD_COMMAND?g
 s?@LD_LIBRARY_PATH_CMD?$LD_LIBRARY_PATH_CMD?g
 s?@RUN_CMD?$RUN_CMD?g
 
 s?@MODELATM?$MODELATM?g
 s?@USE_DATA_ATM4OCN?$USE_DATA_ATM4OCN?g
+
+s?@RRTMG_RADIATION?$RRTMG_RADIATION?g
+s?@RRTMGP_RADIATION?$RRTMGP_RADIATION?g
 
 EOF
 
@@ -2620,6 +2660,10 @@ if( $LSM_BCS == "ICA" ) then
     cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | \
     awk '{ if ($1~"Z0_FORMULATION:") { sub(/4/,"2") }; print }' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
 endif
+
+if( $AGCM_LM == 72 ) then
+    /bin/mv $EXPDIR/RC/GEOS_SurfaceGridComp.rc $EXPDIR/RC/GEOS_SurfaceGridComp.tmp
+    cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | sed -e '/^ *SNOW_ALBEDO_INFO:/ s/1/0/' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
 
 # Enable DATA_DRIVEN GOCART2G
 # ---------------------------

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -2664,6 +2664,7 @@ endif
 if( $AGCM_LM == 72 ) then
     /bin/mv $EXPDIR/RC/GEOS_SurfaceGridComp.rc $EXPDIR/RC/GEOS_SurfaceGridComp.tmp
     cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | sed -e '/^ *SNOW_ALBEDO_INFO:/ s/1/0/' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
+endif
 
 # Enable DATA_DRIVEN GOCART2G
 # ---------------------------

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -299,11 +299,27 @@ set LATLON_AGCM = "#DELETE"
 set CUBE_AGCM = ""
 
 echo "Enter the Atmospheric Model ${C1}Vertical Resolution${CN}: ${C2}LM${CN} (Default: 181)"
+echo "   NOTE: If you choose 72 levels, your defaults will change to match GEOSgcm v11:"
+echo "         - Microphysics will change to BACM_1M"
+echo "         - Land surface model boundary conditions will change to NL3"
+echo "         - Radiation will be set to RRTMG"
+echo "         - Default heartbeat will be set to 450 seconds"
 set   AGCM_LM = $<
 if( .$AGCM_LM == . ) then
   set AGCM_LM = 181
 endif
 
+#######################################################################
+#                 Set Radiation model
+#######################################################################
+
+if ( $AGCM_LM == 72 ) then
+   set RRTMG_RADIATION = ""
+   set RRTMGP_RADIATION = "#DELETE"
+else
+   set RRTMG_RADIATION = "#DELETE"
+   set RRTMGP_RADIATION = ""
+endif
 
 #######################################################################
 #                 Choose microphysics option
@@ -311,13 +327,18 @@ endif
 
 ASKMP:
 
-echo "Enter Choice for Atmospheric Model ${C1}Microphysics${CN}: (Default: GFDL_1M)"
+set DEFAULT_CLDMICRO = "GFDL_1M"
+if ( $AGCM_LM == 72 ) then
+   set DEFAULT_CLDMICRO = "BACM_1M"
+endif
+
+echo "Enter Choice for Atmospheric Model ${C1}Microphysics${CN}: (Default: ${C2}$DEFAULT_CLDMICRO${CN})"
 echo "   ${C2}BACM_1M  --  3-phase 1-moment Bacmeister et al${CN}"
 echo "   ${C2}GFDL_1M  --  6-phase 1-moment Geophysical Fluid Dynamics Laboratory${CN}"
 echo "   ${C2}MGB2_2M  --  5 or 6-phase 2-moment Morrison & Gettleman${CN}"
 set   CLDMICRO = $<
 if( .$CLDMICRO == . ) then
-   set CLDMICRO = "GFDL_1M"
+   set CLDMICRO = $DEFAULT_CLDMICRO
 else
    set CLDMICRO = `echo $CLDMICRO | tr "[:lower:]" "[:upper:]"`
    if( "$CLDMICRO" != "BACM_1M" & \
@@ -1115,8 +1136,13 @@ if ( "$CLDMICRO" == "BACM_1M" ) then
 endif
 
 set GFDL_1M_ = "#"
+set KLID = "0.0"
 if ( "$CLDMICRO" == "GFDL_1M" ) then
    set GFDL_1M_ = ""
+   if ($AGCM_LM >= 181) set KLID = "19.0"
+   if ($AGCM_LM == 137) set KLID = "14.0"
+   if ($AGCM_LM ==  91) set KLID = "13.0"
+   if ($AGCM_LM ==  72) set KLID = "14.0"
 endif
 
 set MGB2_2M_ = "#"
@@ -1156,9 +1182,18 @@ if ($DATA_ATMOS == TRUE) then
   set GWD_IN_BCS   = "FALSE"
 else
 
-echo "Enter the choice of ${C1}Land Surface Boundary Conditions${CN} using: ${C2}ICA${CN} (Icarus), ${C2}NL3${CN} (Icarus-NLv3), ${C2}v14${CN} (v14_BETA) or ${C2}v12${CN} (Default)"
+set DEFAULT_LSM_BCS = "v12"
+set LSM_BCS_V12_DEFAULT_STR = "${C2}v12${CN} (Default)"
+set LSM_BCS_NL3_DEFAULT_STR = "${C2}NL3${CN} (Icarus-NLv3)"
+if ( $AGCM_LM == 72 ) then
+   set DEFAULT_LSM_BCS = "NL3"
+   set LSM_BCS_V12_DEFAULT_STR = "${C2}v12${CN}"
+   set LSM_BCS_NL3_DEFAULT_STR = "${C2}NL3${CN} (Icarus-NLv3, Default)"
+endif
+
+echo "Enter the choice of ${C1}Land Surface Boundary Conditions${CN} using: ${C2}ICA${CN} (Icarus), ${LSM_BCS_NL3_DEFAULT_STR}, ${C2}v14${CN} (v14_BETA) or ${LSM_BCS_V12_DEFAULT_STR}"
 set   LSM_BCS  = $<
-if( .$LSM_BCS == . ) set LSM_BCS = "v12"
+if( .$LSM_BCS == . ) set LSM_BCS = ${DEFAULT_LSM_BCS}
 if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "ica" ) then
     set LSM_BCS      = "ICA"
     set LSM_PARMS    = "#DELETE"
@@ -2381,12 +2416,17 @@ s?@BACM_1M_?$BACM_1M_?g
 s?@GFDL_1M_?$GFDL_1M_?g
 s?@MGB2_2M_?$MGB2_2M_?g
 
+s?@KLID?$KLID?g
+
 s?@PRELOAD_COMMAND?$PRELOAD_COMMAND?g
 s?@LD_LIBRARY_PATH_CMD?$LD_LIBRARY_PATH_CMD?g
 s?@RUN_CMD?$RUN_CMD?g
 
 s?@MODELATM?$MODELATM?g
 s?@USE_DATA_ATM4OCN?$USE_DATA_ATM4OCN?g
+
+s?@RRTMG_RADIATION?$RRTMG_RADIATION?g
+s?@RRTMGP_RADIATION?$RRTMGP_RADIATION?g
 
 EOF
 
@@ -2756,6 +2796,10 @@ if( $LSM_BCS == "ICA" ) then
     cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | \
     awk '{ if ($1~"Z0_FORMULATION:") { sub(/4/,"2") }; print }' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
 endif
+
+if( $AGCM_LM == 72 ) then
+    /bin/mv $EXPDIR/RC/GEOS_SurfaceGridComp.rc $EXPDIR/RC/GEOS_SurfaceGridComp.tmp
+    cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | sed -e '/^ *SNOW_ALBEDO_INFO:/ s/1/0/' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
 
 # Turn on GOCART
 # --------------

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2800,6 +2800,7 @@ endif
 if( $AGCM_LM == 72 ) then
     /bin/mv $EXPDIR/RC/GEOS_SurfaceGridComp.rc $EXPDIR/RC/GEOS_SurfaceGridComp.tmp
     cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | sed -e '/^ *SNOW_ALBEDO_INFO:/ s/1/0/' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
+endif
 
 # Turn on GOCART
 # --------------

--- a/set_resolution_params.csh
+++ b/set_resolution_params.csh
@@ -134,7 +134,12 @@ if( $AGCM_IM ==  "c180" ) then
            set  NX = $OGCM_NY
            set  NY = $OGCM_NX
         endif
+        # For coupled runs, set DT to 450
+        set DT = 450
         set OCEAN_DT = $DT
+        # Our other physics times steps must be divisible by DT
+        set CONV_DT = 450
+        set CHEM_DT = 900
      else
         set  NX = 20
         set  NY = `expr $NX \* 6`
@@ -430,6 +435,6 @@ endif
 if( "$LOCAL_CLDMICRO" == "BACM_1M" ) then
    set DT      = 450
    set CONV_DT = 450
-   set CHEM_DT = 3600
+   set CHEM_DT = 450
 endif
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -299,11 +299,27 @@ set LATLON_AGCM = "#DELETE"
 set CUBE_AGCM = ""
 
 echo "Enter the Atmospheric Model ${C1}Vertical Resolution${CN}: ${C2}LM${CN} (Default: 181)"
+echo "   NOTE: If you choose 72 levels, your defaults will change to match GEOSgcm v11:"
+echo "         - Microphysics will change to BACM_1M"
+echo "         - Land surface model boundary conditions will change to NL3"
+echo "         - Radiation will be set to RRTMG"
+echo "         - Default heartbeat will be set to 450 seconds"
 set   AGCM_LM = $<
 if( .$AGCM_LM == . ) then
   set AGCM_LM = 181
 endif
 
+#######################################################################
+#                 Set Radiation model
+#######################################################################
+
+if ( $AGCM_LM == 72 ) then
+   set RRTMG_RADIATION = ""
+   set RRTMGP_RADIATION = "#DELETE"
+else
+   set RRTMG_RADIATION = "#DELETE"
+   set RRTMGP_RADIATION = ""
+endif
 
 #######################################################################
 #                 Choose microphysics option
@@ -311,13 +327,18 @@ endif
 
 ASKMP:
 
-echo "Enter Choice for Atmospheric Model ${C1}Microphysics${CN}: (Default: GFDL_1M)"
+set DEFAULT_CLDMICRO = "GFDL_1M"
+if ( $AGCM_LM == 72 ) then
+   set DEFAULT_CLDMICRO = "BACM_1M"
+endif
+
+echo "Enter Choice for Atmospheric Model ${C1}Microphysics${CN}: (Default: ${C2}$DEFAULT_CLDMICRO${CN})"
 echo "   ${C2}BACM_1M  --  3-phase 1-moment Bacmeister et al${CN}"
 echo "   ${C2}GFDL_1M  --  6-phase 1-moment Geophysical Fluid Dynamics Laboratory${CN}"
 echo "   ${C2}MGB2_2M  --  5 or 6-phase 2-moment Morrison & Gettleman${CN}"
 set   CLDMICRO = $<
 if( .$CLDMICRO == . ) then
-   set CLDMICRO = "GFDL_1M"
+   set CLDMICRO = $DEFAULT_CLDMICRO
 else
    set CLDMICRO = `echo $CLDMICRO | tr "[:lower:]" "[:upper:]"`
    if( "$CLDMICRO" != "BACM_1M" & \
@@ -1026,8 +1047,13 @@ if ( "$CLDMICRO" == "BACM_1M" ) then
 endif
 
 set GFDL_1M_ = "#"
+set KLID = "0.0"
 if ( "$CLDMICRO" == "GFDL_1M" ) then
    set GFDL_1M_ = ""
+   if ($AGCM_LM >= 181) set KLID = "19.0"
+   if ($AGCM_LM == 137) set KLID = "14.0"
+   if ($AGCM_LM ==  91) set KLID = "13.0"
+   if ($AGCM_LM ==  72) set KLID = "14.0"
 endif
 
 set MGB2_2M_ = "#"
@@ -1067,9 +1093,18 @@ if ($DATA_ATMOS == TRUE) then
   set GWD_IN_BCS   = "FALSE"
 else
 
-echo "Enter the choice of ${C1}Land Surface Boundary Conditions${CN} using: ${C2}ICA${CN} (Icarus), ${C2}NL3${CN} (Icarus-NLv3), ${C2}v14${CN} (v14_BETA) or ${C2}v12${CN} (Default)"
+set DEFAULT_LSM_BCS = "v12"
+set LSM_BCS_V12_DEFAULT_STR = "${C2}v12${CN} (Default)"
+set LSM_BCS_NL3_DEFAULT_STR = "${C2}NL3${CN} (Icarus-NLv3)"
+if ( $AGCM_LM == 72 ) then
+   set DEFAULT_LSM_BCS = "NL3"
+   set LSM_BCS_V12_DEFAULT_STR = "${C2}v12${CN}"
+   set LSM_BCS_NL3_DEFAULT_STR = "${C2}NL3${CN} (Icarus-NLv3, Default)"
+endif
+
+echo "Enter the choice of ${C1}Land Surface Boundary Conditions${CN} using: ${C2}ICA${CN} (Icarus), ${LSM_BCS_NL3_DEFAULT_STR}, ${C2}v14${CN} (v14_BETA) or ${LSM_BCS_V12_DEFAULT_STR}"
 set   LSM_BCS  = $<
-if( .$LSM_BCS == . ) set LSM_BCS = "v12"
+if( .$LSM_BCS == . ) set LSM_BCS = ${DEFAULT_LSM_BCS}
 if( `echo $LSM_BCS | tr '[:upper:]' '[:lower:]'` == "ica" ) then
     set LSM_BCS      = "ICA"
     set LSM_PARMS    = "#DELETE"
@@ -2186,12 +2221,17 @@ s?@BACM_1M_?$BACM_1M_?g
 s?@GFDL_1M_?$GFDL_1M_?g
 s?@MGB2_2M_?$MGB2_2M_?g
 
+s?@KLID?$KLID?g
+
 s?@PRELOAD_COMMAND?$PRELOAD_COMMAND?g
 s?@LD_LIBRARY_PATH_CMD?$LD_LIBRARY_PATH_CMD?g
 s?@RUN_CMD?$RUN_CMD?g
 
 s?@MODELATM?$MODELATM?g
 s?@USE_DATA_ATM4OCN?$USE_DATA_ATM4OCN?g
+
+s?@RRTMG_RADIATION?$RRTMG_RADIATION?g
+s?@RRTMGP_RADIATION?$RRTMGP_RADIATION?g
 
 EOF
 
@@ -2486,6 +2526,10 @@ if( $LSM_BCS == "ICA" ) then
     cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | \
     awk '{ if ($1~"Z0_FORMULATION:") { sub(/4/,"2") }; print }' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
 endif
+
+if( $AGCM_LM == 72 ) then
+    /bin/mv $EXPDIR/RC/GEOS_SurfaceGridComp.rc $EXPDIR/RC/GEOS_SurfaceGridComp.tmp
+    cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | sed -e '/^ *SNOW_ALBEDO_INFO:/ s/1/0/' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
 
 # Enable DATA_DRIVEN GOCART2G
 # ---------------------------

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -2530,6 +2530,7 @@ endif
 if( $AGCM_LM == 72 ) then
     /bin/mv $EXPDIR/RC/GEOS_SurfaceGridComp.rc $EXPDIR/RC/GEOS_SurfaceGridComp.tmp
     cat $EXPDIR/RC/GEOS_SurfaceGridComp.tmp | sed -e '/^ *SNOW_ALBEDO_INFO:/ s/1/0/' > $EXPDIR/RC/GEOS_SurfaceGridComp.rc
+endif
 
 # Enable DATA_DRIVEN GOCART2G
 # ---------------------------


### PR DESCRIPTION
Closes #814 

TL;DR: Updates setup to make L72 runs like v11.

NOTE: Labeled as 0-diff (because it is for all non-L72 runs) but as non-zero-diff for L72

---

This pull request introduces coordinated changes across multiple setup scripts and configuration files to ensure that selecting a 72-level atmospheric model (`AGCM_LM == 72`) automatically updates several model defaults to match the GEOSgcm v11 configuration. The updates improve consistency, user guidance, and automation for model configuration, especially for users choosing the 72-level option. The main changes include automatic selection of microphysics, land surface boundary conditions, radiation schemes, and time step settings, along with supporting template and parameter updates.

**Automated configuration for AGCM_LM = 72:**

* When 72 levels are chosen, the default microphysics is set to `BACM_1M`, land surface boundary conditions to `NL3`, radiation scheme to `RRTMG`, and the default heartbeat to 450 seconds. Informative notes are displayed to users in all setup scripts (`gcm_setup`, `geoschemchem_setup`, `gmichem_setup`, `stratchem_setup`).

**Radiation scheme selection and template support:**

* Introduced logic and template variables (`RRTMG_RADIATION`, `RRTMGP_RADIATION`) to switch between RRTMG and RRTMGP radiation schemes based on the vertical resolution. This is reflected in both setup scripts and the `AGCM.rc.tmpl` file, allowing dynamic configuration in the final runtime configuration.

**Land surface boundary condition defaults and user prompts:**

* The default land surface boundary condition is now set to `NL3` for 72 levels and `v12` otherwise, with corresponding updates to user prompts and variable substitution logic in all relevant setup scripts.

**Microphysics and parameter automation:**

* The default microphysics option is now determined by the vertical resolution, and the `KLID` parameter is automatically set according to both microphysics and vertical resolution, streamlining configuration and reducing manual errors.

**Time step and physics parameter updates for 72-level runs:**

* Physics time steps (`DT`, `CONV_DT`, `CHEM_DT`) are set to values compatible with the 72-level configuration, including updates for coupled runs and BACM_1M microphysics, ensuring correct and consistent model operation.
 
**Additional configuration tweaks for 72-level runs:**

* For 72-level runs, the snow albedo info in `GEOS_SurfaceGridComp.rc` is modified to match expected defaults, further automating post-setup adjustments. 

These changes collectively make it much easier and less error-prone to configure the model for 72-level runs, aligning with GEOSgcm v11 standards and improving the user experience for both new and experienced users.