### PR TITLE
Fixes #867. Update walltimes to 4-hours, fix scm_setup

### DIFF
--- a/gcm_emip.setup
+++ b/gcm_emip.setup
@@ -25,6 +25,7 @@ cat > sedfile << EOF
 s?@RSTDATE?$RSTDATE?g
 s?@GCMEMIP?TRUE?g
 s?@BATCH_NAME?SBATCH?g
+s?gcm_run.o%j?gcm_run.o$RSTDATE?g
 EOF
 sed -f sedfile gcm_run.tmp > gcm_run.j$RSTDATE
 /bin/rm -f sedfile

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -10,7 +10,7 @@
 #@RUN_Q
 #@BATCH_GROUP
 #@BATCH_JOINOUTERR
-#@BATCH_NAME -o gcm_run.o@RSTDATE
+#@BATCH_NAME -o gcm_run.o%j
 
 #######################################################################
 #                         System Settings

--- a/gcm_setup
+++ b/gcm_setup
@@ -1752,6 +1752,7 @@ setenv BOUNDARY_DIR ""
 
 if( $SITE == 'NAS' ) then
               setenv BATCH_CMD "qsub"                 # PBS Batch command
+              setenv BATCH_NAME "DELETE"              # PBS Batch pragma (not needed for NAS)
               setenv BATCH_GROUP "PBS -W group_list=" # PBS Syntax for GROUP
               setenv BATCH_TIME "PBS -l walltime="    # PBS Syntax for walltime
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
@@ -1800,6 +1801,7 @@ if( $SITE == 'NAS' ) then
 
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                               # SLURM Batch pragma
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
@@ -1853,6 +1855,7 @@ else if( $SITE == 'NCCS' ) then
 
 else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
               setenv BATCH_CMD "sbatch"                                                    # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                                   # SLURM Batch pragma
               setenv BATCH_GROUP DELETE                                                    # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                           # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                    # SLURM Syntax for job name
@@ -1891,6 +1894,7 @@ else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
 else
 # These are defaults for the desktop
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                               # SLURM Batch pragma
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
@@ -2385,6 +2389,7 @@ s?@HOMDIR?$HOMDIR?g
 s?@BATCH_GROUP?${BATCH_GROUP}${GROUP}?g
 s?@BATCH_TIME?$BATCH_TIME?g
 s?@BATCH_CMD?$BATCH_CMD?g
+s?@BATCH_NAME?$BATCH_NAME?g
 s?@BATCH_JOBNAME?$BATCH_JOBNAME?g
 s?@BATCH_OUTPUTNAME?$BATCH_OUTPUTNAME?g
 s?@BATCH_JOINOUTERR?$BATCH_JOINOUTERR?g

--- a/gcm_setup
+++ b/gcm_setup
@@ -1757,11 +1757,11 @@ if( $SITE == 'NAS' ) then
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
               setenv BATCH_JOINOUTERR "PBS -j oe -k oed"  # PBS Syntax for joining output and error
-              setenv     RUN_FT "6:00:00"             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "8:00:00"             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"             # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"             # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"             # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"             # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "8:00:00"             # Wallclock Time   for gcm_plot.j
-              setenv ARCHIVE_T  "8:00:00"             # Wallclock Time   for gcm_archive.j
+              setenv ARCHIVE_T  "4:00:00"             # Wallclock Time   for gcm_archive.j
               set QTYPE = "normal"                    # Queue to use
 
               @ NPCUS = `echo "($POST_NPES + $NCPUS_PER_NODE - 1)/$NCPUS_PER_NODE" | bc`
@@ -1805,9 +1805,9 @@ else if( $SITE == 'NCCS' ) then
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
-              setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "12:00:00"                                             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"                                              # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"                                              # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"                                              # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"                                              # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "12:00:00"                                             # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "2:00:00"                                              # Wallclock Time   for gcm_archive.j
 
@@ -1858,9 +1858,9 @@ else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
               setenv BATCH_JOBNAME "SBATCH --job-name="                                    # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                                   # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                             # SLURM joins out and err by default
