### PR TITLE
update related to v14 BCs 

### DIFF
--- a/linkbcs.tmpl
+++ b/linkbcs.tmpl
@@ -76,7 +76,7 @@ if ( $bc_is_gm4 ) then
   set topo_src_dir = "$BCSDIR/TOPO/TOPO_@ATMOStag"
 else
   set stream = v1
-  if ( $bc_ver_num >= 14 ) set stream = v2
+  if ( $bc_ver_num >= 15 ) set stream = v2
   set topo_src_dir = "@BCS_INPUT_BASE/TOPO/${stream}/@ATMOStag/smoothed"
 endif
 

--- a/linkbcs.tmpl
+++ b/linkbcs.tmpl
@@ -24,7 +24,7 @@ setenv BCRSLV    @ATMOStag_@OCEANtag
 @MOM6/bin/ln -sf $CPLDIR/@OGCM_IMx@OGCM_JM/vgrid@OGCM_LM.ascii ./vgrid.ascii
 @MIT/bin/ln  -sf $CPLDIR/DC0360xPC0181_LL5400x15-LL.bin DC0360xPC0181_LL5400x15-LL.bin
 
- # Precip correction
+# Precip correction
 #/bin/ln -s /discover/nobackup/projects/gmao/share/gmao_ops/fvInput/merra_land/precip_CPCUexcludeAfrica-CMAP_corrected_MERRA/GEOSdas-2_1_4 ExtData/PCP
 
 @DATAOCEAN/bin/ln -sf $BCSDIR/geometry/$BCRSLV/${BCRSLV}-Pfafstetter.til  tile.data


### PR DESCRIPTION
 It was decided for `v14` BCs to still link to `v1 TOPO`. 

Current relevant BCs:
`NL3` v1 TOPO - Old "new land" 
`v12` v1 TOPO - Current default for GCMv12 
`v14` v1 TOPO - Hopefully new default for GCMv12. 
                             Where v14 has updates included in v13 BCs for coupled ocean runs + update for peat. 
                             Remap restarts already links properly to this topo version based on `v14/TOPO/TOPO_version_info`

This PR is zero diff trivial since this was still not used. 