### PR TITLE
v12: More updates to make L72 like v11

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -113,7 +113,7 @@ SHALLOW_OPTION: UW
 # convection scheme options
 # ----------------------------------------
 CONVPAR_OPTION: @CONVPAR_OPTION
-# @BACM_1M_USE_GF2020: 0
+@BACM_1M_USE_GF2020: 0
 # Convective plumes to be activated (1 true, 0 false)
 DEEP: 1
 SHALLOW: 0

--- a/gcm_setup
+++ b/gcm_setup
@@ -2488,6 +2488,19 @@ endif
 # Enable DATA_DRIVEN GOCART2G
 # ---------------------------
 if( $AERO_PROVIDER == GOCART2G ) then
+
+    # Switch GOCART2G tuning coefficients to L072 values if needed
+    # -------------------------------------------------------------
+    if( $AGCM_LM == 72 ) then
+        foreach file ($EXPDIR/RC/DU2G_instance_DU.rc $EXPDIR/RC/SS2G_instance_SS.rc)
+            /bin/mv $file $EXPDIR/RC/dummy
+            sed -e 's/^\(.*# L181\)/#\1/' \
+                -e 's/^#\(.*# L072\)/\1/' \
+                $EXPDIR/RC/dummy > $file
+        end
+        /bin/rm -f $EXPDIR/RC/dummy
+    endif
+
     if ($DATA_DRIVEN == TRUE ) then
        /bin/mv $EXPDIR/RC/GOCART2G_GridComp.rc $EXPDIR/RC/GOCART2G_GridComp.tmp
        cat $EXPDIR/RC/GOCART2G_GridComp.tmp | \

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -2669,6 +2669,19 @@ endif
 # Enable DATA_DRIVEN GOCART2G
 # ---------------------------
 if( $AERO_PROVIDER == GOCART2G ) then
+
+    # Switch GOCART2G tuning coefficients to L072 values if needed
+    # -------------------------------------------------------------
+    if( $AGCM_LM == 72 ) then
+        foreach file ($EXPDIR/RC/DU2G_instance_DU.rc $EXPDIR/RC/SS2G_instance_SS.rc)
+            /bin/mv $file $EXPDIR/RC/dummy
+            sed -e 's/^\(.*# L181\)/#\1/' \
+                -e 's/^#\(.*# L072\)/\1/' \
+                $EXPDIR/RC/dummy > $file
+        end
+        /bin/rm -f $EXPDIR/RC/dummy
+    endif
+
     if ($DATA_DRIVEN == TRUE ) then
        /bin/mv $EXPDIR/RC/GOCART2G_GridComp.rc $EXPDIR/RC/GOCART2G_GridComp.tmp
        cat $EXPDIR/RC/GOCART2G_GridComp.tmp | \

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2842,6 +2842,19 @@ awk '{ if ($1~"ENABLE_GOCART_DATA:") { sub(/TRUE/,"FALSE") }; print }' > $EXPDIR
 # Turn on GOCART2G
 # ----------------
 if( $LGOCART2G == TRUE ) then
+
+    # Switch GOCART2G tuning coefficients to L072 values if needed
+    # -------------------------------------------------------------
+    if( $AGCM_LM == 72 ) then
+        foreach file ($EXPDIR/RC/DU2G_instance_DU.rc $EXPDIR/RC/SS2G_instance_SS.rc)
+            /bin/mv $file $EXPDIR/RC/dummy
+            sed -e 's/^\(.*# L181\)/#\1/' \
+                -e 's/^#\(.*# L072\)/\1/' \
+                $EXPDIR/RC/dummy > $file
+        end
+        /bin/rm -f $EXPDIR/RC/dummy
+    endif
+
     if ($DATA_DRIVEN == TRUE ) then
        /bin/mv $EXPDIR/RC/GOCART2G_GridComp.rc $EXPDIR/RC/GOCART2G_GridComp.tmp
        cat $EXPDIR/RC/GOCART2G_GridComp.tmp | \

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -2535,6 +2535,19 @@ endif
 # Enable DATA_DRIVEN GOCART2G
 # ---------------------------
 if( $AERO_PROVIDER == GOCART2G ) then
+
+    # Switch GOCART2G tuning coefficients to L072 values if needed
+    # -------------------------------------------------------------
+    if( $AGCM_LM == 72 ) then
+        foreach file ($EXPDIR/RC/DU2G_instance_DU.rc $EXPDIR/RC/SS2G_instance_SS.rc)
+            /bin/mv $file $EXPDIR/RC/dummy
+            sed -e 's/^\(.*# L181\)/#\1/' \
+                -e 's/^#\(.*# L072\)/\1/' \
+                $EXPDIR/RC/dummy > $file
+        end
+        /bin/rm -f $EXPDIR/RC/dummy
+    endif
+
     if ($DATA_DRIVEN == TRUE ) then
        /bin/mv $EXPDIR/RC/GOCART2G_GridComp.rc $EXPDIR/RC/GOCART2G_GridComp.tmp
        cat $EXPDIR/RC/GOCART2G_GridComp.tmp | \


### PR DESCRIPTION
Per @sdrabenh, in GOCART we have a couple files that need to be changed for L72:

```
ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_instance_SS.rc
31-emission_scale:  0.600 0.525 0.450 0.400 0.375 0.350   # L181 global scaling factor
32:#emission_scale: 0.613 0.613 0.613 0.429 0.429 0.429   # L072 global scaling factor

ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_instance_DU.rc
20-Ch_DU:  0.20 0.15 0.10 0.09 0.080 0.070 # L181 values for (a,b,c,d,e,f)
21:#Ch_DU: 0.30 0.30 0.11 0.11 0.110 0.088 # L072 values for (a,b,c,d,e,f)
```

By default we point to the L181 ones, but for L72, we need to use the others.

Also: Fix a bug in AGCM.rc.tmpl