### PR TITLE
Update SLURM resource request for gcm_plot.j

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -1820,8 +1820,12 @@ else if( $SITE == 'NCCS' ) then
               setenv    PLOT_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_moveplot.j
               setenv ARCHIVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_archive.j
-              setenv    POST_P  "SBATCH --nodes=${NPCUS} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_post.j
-              setenv    PLOT_P  "SBATCH --nodes=4 --ntasks=4"                                 # PE Configuration for gcm_plot.j
+              setenv    POST_P  "SBATCH --nodes=1 --ntasks-per-node=${NCPUS_PER_NODE}"        # PE Configuration for gcm_post.j
+              if      ($MODEL == 'mil') then
+                 setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=24 --mem=488G"  # PE Configuration for gcm_plot.j
+              else if ($MODEL == 'cas') then
+                 setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=10 --mem=185G"  # PE Configuration for gcm_plot.j
+              endif
               setenv ARCHIVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_archive.j
               setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -1825,6 +1825,8 @@ else if( $SITE == 'NCCS' ) then
                  setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=24 --mem=488G"  # PE Configuration for gcm_plot.j
               else if ($MODEL == 'cas') then
                  setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=10 --mem=185G"  # PE Configuration for gcm_plot.j
+              else
+                 setenv PLOT_P  "SBATCH --nodes=4 --ntasks=4"                                 # PE Configuration for gcm_plot.j
               endif
               setenv ARCHIVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_archive.j
               setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1850,8 +1850,12 @@ else if( $SITE == 'NCCS' ) then
               setenv    PLOT_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_moveplot.j
               setenv ARCHIVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_archive.j
-              setenv    POST_P  "SBATCH --nodes=${NPCUS} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_post.j
-              setenv    PLOT_P  "SBATCH --nodes=4 --ntasks=4"                                 # PE Configuration for gcm_plot.j
+              setenv    POST_P  "SBATCH --nodes=1 --ntasks-per-node=${NCPUS_PER_NODE}"        # PE Configuration for gcm_post.j
+              if      ($MODEL == 'mil') then
+                 setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=24 --mem=488G"  # PE Configuration for gcm_plot.j
+              else if ($MODEL == 'cas') then
+                 setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=10 --mem=185G"  # PE Configuration for gcm_plot.j
+              endif
               setenv ARCHIVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_archive.j
               setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j
 

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1855,6 +1855,8 @@ else if( $SITE == 'NCCS' ) then
                  setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=24 --mem=488G"  # PE Configuration for gcm_plot.j
               else if ($MODEL == 'cas') then
                  setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=10 --mem=185G"  # PE Configuration for gcm_plot.j
+              else
+                 setenv PLOT_P  "SBATCH --nodes=4 --ntasks=4"                                 # PE Configuration for gcm_plot.j
               endif
               setenv ARCHIVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_archive.j
               setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2036,8 +2036,12 @@ else if( $SITE == 'NCCS' ) then
               setenv    PLOT_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_moveplot.j
               setenv ARCHIVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_archive.j
-              setenv    POST_P  "SBATCH --nodes=${NPCUS} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_post.j
-              setenv    PLOT_P  "SBATCH --nodes=4 --ntasks=4"                                 # PE Configuration for gcm_plot.j
+              setenv    POST_P  "SBATCH --nodes=1 --ntasks-per-node=${NCPUS_PER_NODE}"        # PE Configuration for gcm_post.j
+              if      ($MODEL == 'mil') then
+                 setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=24 --mem=488G"  # PE Configuration for gcm_plot.j
+              else if ($MODEL == 'cas') then
+                 setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=10 --mem=185G"  # PE Configuration for gcm_plot.j
+              endif
               setenv ARCHIVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_archive.j
               setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2041,6 +2041,8 @@ else if( $SITE == 'NCCS' ) then
                  setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=24 --mem=488G"  # PE Configuration for gcm_plot.j
               else if ($MODEL == 'cas') then
                  setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=10 --mem=185G"  # PE Configuration for gcm_plot.j
+              else
+                 setenv PLOT_P  "SBATCH --nodes=4 --ntasks=4"                                 # PE Configuration for gcm_plot.j
               endif
               setenv ARCHIVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_archive.j
               setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1840,6 +1840,8 @@ else if( $SITE == 'NCCS' ) then
                  setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=24 --mem=488G"  # PE Configuration for gcm_plot.j
               else if ($MODEL == 'cas') then
                  setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=10 --mem=185G"  # PE Configuration for gcm_plot.j
+              else
+                 setenv PLOT_P  "SBATCH --nodes=4 --ntasks=4"                                 # PE Configuration for gcm_plot.j
               endif
               setenv ARCHIVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_archive.j
               setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1835,8 +1835,12 @@ else if( $SITE == 'NCCS' ) then
               setenv    PLOT_Q  "SBATCH --constraint=${MODEL}"                                # batch queue name for gcm_plot.j
               setenv    MOVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_moveplot.j
               setenv ARCHIVE_Q  "SBATCH --partition=datamove"                                 # batch queue name for gcm_archive.j
-              setenv    POST_P  "SBATCH --nodes=${NPCUS} --ntasks-per-node=${NCPUS_PER_NODE}" # PE Configuration for gcm_post.j
-              setenv    PLOT_P  "SBATCH --nodes=4 --ntasks=4"                                 # PE Configuration for gcm_plot.j
+              setenv    POST_P  "SBATCH --nodes=1 --ntasks-per-node=${NCPUS_PER_NODE}"        # PE Configuration for gcm_post.j
+              if      ($MODEL == 'mil') then
+                 setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=24 --mem=488G"  # PE Configuration for gcm_plot.j
+              else if ($MODEL == 'cas') then
+                 setenv PLOT_P  "SBATCH --constraint=${MODEL} --nodes=1 --ntasks-per-node=10 --mem=185G"  # PE Configuration for gcm_plot.j
+              endif
               setenv ARCHIVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_archive.j
               setenv    MOVE_P  "SBATCH --ntasks=1"                                           # PE Configuration for gcm_moveplot.j
 


### PR DESCRIPTION
With `cas` and `mil` nodes, having 48 and 128 cpus respectively, it is not practical for each plot job to request 4 nodes using only 4 tasks, each task limited by default memory partitions. This PR reduces the number of requested nodes to one, but increases the total number of tasks. It also expands the memory footprint to roughly 20G per task which is sufficient for most users. It also reduces the number of requested nodes to one for time averaging, which is sufficient for most collections and resolutions.