### PR TITLE
Adding options for 1/2 and 1/8 deg ocean resolutions for mom6 grids in gcm_setup

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -641,9 +641,11 @@ if( $OGCM == TRUE ) then
        # c12      1x6        12x72      3x2          72x36        50
        # c90      5x36       90x540     90x2         540x458      50
        # c180     30x36      180x1080   36x30        1440x1080    75
-       #
+       # c180     24x36      180x1080   36x24        720x576      75
+       # c360     30x36      180x1080   36x30        1440x1080    75
+       # c180     20x36      180x1080   36x20        2880x2240    75
        # See https://github.com/GEOS-ESM/GEOSgcm/wiki/Coupled-model-configurations-(GEOS-MOM6)
-
+  
        if ( $AGCM_IM == "c12" ) then
           set OGCM_NX = 3
           set OGCM_NY = 2
@@ -657,6 +659,41 @@ if( $OGCM == TRUE ) then
           set OGCM_JM = 458
           set OGCM_LM = 50
        else if ( $AGCM_IM == "c180" ) then
+
+          DOROCN:
+          set DEFAULT_HRCODE = 'o1440'
+          echo "Enter the ${C1}Ocean Horizontal Resolution ${CN}code: ${C2}o720${CN}  (1/2-deg,  720x576  Tripolar)"
+          echo "                                            ${C2}o1440${CN} (1/4-deg, 1440x1080  Tripolar) (Default)"
+          echo "                                            ${C2}o2880${CN} (1/8-deg, 2880x2240 Tripolar)"
+          set   HRCODE = `echo $<`
+          if( .$HRCODE == . ) set HRCODE = $DEFAULT_HRCODE
+          set   HRCODE = `echo $HRCODE | tr "[:upper:]" "[:lower:]"`
+
+          if( $HRCODE != 'o720' & \
+             $HRCODE != 'o1440' & \
+             $HRCODE != 'o2880' ) goto DOROCN
+
+          if ( $HRCODE == "o720" ) then
+             set OGCM_IM = 720
+             set OGCM_JM = 576
+             set OGCM_NX = 36
+             set OGCM_NY = 24
+             set OGCM_LM = 75
+          else if ( $HRCODE == "o2880" ) then
+             set OGCM_IM = 2880
+             set OGCM_JM = 2240
+             set OGCM_NX = 36
+             set OGCM_NY = 20
+             set OGCM_LM = 75
+          else if ( $HRCODE == "o1440" ) then
+             set OGCM_IM = 1440
+             set OGCM_JM = 1080
+             set OGCM_NX = 36
+             set OGCM_NY = 30
+             set OGCM_LM = 75
+          endif 
+
+       else if ( $AGCM_IM == "c360" ) then
           set OGCM_NX = 36
           set OGCM_NY = 30
           set OGCM_IM = 1440
@@ -664,7 +701,7 @@ if( $OGCM == TRUE ) then
           set OGCM_LM = 75
        else
           echo
-          echo "ERROR: MOM6 is currently only supported for c12, c90, and c180 atmospheric resolutions"
+          echo "ERROR: MOM6 is currently only supported for c12, c90, c180 and c360 atmospheric resolutions"
           exit 1
        endif
     endif

--- a/gcm_setup
+++ b/gcm_setup
@@ -633,8 +633,9 @@ if( $OGCM == TRUE ) then
         endif
 
     else if ( "$OCNMODEL" == "MOM6" ) then
-       # For MOM6 we currently have only 3 allowed ocean resolutions based on the
-       # atmospheric resolution. The allowed are:
+       # Updated by Sina Khani: 
+       # For MOM6 we currently have only 4 allowed ocean resolutions (1/2, 1/4, 1/8 deg)
+       # based on the atmospheric resolution (c180 and c360). The allowed are:
        #
        # Atm Res  Atm NXxNY  Atm IMxJM  Ocean NXxNY  Ocean IMxJM  Ocean LM
        # -------  ---------  ---------  -----------  -----------  --------

--- a/gcm_setup
+++ b/gcm_setup
@@ -654,7 +654,7 @@ if( $OGCM == TRUE ) then
         endif
 
     else if ( "$OCNMODEL" == "MOM6" ) then
