### PR TITLE
v12: Fix scm_setup

### DIFF
--- a/scm_setup
+++ b/scm_setup
@@ -522,22 +522,21 @@ builtin cd $CURRDIR
 
 if [ $nlev -ne 72 ]
 then
-
-  digits=0000
-  temp=$digits$nlev
-  padlev=${temp:(-${#digits})}
-
   $ISED -e "s/L72/L${nlev}/g" -e "s/z72/z${nlev}/g" $expdir/*.rc
   $ISED -e "s/L72/L${nlev}/g" -e "s/z72/z${nlev}/g" $expdir/*.yaml
-
-  $ISED "/AGCM_LM:/c\AGCM_LM: ${nlev}" $expdir/AGCM.rc
-  $ISED "/AGCM.LM:/c\AGCM.LM: ${nlev}" $expdir/AGCM.rc
-  $ISED "/SCMGRID.LM:/c\SCMGRID.LM: ${nlev}" $expdir/HISTORY.rc
-  cp $SOURCEDIR/*rst.r0001x0001x${padlev} $expdir
-  /bin/mv $expdir/datmodyn_internal_rst.r0001x0001x${padlev} $expdir/datmodyn_internal_rst
-  /bin/mv $expdir/moist_internal_rst.r0001x0001x${padlev} $expdir/moist_internal_rst
-
 fi
+
+$ISED "/AGCM_LM:/c\AGCM_LM: ${nlev}" $expdir/AGCM.rc
+$ISED "/AGCM.LM:/c\AGCM.LM: ${nlev}" $expdir/AGCM.rc
+$ISED "/SCMGRID.LM:/c\SCMGRID.LM: ${nlev}" $expdir/HISTORY.rc
+
+digits=0000
+temp=$digits$nlev
+padlev=${temp:(-${#digits})}
+
+cp $SOURCEDIR/*rst.r0001x0001x${padlev} $expdir
+/bin/mv $expdir/datmodyn_internal_rst.r0001x0001x${padlev} $expdir/datmodyn_internal_rst
+/bin/mv $expdir/moist_internal_rst.r0001x0001x${padlev} $expdir/moist_internal_rst
 
 # We need to handle KLID like gcm_setup does
 ## First, initialize to 0


### PR DESCRIPTION
Per @narnold1, `scm_setup` was broken except for 181-level runs.

Heck, it's possible it might have had issues at 181 we were just lucky? This seems to be correct.