-              setenv RUN_FT "06:00:00"                                                     # Wallclock Time   for gcm_forecast.j
-              setenv RUN_T  "12:00:00"                                                     # Wallclock Time   for gcm_run.j
-              setenv POST_T  "8:00:00"                                                     # Wallclock Time   for gcm_post.j
+              setenv RUN_FT "4:00:00"                                                      # Wallclock Time   for gcm_forecast.j
+              setenv RUN_T  "4:00:00"                                                      # Wallclock Time   for gcm_run.j
+              setenv POST_T  "4:00:00"                                                     # Wallclock Time   for gcm_post.j
               setenv PLOT_T  "12:00:00"                                                    # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "1:00:00"                                                  # Wallclock Time   for gcm_archive.j
               setenv RUN_Q     "SBATCH --constraint=${MODEL}"                              # batch queue name for gcm_run.j
@@ -1896,9 +1896,9 @@ else
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
-              setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "12:00:00"                                             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"                                              # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"                                              # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"                                              # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"                                              # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "12:00:00"                                             # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "1:00:00"                                              # Wallclock Time   for gcm_archive.j
               setenv  RUN_Q     NULL                                                   # batch queue name for gcm_run.j

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1782,16 +1782,17 @@ setenv BOUNDARY_DIR ""
 
 if( $SITE == 'NAS' ) then
               setenv BATCH_CMD "qsub"                 # PBS Batch command
+              setenv BATCH_NAME "DELETE"              # PBS Batch pragma (not needed for NAS)
               setenv BATCH_GROUP "PBS -W group_list=" # PBS Syntax for GROUP
               setenv BATCH_TIME "PBS -l walltime="    # PBS Syntax for walltime
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
               setenv BATCH_JOINOUTERR "PBS -j oe -k oed"  # PBS Syntax for joining output and error
-              setenv     RUN_FT "6:00:00"             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "8:00:00"             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"             # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"             # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"             # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"             # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "8:00:00"             # Wallclock Time   for gcm_plot.j
-              setenv ARCHIVE_T  "8:00:00"             # Wallclock Time   for gcm_archive.j
+              setenv ARCHIVE_T  "4:00:00"             # Wallclock Time   for gcm_archive.j
               set QTYPE = "normal"                    # Queue to use
 
               @ NPCUS = `echo "($POST_NPES + $NCPUS_PER_NODE - 1)/$NCPUS_PER_NODE" | bc`
@@ -1830,14 +1831,15 @@ if( $SITE == 'NAS' ) then
 
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                               # SLURM Batch pragma
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
-              setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "12:00:00"                                             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"                                              # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"                                              # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"                                              # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"                                              # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "12:00:00"                                             # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "2:00:00"                                              # Wallclock Time   for gcm_archive.j
 
@@ -1883,14 +1885,15 @@ else if( $SITE == 'NCCS' ) then
 
 else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
               setenv BATCH_CMD "sbatch"                                                    # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                                   # SLURM Batch pragma
               setenv BATCH_GROUP DELETE                                                    # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                           # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                    # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                                   # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                             # SLURM joins out and err by default
-              setenv RUN_FT "06:00:00"                                                     # Wallclock Time   for gcm_forecast.j
-              setenv RUN_T  "12:00:00"                                                     # Wallclock Time   for gcm_run.j
-              setenv POST_T  "8:00:00"                                                     # Wallclock Time   for gcm_post.j
+              setenv RUN_FT "4:00:00"                                                      # Wallclock Time   for gcm_forecast.j
+              setenv RUN_T  "4:00:00"                                                      # Wallclock Time   for gcm_run.j
+              setenv POST_T  "4:00:00"                                                     # Wallclock Time   for gcm_post.j
               setenv PLOT_T  "12:00:00"                                                    # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "1:00:00"                                                  # Wallclock Time   for gcm_archive.j
               setenv RUN_Q     "SBATCH --constraint=${MODEL}"                              # batch queue name for gcm_run.j
@@ -1921,14 +1924,15 @@ else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
 else
 # These are defaults for the desktop
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                               # SLURM Batch pragma
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
-              setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "12:00:00"                                             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"                                              # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"                                              # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"                                              # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"                                              # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "12:00:00"                                             # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "1:00:00"                                              # Wallclock Time   for gcm_archive.j
               setenv  RUN_Q     NULL                                                   # batch queue name for gcm_run.j