-       # Updated by Sina Khani: 
+       # Updated by Sina Khani:
        # For MOM6 we currently have only 4 allowed ocean resolutions (1/2, 1/4, 1/8 deg)
        # based on the atmospheric resolution (c180 and c360). The allowed are:
        #
@@ -667,7 +667,7 @@ if( $OGCM == TRUE ) then
        # c360     30x36      180x1080   36x30        1440x1080    75
        # c180     20x36      180x1080   36x20        2880x2240    75
        # See https://github.com/GEOS-ESM/GEOSgcm/wiki/Coupled-model-configurations-(GEOS-MOM6)
-  
+
        if ( $AGCM_IM == "c12" ) then
           set OGCM_NX = 3
           set OGCM_NY = 2
@@ -713,7 +713,7 @@ if( $OGCM == TRUE ) then
              set OGCM_NX = 36
              set OGCM_NY = 30
              set OGCM_LM = 75
-          endif 
+          endif
 
        else if ( $AGCM_IM == "c360" ) then
           set OGCM_NX = 36

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -654,15 +654,18 @@ if( $OGCM == TRUE ) then
         endif
 
     else if ( "$OCNMODEL" == "MOM6" ) then
-       # For MOM6 we currently have only 3 allowed ocean resolutions based on the
-       # atmospheric resolution. The allowed are:
+       # Updated by Sina Khani:
+       # For MOM6 we currently have only 4 allowed ocean resolutions (1/2, 1/4, 1/8 deg)
+       # based on the atmospheric resolution (c180 and c360). The allowed are:
        #
        # Atm Res  Atm NXxNY  Atm IMxJM  Ocean NXxNY  Ocean IMxJM  Ocean LM
        # -------  ---------  ---------  -----------  -----------  --------
        # c12      1x6        12x72      3x2          72x36        50
        # c90      5x36       90x540     90x2         540x458      50
        # c180     30x36      180x1080   36x30        1440x1080    75
-       #
+       # c180     24x36      180x1080   36x24        720x576      75
+       # c360     30x36      180x1080   36x30        1440x1080    75
+       # c180     20x36      180x1080   36x20        2880x2240    75
        # See https://github.com/GEOS-ESM/GEOSgcm/wiki/Coupled-model-configurations-(GEOS-MOM6)
 
        if ( $AGCM_IM == "c12" ) then
@@ -678,6 +681,41 @@ if( $OGCM == TRUE ) then
           set OGCM_JM = 458
           set OGCM_LM = 50
        else if ( $AGCM_IM == "c180" ) then
+
+          DOROCN:
+          set DEFAULT_HRCODE = 'o1440'
+          echo "Enter the ${C1}Ocean Horizontal Resolution ${CN}code: ${C2}o720${CN}  (1/2-deg,  720x576  Tripolar)"
+          echo "                                            ${C2}o1440${CN} (1/4-deg, 1440x1080  Tripolar) (Default)"
+          echo "                                            ${C2}o2880${CN} (1/8-deg, 2880x2240 Tripolar)"
+          set   HRCODE = `echo $<`
+          if( .$HRCODE == . ) set HRCODE = $DEFAULT_HRCODE
+          set   HRCODE = `echo $HRCODE | tr "[:upper:]" "[:lower:]"`
+
+          if( $HRCODE != 'o720' & \
+             $HRCODE != 'o1440' & \
+             $HRCODE != 'o2880' ) goto DOROCN
+
+          if ( $HRCODE == "o720" ) then
+             set OGCM_IM = 720
+             set OGCM_JM = 576
+             set OGCM_NX = 36
+             set OGCM_NY = 24
+             set OGCM_LM = 75
+          else if ( $HRCODE == "o2880" ) then
+             set OGCM_IM = 2880
+             set OGCM_JM = 2240
+             set OGCM_NX = 36
+             set OGCM_NY = 20
+             set OGCM_LM = 75
+          else if ( $HRCODE == "o1440" ) then
+             set OGCM_IM = 1440
+             set OGCM_JM = 1080
+             set OGCM_NX = 36
+             set OGCM_NY = 30
+             set OGCM_LM = 75
+          endif
+
+       else if ( $AGCM_IM == "c360" ) then
           set OGCM_NX = 36
           set OGCM_NY = 30
           set OGCM_IM = 1440
