### PR TITLE
Replace GETFILE/FREE_FILE with standard Fortran I/O in idfupd.F90

### DIFF
--- a/idfupd.F90
+++ b/idfupd.F90
@@ -688,7 +688,7 @@ CONTAINS
      CUR_M  = BEG_M
      CUR_S  = BEG_S
 
-     UNIT = GETFILE ( "cap_restart", form="formatted", ALL_PES=.true., rc=status )
+     open(newunit=UNIT, file="cap_restart", form="formatted", action="read", iostat=status)
      VERIFY_(STATUS)
 
      rewind(UNIT)
@@ -706,7 +706,7 @@ CONTAINS
 
 999  continue  ! Initialize Current time
 
-     call FREE_FILE (UNIT)
+     close(UNIT)
 
      call ESMF_TimeSet( CurrTime, YY = CUR_YY, &
                                   MM = CUR_MM, &


### PR DESCRIPTION
## Summary

- Replace `GETFILE("cap_restart", form="formatted", ALL_PES=.true.)` with `open(newunit=UNIT, file="cap_restart", form="formatted", action="read", iostat=status)`
- Replace `FREE_FILE(UNIT)` with `close(UNIT)`

Part of the broader effort to remove `BinIO` (`BinIOMod`) from MAPL. `GETFILE` and `FREE_FILE` are legacy wrappers that predate the Fortran 2003 `NEWUNIT=` specifier. See `@MAPL/docs/migrating_from_BinIO.md` for guidance.