@@ -2415,6 +2419,7 @@ s?@HOMDIR?$HOMDIR?g
 s?@BATCH_GROUP?${BATCH_GROUP}${GROUP}?g
 s?@BATCH_TIME?$BATCH_TIME?g
 s?@BATCH_CMD?$BATCH_CMD?g
+s?@BATCH_NAME?$BATCH_NAME?g
 s?@BATCH_JOBNAME?$BATCH_JOBNAME?g
 s?@BATCH_OUTPUTNAME?$BATCH_OUTPUTNAME?g
 s?@BATCH_JOINOUTERR?$BATCH_JOINOUTERR?g

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -1968,16 +1968,17 @@ setenv BOUNDARY_DIR ""
 
 if( $SITE == 'NAS' ) then
               setenv BATCH_CMD "qsub"                 # PBS Batch command
+              setenv BATCH_NAME "DELETE"              # PBS Batch pragma (not needed for NAS)
               setenv BATCH_GROUP "PBS -W group_list=" # PBS Syntax for GROUP
               setenv BATCH_TIME "PBS -l walltime="    # PBS Syntax for walltime
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
               setenv BATCH_JOINOUTERR "PBS -j oe -k oed"  # PBS Syntax for joining output and error
-              setenv     RUN_FT "6:00:00"             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "8:00:00"             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"             # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"             # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"             # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"             # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "8:00:00"             # Wallclock Time   for gcm_plot.j
-              setenv ARCHIVE_T  "8:00:00"             # Wallclock Time   for gcm_archive.j
+              setenv ARCHIVE_T  "4:00:00"             # Wallclock Time   for gcm_archive.j
               set QTYPE = "normal"                    # Queue to use
 
               @ NPCUS = `echo "($POST_NPES + $NCPUS_PER_NODE - 1)/$NCPUS_PER_NODE" | bc`
@@ -2016,14 +2017,15 @@ if( $SITE == 'NAS' ) then
 
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                               # SLURM Batch pragma
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
-              setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "12:00:00"                                             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"                                              # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"                                              # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"                                              # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"                                              # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "12:00:00"                                             # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "2:00:00"                                              # Wallclock Time   for gcm_archive.j
 
@@ -2069,14 +2071,15 @@ else if( $SITE == 'NCCS' ) then
 
 else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
               setenv BATCH_CMD "sbatch"                                                    # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                                   # SLURM Batch pragma
               setenv BATCH_GROUP DELETE                                                    # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                           # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                    # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                                   # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                             # SLURM joins out and err by default
-              setenv RUN_FT "06:00:00"                                                     # Wallclock Time   for gcm_forecast.j
-              setenv RUN_T  "12:00:00"                                                     # Wallclock Time   for gcm_run.j
-              setenv POST_T  "8:00:00"                                                     # Wallclock Time   for gcm_post.j
+              setenv RUN_FT "4:00:00"                                                      # Wallclock Time   for gcm_forecast.j
+              setenv RUN_T  "4:00:00"                                                      # Wallclock Time   for gcm_run.j
+              setenv POST_T  "4:00:00"                                                     # Wallclock Time   for gcm_post.j
               setenv PLOT_T  "12:00:00"                                                    # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "1:00:00"                                                  # Wallclock Time   for gcm_archive.j
               setenv RUN_Q     "SBATCH --constraint=${MODEL}"                              # batch queue name for gcm_run.j
@@ -2107,14 +2110,15 @@ else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
 else
 # These are defaults for the desktop
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                               # SLURM Batch pragma
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
-              setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "12:00:00"                                             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"                                              # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"                                              # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"                                              # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"                                              # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "12:00:00"                                             # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "1:00:00"                                              # Wallclock Time   for gcm_archive.j
               setenv  RUN_Q     NULL                                                   # batch queue name for gcm_run.j
@@ -2607,6 +2611,7 @@ s?@HOMDIR?$HOMDIR?g
 s?@BATCH_GROUP?${BATCH_GROUP}${GROUP}?g
 s?@BATCH_TIME?$BATCH_TIME?g
 s?@BATCH_CMD?$BATCH_CMD?g