@@ -685,7 +723,7 @@ if( $OGCM == TRUE ) then
           set OGCM_LM = 75
        else
           echo
-          echo "ERROR: MOM6 is currently only supported for c12, c90, and c180 atmospheric resolutions"
+          echo "ERROR: MOM6 is currently only supported for c12, c90, c180 and c360 atmospheric resolutions"
           exit 1
        endif
     endif

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -654,15 +654,18 @@ if( $OGCM == TRUE ) then
         endif
 
     else if ( "$OCNMODEL" == "MOM6" ) then
-       # For MOM6 we currently have only 3 allowed ocean resolutions based on the
-       # atmospheric resolution. The allowed are:
+       # Updated by Sina Khani:
+       # For MOM6 we currently have only 4 allowed ocean resolutions (1/2, 1/4, 1/8 deg)
+       # based on the atmospheric resolution (c180 and c360). The allowed are:
        #
        # Atm Res  Atm NXxNY  Atm IMxJM  Ocean NXxNY  Ocean IMxJM  Ocean LM
        # -------  ---------  ---------  -----------  -----------  --------
        # c12      1x6        12x72      3x2          72x36        50
        # c90      5x36       90x540     90x2         540x458      50
        # c180     30x36      180x1080   36x30        1440x1080    75
-       #
+       # c180     24x36      180x1080   36x24        720x576      75
+       # c360     30x36      180x1080   36x30        1440x1080    75
+       # c180     20x36      180x1080   36x20        2880x2240    75
        # See https://github.com/GEOS-ESM/GEOSgcm/wiki/Coupled-model-configurations-(GEOS-MOM6)
 
        if ( $AGCM_IM == "c12" ) then
@@ -678,6 +681,41 @@ if( $OGCM == TRUE ) then
           set OGCM_JM = 458
           set OGCM_LM = 50
        else if ( $AGCM_IM == "c180" ) then
+
+          DOROCN:
+          set DEFAULT_HRCODE = 'o1440'
+          echo "Enter the ${C1}Ocean Horizontal Resolution ${CN}code: ${C2}o720${CN}  (1/2-deg,  720x576  Tripolar)"
+          echo "                                            ${C2}o1440${CN} (1/4-deg, 1440x1080  Tripolar) (Default)"
+          echo "                                            ${C2}o2880${CN} (1/8-deg, 2880x2240 Tripolar)"
+          set   HRCODE = `echo $<`
+          if( .$HRCODE == . ) set HRCODE = $DEFAULT_HRCODE
+          set   HRCODE = `echo $HRCODE | tr "[:upper:]" "[:lower:]"`
+
+          if( $HRCODE != 'o720' & \
+             $HRCODE != 'o1440' & \
+             $HRCODE != 'o2880' ) goto DOROCN
+
+          if ( $HRCODE == "o720" ) then
+             set OGCM_IM = 720
+             set OGCM_JM = 576
+             set OGCM_NX = 36
+             set OGCM_NY = 24
+             set OGCM_LM = 75
+          else if ( $HRCODE == "o2880" ) then
+             set OGCM_IM = 2880
+             set OGCM_JM = 2240
+             set OGCM_NX = 36
+             set OGCM_NY = 20
+             set OGCM_LM = 75
+          else if ( $HRCODE == "o1440" ) then
+             set OGCM_IM = 1440
+             set OGCM_JM = 1080
+             set OGCM_NX = 36
+             set OGCM_NY = 30
+             set OGCM_LM = 75
+          endif
+
+       else if ( $AGCM_IM == "c360" ) then
           set OGCM_NX = 36
           set OGCM_NY = 30
           set OGCM_IM = 1440
@@ -685,7 +723,7 @@ if( $OGCM == TRUE ) then
           set OGCM_LM = 75
        else
           echo
