### PR TITLE
v12: Generalize GEOS-IT Replay

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -382,8 +382,8 @@ RECORD_REF_TIME: >>>REFTIME<<< >>>FCSTIME<<<
 #M2 REPLAY_FILE: ana/MERRA2_all/Y%y4/M%m2/MERRA2.ana.eta.%y4%m2%d2_%h2z.nc4
 #M2 MKIAU_JCAP: 62
 
-# GEOS-IT Regular REPLAY Configuration
-# --------------------------------------------
+# GEOS-IT Regular REPLAY Configuration (1999-Present)
+# ---------------------------------------------------
 #IT REPLAY_ANA_EXPID: GEOS-IT
 #IT REPLAY_ANA_LOCATION: /discover/nobackup/projects/gmao/geos-it/dao_ops/archive/d5294_geosit_ALL
 #IT REPLAY_MODE: Regular

--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -385,9 +385,9 @@ RECORD_REF_TIME: >>>REFTIME<<< >>>FCSTIME<<<
 # GEOS-IT Regular REPLAY Configuration
 # --------------------------------------------
 #IT REPLAY_ANA_EXPID: GEOS-IT
-#IT REPLAY_ANA_LOCATION: /discover/nobackup/projects/gmao/geos-it/dao_ops/archive/d5294_geosit_jan18
+#IT REPLAY_ANA_LOCATION: /discover/nobackup/projects/gmao/geos-it/dao_ops/archive/d5294_geosit_ALL
 #IT REPLAY_MODE: Regular
-#IT REPLAY_FILE: ana/Y%y4/M%m2/d5294_geosit_jan18.ana.eta.%y4%m2%d2_%h2%n2z.nc4
+#IT REPLAY_FILE: ana/Y%y4/M%m2/d5294_geosit.ana.eta.%y4%m2%d2_%h2%n2z.nc4
 #IT MKIAU_JCAP: 62
 
 # 4dvar ANA EXPID and LOCATION used for REPLAY


### PR DESCRIPTION
Closes #854 

This PR "generalizes" the GEOS-IT replay bits of `AGCM.rc` to use the `d5294_geosit_ALL` "meta-archive" which combines all the streams.

This allows GEOS-IT replay from Y1999 to modern day.