+s?@BATCH_NAME?$BATCH_NAME?g
 s?@BATCH_JOBNAME?$BATCH_JOBNAME?g
 s?@BATCH_OUTPUTNAME?$BATCH_OUTPUTNAME?g
 s?@BATCH_JOINOUTERR?$BATCH_JOINOUTERR?g

--- a/scm_setup
+++ b/scm_setup
@@ -514,22 +514,22 @@ builtin cd $CURRDIR
 
 if [ $nlev -ne 72 ]
 then
-
-  digits=0000
-  temp=$digits$nlev
-  padlev=${temp:(-${#digits})}
-
   $ISED -e "s/L72/L${nlev}/g" -e "s/z72/z${nlev}/g" $expdir/*.rc
   $ISED -e "s/L72/L${nlev}/g" -e "s/z72/z${nlev}/g" $expdir/*.yaml
-
-  $ISED "/AGCM_LM:/c\AGCM_LM: ${nlev}" $expdir/AGCM.rc
-  $ISED "/AGCM.LM:/c\AGCM.LM: ${nlev}" $expdir/AGCM.rc
-  $ISED "/SCMGRID.LM:/c\SCMGRID.LM: ${nlev}" $expdir/HISTORY.rc
-  cp $SOURCEDIR/*rst.r0001x0001x${padlev} $expdir
-  /bin/mv $expdir/datmodyn_internal_rst.r0001x0001x${padlev} $expdir/datmodyn_internal_rst
-  /bin/mv $expdir/moist_internal_rst.r0001x0001x${padlev} $expdir/moist_internal_rst
-
 fi
+
+$ISED "/AGCM_LM:/c\AGCM_LM: ${nlev}" $expdir/AGCM.rc
+$ISED "/AGCM.LM:/c\AGCM.LM: ${nlev}" $expdir/AGCM.rc
+$ISED "/SCMGRID.LM:/c\SCMGRID.LM: ${nlev}" $expdir/HISTORY.rc
+
+digits=0000
+temp=$digits$nlev
+padlev=${temp:(-${#digits})}
+
+cp $SOURCEDIR/*rst.r0001x0001x${padlev} $expdir
+/bin/mv $expdir/datmodyn_internal_rst.r0001x0001x${padlev} $expdir/datmodyn_internal_rst
+/bin/mv $expdir/moist_internal_rst.r0001x0001x${padlev} $expdir/moist_internal_rst
+
 
 /bin/ln -s $CHMDIR/g5chem $expdir/ExtData
 /bin/ln -s $CHMDIR/PIESA $expdir/ExtData

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1767,16 +1767,17 @@ setenv BOUNDARY_DIR ""
 
 if( $SITE == 'NAS' ) then
               setenv BATCH_CMD "qsub"                 # PBS Batch command
+              setenv BATCH_NAME "DELETE"              # PBS Batch pragma (not needed for NAS)
               setenv BATCH_GROUP "PBS -W group_list=" # PBS Syntax for GROUP
               setenv BATCH_TIME "PBS -l walltime="    # PBS Syntax for walltime
               setenv BATCH_JOBNAME "PBS -N "          # PBS Syntax for job name
               setenv BATCH_OUTPUTNAME "PBS -o "       # PBS Syntax for job output name
               setenv BATCH_JOINOUTERR "PBS -j oe -k oed"  # PBS Syntax for joining output and error
-              setenv     RUN_FT "6:00:00"             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "8:00:00"             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"             # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"             # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"             # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"             # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "8:00:00"             # Wallclock Time   for gcm_plot.j
-              setenv ARCHIVE_T  "8:00:00"             # Wallclock Time   for gcm_archive.j
+              setenv ARCHIVE_T  "4:00:00"             # Wallclock Time   for gcm_archive.j
               set QTYPE = "normal"                    # Queue to use
 
               @ NPCUS = `echo "($POST_NPES + $NCPUS_PER_NODE - 1)/$NCPUS_PER_NODE" | bc`
@@ -1815,14 +1816,15 @@ if( $SITE == 'NAS' ) then
 
 else if( $SITE == 'NCCS' ) then
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                               # SLURM Batch pragma
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
-              setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "12:00:00"                                             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"                                              # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"                                              # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"                                              # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"                                              # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "12:00:00"                                             # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "2:00:00"                                              # Wallclock Time   for gcm_archive.j
 
@@ -1868,14 +1870,15 @@ else if( $SITE == 'NCCS' ) then
 
 else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
               setenv BATCH_CMD "sbatch"                                                    # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                                   # SLURM Batch pragma
               setenv BATCH_GROUP DELETE                                                    # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                           # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                    # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                                   # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                             # SLURM joins out and err by default
-              setenv RUN_FT "06:00:00"                                                     # Wallclock Time   for gcm_forecast.j
-              setenv RUN_T  "12:00:00"                                                     # Wallclock Time   for gcm_run.j
-              setenv POST_T  "8:00:00"                                                     # Wallclock Time   for gcm_post.j
+              setenv RUN_FT "4:00:00"                                                      # Wallclock Time   for gcm_forecast.j
+              setenv RUN_T  "4:00:00"                                                      # Wallclock Time   for gcm_run.j
+              setenv POST_T  "4:00:00"                                                     # Wallclock Time   for gcm_post.j
               setenv PLOT_T  "12:00:00"                                                    # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "1:00:00"                                                  # Wallclock Time   for gcm_archive.j
               setenv RUN_Q     "SBATCH --constraint=${MODEL}"                              # batch queue name for gcm_run.j
@@ -1906,14 +1909,15 @@ else if( $SITE == 'AWS' | $SITE == 'Azure' ) then
 else
 # These are defaults for the desktop
               setenv BATCH_CMD "sbatch"                                                # SLURM Batch command
+              setenv BATCH_NAME "SBATCH"                                               # SLURM Batch pragma
               setenv BATCH_GROUP "SBATCH --account="                                   # SLURM Syntax for account name
               setenv BATCH_TIME "SBATCH --time="                                       # SLURM Syntax for walltime
               setenv BATCH_JOBNAME "SBATCH --job-name="                                # SLURM Syntax for job name
               setenv BATCH_OUTPUTNAME "SBATCH --output="                               # SLURM Syntax for job output name
               setenv BATCH_JOINOUTERR "DELETE"                                         # SLURM joins out and err by default
-              setenv     RUN_FT "06:00:00"                                             # Wallclock Time   for gcm_forecast.j
-              setenv     RUN_T  "12:00:00"                                             # Wallclock Time   for gcm_run.j
-              setenv    POST_T  "8:00:00"                                              # Wallclock Time   for gcm_post.j
+              setenv     RUN_FT "4:00:00"                                              # Wallclock Time   for gcm_forecast.j
+              setenv     RUN_T  "4:00:00"                                              # Wallclock Time   for gcm_run.j
+              setenv    POST_T  "4:00:00"                                              # Wallclock Time   for gcm_post.j
               setenv    PLOT_T  "12:00:00"                                             # Wallclock Time   for gcm_plot.j
               setenv ARCHIVE_T  "1:00:00"                                              # Wallclock Time   for gcm_archive.j
               setenv  RUN_Q     NULL                                                   # batch queue name for gcm_run.j
@@ -2400,6 +2404,7 @@ s?@HOMDIR?$HOMDIR?g
 s?@BATCH_GROUP?${BATCH_GROUP}${GROUP}?g
 s?@BATCH_TIME?$BATCH_TIME?g
 s?@BATCH_CMD?$BATCH_CMD?g
+s?@BATCH_NAME?$BATCH_NAME?g
 s?@BATCH_JOBNAME?$BATCH_JOBNAME?g
 s?@BATCH_OUTPUTNAME?$BATCH_OUTPUTNAME?g
 s?@BATCH_JOINOUTERR?$BATCH_JOINOUTERR?g


### PR DESCRIPTION
Closes #867 

This PR updates `gcm_setup` to default to 4-hour walltimes for `gcm_run.j`, `gcm_regress.j`, and `gcm_post.j`

I did *not* change the plot walltime as @sdrabenh said to avoid that for now.

~NOTE: I do *NOT* update the other setup scripts. I have no idea if their default jobs could run in 4 hours or not. To that end, I'll mention @mmanyin to answer in the positive/negative for GMI and StratChem.~ → I've updated them. See below.

Also, I fix a bug in `scm_setup` found by @narnold1 (see #868 for the v12 version)