-          echo "ERROR: MOM6 is currently only supported for c12, c90, and c180 atmospheric resolutions"
+          echo "ERROR: MOM6 is currently only supported for c12, c90, c180 and c360 atmospheric resolutions"
           exit 1
        endif
     endif

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -654,15 +654,18 @@ if( $OGCM == TRUE ) then
         endif
 
     else if ( "$OCNMODEL" == "MOM6" ) then
-       # For MOM6 we currently have only 3 allowed ocean resolutions based on the
-       # atmospheric resolution. The allowed are:
+       # Updated by Sina Khani:
+       # For MOM6 we currently have only 4 allowed ocean resolutions (1/2, 1/4, 1/8 deg)
+       # based on the atmospheric resolution (c180 and c360). The allowed are:
        #
        # Atm Res  Atm NXxNY  Atm IMxJM  Ocean NXxNY  Ocean IMxJM  Ocean LM
        # -------  ---------  ---------  -----------  -----------  --------
        # c12      1x6        12x72      3x2          72x36        50
        # c90      5x36       90x540     90x2         540x458      50
        # c180     30x36      180x1080   36x30        1440x1080    75
-       #
+       # c180     24x36      180x1080   36x24        720x576      75
+       # c360     30x36      180x1080   36x30        1440x1080    75
+       # c180     20x36      180x1080   36x20        2880x2240    75
        # See https://github.com/GEOS-ESM/GEOSgcm/wiki/Coupled-model-configurations-(GEOS-MOM6)
 
        if ( $AGCM_IM == "c12" ) then
@@ -678,6 +681,41 @@ if( $OGCM == TRUE ) then
           set OGCM_JM = 458
           set OGCM_LM = 50
        else if ( $AGCM_IM == "c180" ) then
+
+          DOROCN:
+          set DEFAULT_HRCODE = 'o1440'
+          echo "Enter the ${C1}Ocean Horizontal Resolution ${CN}code: ${C2}o720${CN}  (1/2-deg,  720x576  Tripolar)"
+          echo "                                            ${C2}o1440${CN} (1/4-deg, 1440x1080  Tripolar) (Default)"
+          echo "                                            ${C2}o2880${CN} (1/8-deg, 2880x2240 Tripolar)"
+          set   HRCODE = `echo $<`
+          if( .$HRCODE == . ) set HRCODE = $DEFAULT_HRCODE
+          set   HRCODE = `echo $HRCODE | tr "[:upper:]" "[:lower:]"`
+
+          if( $HRCODE != 'o720' & \
+             $HRCODE != 'o1440' & \
+             $HRCODE != 'o2880' ) goto DOROCN
+
+          if ( $HRCODE == "o720" ) then
+             set OGCM_IM = 720
+             set OGCM_JM = 576
+             set OGCM_NX = 36
+             set OGCM_NY = 24
+             set OGCM_LM = 75
+          else if ( $HRCODE == "o2880" ) then
+             set OGCM_IM = 2880
+             set OGCM_JM = 2240
+             set OGCM_NX = 36
+             set OGCM_NY = 20
+             set OGCM_LM = 75
+          else if ( $HRCODE == "o1440" ) then
+             set OGCM_IM = 1440
+             set OGCM_JM = 1080
+             set OGCM_NX = 36
+             set OGCM_NY = 30
+             set OGCM_LM = 75
+          endif
+
+       else if ( $AGCM_IM == "c360" ) then
           set OGCM_NX = 36
           set OGCM_NY = 30
           set OGCM_IM = 1440
@@ -685,7 +723,7 @@ if( $OGCM == TRUE ) then
           set OGCM_LM = 75
        else
           echo
-          echo "ERROR: MOM6 is currently only supported for c12, c90, and c180 atmospheric resolutions"
+          echo "ERROR: MOM6 is currently only supported for c12, c90, c180 and c360 atmospheric resolutions"
           exit 1
        endif
     endif


### PR DESCRIPTION
This PR updates gcm_setup by including ocean resolutions of 1/2 and 1/8 deg in mom6. This is a zero-diff PR to data-ocean (EMIP, AMIP, etc) runs. 