### PR TITLE
Migrate idfupd.F90 packed-time calls to MAPL_PackedTimeMod

### DIFF
--- a/idfupd.F90
+++ b/idfupd.F90
@@ -25,6 +25,7 @@ program idfupd
 
   use ESMF
   use MAPL
+  use MAPL_PackedTimeMod, only: MAPL_UnpackDateTime => UnpackDateTime
 
   use FVdycore_GridCompMod,   only : FV_SetServices    => SetServices
   use FVdycoreCubed_GridComp, only : FV3_SetServices   => SetServices


### PR DESCRIPTION
## Summary
- `idfupd.F90`: import `MAPL_UnpackDateTime` from `MAPL_PackedTimeMod` instead of the legacy `MAPL` umbrella module

Part of GEOS-ESM/MAPL#4811 — enables deletion of legacy packed-time symbols from `Base_Base`.