### PR TITLE
Make running gcm_setup more flexible

### DIFF
--- a/gcm_setup
+++ b/gcm_setup
@@ -31,8 +31,8 @@ endif
 #                     Build Directory Locations
 #######################################################################
 
-# Set Current Working Path to gcm_setup
-# -------------------------------------
+# Set Directory Location of gcm_setup
+# ------------------------------------
 setenv ARCH `uname -s`
 setenv NODE `uname -n`
 
@@ -47,15 +47,20 @@ else
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
 endif
-set BINDIR   = `pwd -L`
+# Derive BINDIR from the script's own location, not the current working directory.
+# pushd/popd converts the relative dirname($0) to an absolute path.
+pushd `dirname $0` > /dev/null
+set BINDIR = `pwd -L`
+popd > /dev/null
 set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 
-# Test if GEOSgcm.x is here which means you are in install directory
+# Test if GEOSgcm.x is here which means we are in the install bin/ directory.
+# This rejects running gcm_setup directly from the source or build tree.
 if (! -x ${BINDIR}/GEOSgcm.x) then
-   echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
-   echo "This is no longer supported. Please run from the bin/ directory"
-   echo "in your installation"
+   echo "ERROR: $0 must be run from the bin/ directory of an installation."
+   echo "       GEOSgcm.x was not found in ${BINDIR}."
+   echo "       Do not run gcm_setup from the source or build tree."
    exit 1
 endif
 

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -47,15 +47,20 @@ else
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
 endif
-set BINDIR   = `pwd -L`
+# Derive BINDIR from the script's own location, not the current working directory.
+# pushd/popd converts the relative dirname($0) to an absolute path.
+pushd `dirname $0` > /dev/null
+set BINDIR = `pwd -L`
+popd > /dev/null
 set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 
-# Test if GEOSgcm.x is here which means you are in install directory
+# Test if GEOSgcm.x is here which means we are in the install bin/ directory.
+# This rejects running this script directly from the source or build tree.
 if (! -x ${BINDIR}/GEOSgcm.x) then
-   echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
-   echo "This is no longer supported. Please run from the bin/ directory"
-   echo "in your installation"
+   echo "ERROR: $0 must be run from the bin/ directory of an installation."
+   echo "       GEOSgcm.x was not found in ${BINDIR}."
+   echo "       Do not run this script from the source or build tree."
    exit 1
 endif
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -47,15 +47,20 @@ else
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
 endif
-set BINDIR   = `pwd -L`
+# Derive BINDIR from the script's own location, not the current working directory.
+# pushd/popd converts the relative dirname($0) to an absolute path.
+pushd `dirname $0` > /dev/null
+set BINDIR = `pwd -L`
+popd > /dev/null
 set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 
-# Test if GEOSgcm.x is here which means you are in install directory
+# Test if GEOSgcm.x is here which means we are in the install bin/ directory.
+# This rejects running this script directly from the source or build tree.
 if (! -x ${BINDIR}/GEOSgcm.x) then
-   echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
-   echo "This is no longer supported. Please run from the bin/ directory"
-   echo "in your installation"
+   echo "ERROR: $0 must be run from the bin/ directory of an installation."
+   echo "       GEOSgcm.x was not found in ${BINDIR}."
+   echo "       Do not run this script from the source or build tree."
    exit 1
 endif
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -47,15 +47,20 @@ else
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
 endif
-set BINDIR   = `pwd -L`
+# Derive BINDIR from the script's own location, not the current working directory.
+# pushd/popd converts the relative dirname($0) to an absolute path.
+pushd `dirname $0` > /dev/null
+set BINDIR = `pwd -L`
+popd > /dev/null
 set GEOSDEF  = `dirname $BINDIR`
 set ETCDIR   = ${GEOSDEF}/etc
 
-# Test if GEOSgcm.x is here which means you are in install directory
+# Test if GEOSgcm.x is here which means we are in the install bin/ directory.
+# This rejects running this script directly from the source or build tree.
 if (! -x ${BINDIR}/GEOSgcm.x) then
-   echo "You are trying to run $0 in the Applications/GEOSgcm_App directory"
-   echo "This is no longer supported. Please run from the bin/ directory"
-   echo "in your installation"
+   echo "ERROR: $0 must be run from the bin/ directory of an installation."
+   echo "       GEOSgcm.x was not found in ${BINDIR}."
+   echo "       Do not run this script from the source or build tree."
    exit 1
 endif
 


### PR DESCRIPTION
As found by @AgilentGCMS, `gcm_setup` was not as flexible as intended. We wanted users to be able to only run `gcm_setup` from the `install/bin` dir, but there should be no reason a user has to actually be in that directory.

This PR, makes it more flexible for a user so you could do:

```
/path/to/install/bin/gcm_setup
```
and it should run.