### PR TITLE
Run GEOS from install dir in experiment

### DIFF
--- a/gcm_forecast.tmpl
+++ b/gcm_forecast.tmpl
@@ -32,9 +32,15 @@ setenv GEOSETC          @GEOSETC
 setenv GEOSUTIL         @GEOSSRC
 
 source $GEOSBIN/g5_modules
-setenv @LD_LIBRARY_PATH_CMD ${LD_LIBRARY_PATH}:${GEOSDIR}/lib
+
+# We only prepend to DY/LD_LIBRARY_PATH if it exists
+# We only add BASEDIR to the @LD_LIBRARY_PATH_CMD if BASEDIR is defined (i.e., not running with Spack)
 if ( $?BASEDIR ) then
-   setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+   if ( $?@LD_LIBRARY_PATH_CMD ) then
+      setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+   else
+      setenv @LD_LIBRARY_PATH_CMD ${BASEDIR}/${ARCH}/lib
+   endif
 endif
 
 setenv RUN_CMD "@RUN_CMD"
@@ -50,6 +56,9 @@ echo   VERSION: $GCMVER
 setenv  EXPID   @EXPID
 setenv  EXPDIR  @EXPDIR
 setenv  HOMDIR  @HOMDIR
+
+setenv EXPBINDIR $EXPDIR/install/bin
+setenv EXPLIBDIR $EXPDIR/install/lib
 
 #######################################################################
 #                  Set Forecast Run Parameters
@@ -450,10 +459,7 @@ chmod +x linkbcs
 #                    Get Executable and RESTARTS
 #######################################################################
 
- echo "Copying $EXPDIR/GEOSgcm.x to $SCRDIR"
- echo ""
- /bin/cp $EXPDIR/GEOSgcm.x $SCRDIR/GEOSgcm.x
- setenv GEOSEXE $SCRDIR/GEOSgcm.x
+ setenv GEOSEXE $EXPBINDIR/GEOSgcm.x
 
 set rst_files      = `grep "RESTART_FILE"    AGCM.rc | grep -v VEGDYN | grep -v "#" | cut -d ":" -f1 | cut -d "_" -f1-2`
 set rst_file_names = `grep "RESTART_FILE"    AGCM.rc | grep -v VEGDYN | grep -v "#" | cut -d ":" -f2`
@@ -643,8 +649,8 @@ if ( ! -e gwd_internal_rst ) then
 endif
 
 if (! -e tile.bin) then
-$GEOSBIN/binarytile.x tile.data tile.bin
-@MOM5 $GEOSBIN/binarytile.x tile_hist.data tile_hist.bin
+$EXPBINDIR/binarytile.x tile.data tile.bin
+@MOM5 $EXPBINDIR/binarytile.x tile_hist.data tile_hist.bin
 endif
 
 # If running in dual ocean mode, link sst and fraci data here
@@ -656,11 +662,11 @@ endif
 # Test Openwater Restart for Number of tiles correctness
 # ------------------------------------------------------
 
-if ( -x $GEOSBIN/rs_numtiles.x ) then
+if ( -x $EXPBINDIR/rs_numtiles.x ) then
 
    set N_OPENW_TILES_EXPECTED = `grep '^\s*0' tile.data | wc -l`
-   @SINGULARITY_BUILD set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $SINGULARITY_RUN $GEOSBIN/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
-   @NATIVE_BUILD set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $GEOSBIN/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
+   @SINGULARITY_BUILD set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $SINGULARITY_RUN $EXPBINDIR/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
+   @NATIVE_BUILD set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $EXPBINDIR/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
 
    if ( $N_OPENW_TILES_EXPECTED != $N_OPENW_TILES_FOUND ) then
       echo "Error! Found $N_OPENW_TILES_FOUND tiles in openwater. Expect to find $N_OPENW_TILES_EXPECTED tiles."

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -206,7 +206,7 @@ if ( ! -e gwd_internal_rst ) then
 endif
 
 
-if(! -e tile.bin) $EXPDIR/binarytile.x tile.data tile.bin
+if(! -e tile.bin) $EXPBINDIR/binarytile.x tile.data tile.bin
 
 #######################################################################
 #                 Create Simple History for Efficiency

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -101,15 +101,13 @@ setenv GEOSBIN @GEOSBIN
 source $GEOSBIN/g5_modules
 
 # We only prepend to DY/LD_LIBRARY_PATH if it exists
-if ( $?@LD_LIBRARY_PATH_CMD ) then
-   setenv @LD_LIBRARY_PATH_CMD "${@LD_LIBRARY_PATH_CMD}:${GEOSDIR}/lib"
-else
-   setenv @LD_LIBRARY_PATH_CMD "${GEOSDIR}/lib"
-endif
-
 # We only add BASEDIR to the @LD_LIBRARY_PATH_CMD if BASEDIR is defined (i.e., not running with Spack)
 if ( $?BASEDIR ) then
-    setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+   if ( $?@LD_LIBRARY_PATH_CMD ) then
+      setenv @LD_LIBRARY_PATH_CMD ${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib
+   else
+      setenv @LD_LIBRARY_PATH_CMD ${BASEDIR}/${ARCH}/lib
+   endif
 endif
 
 setenv RUN_CMD "@RUN_CMD"
@@ -122,6 +120,9 @@ setenv EXPID  @EXPID
 setenv EXPDIR @EXPDIR
 setenv HOMDIR @HOMDIR
 setenv SCRDIR $EXPDIR/scratch
+
+setenv EXPBINDIR $EXPDIR/install/bin
+setenv EXPLIBDIR $EXPDIR/install/lib
 
 #######################################################################
 #                 Create Clean Regress Sub-Directory
@@ -143,7 +144,6 @@ cd $EXPDIR/regress
 
 cp $EXPDIR/RC/*.rc     $EXPDIR/regress
 cp $EXPDIR/RC/*.yaml   $EXPDIR/regress
-cp $EXPDIR/GEOSgcm.x   $EXPDIR/regress
 cp $EXPDIR/linkbcs     $EXPDIR/regress
 cp $HOMDIR/*.yaml      $EXPDIR/regress
 @COUPLED cp $HOMDIR/*.nml       $EXPDIR/regress
@@ -151,6 +151,8 @@ cp $HOMDIR/*.yaml      $EXPDIR/regress
 @MOM6cp $HOMDIR/MOM_override $EXPDIR/regress
 
 cat fvcore_layout.rc >> input.nml
+
+setenv GEOSEXE $EXPBINDIR/GEOSgcm.x
 
 # Define Atmospheric Resolution
 # -----------------------------
@@ -204,7 +206,7 @@ if ( ! -e gwd_internal_rst ) then
 endif
 
 
-if(! -e tile.bin) $GEOSBIN/binarytile.x tile.data tile.bin
+if(! -e tile.bin) $EXPDIR/binarytile.x tile.data tile.bin
 
 #######################################################################
 #                 Create Simple History for Efficiency
@@ -454,7 +456,7 @@ if( $RUN_STARTSTOP == TRUE ) then
 
    echo "=== Running test of duration ${test_duration_step1} with NX = $NX and NY = $NY starting at $nymd0 $nhms0 ==="
 
-   @OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
+   @OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $NPES $GEOSEXE --logging_config 'logging.yaml'
 
    set date = `cat cap_restart`
    set nymde1 = $date[1]
@@ -520,7 +522,7 @@ set NY = `grep "^ *NY": AGCM.rc | cut -d':' -f2`
 
 echo "=== Running test of duration ${test_duration_step2} with NX = $NX and NY = $NY starting at $nymd0 $nhms0 ==="
 
-@OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
+@OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $NPES $GEOSEXE --logging_config 'logging.yaml'
 
 set date = `cat cap_restart`
 set nymde2 = $date[1]
@@ -639,7 +641,7 @@ if ($RUN_STARTSTOP == TRUE) then
 
    echo "=== Running test of duration ${test_duration_step3} with NX = $NX and NY = $NY starting at $nymdb $nhmsb ==="
 
-   @OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
+   @OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $NPES $GEOSEXE --logging_config 'logging.yaml'
 
    set date = `cat cap_restart`
    set nymde3 = $date[1]
@@ -770,7 +772,7 @@ if ( $RUN_LAYOUT == TRUE) then
 
    echo "=== Running test of duration ${test_duration_step4} with NX = $test_NX and NY = $test_NY starting at $nymd0 $nhms0 ==="
 
-   @OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
+   @OCEAN_PRELOAD @SEVERAL_TRIES $RUN_CMD $NPES $GEOSEXE --logging_config 'logging.yaml'
 
    set date = `cat cap_restart`
    set nymde4 = $date[1]
@@ -893,7 +895,7 @@ if ( $RUN_OPENMP == TRUE) then
 
    echo "=== Running OpenMP test of duration ${test_duration_step5} with NX = $NX0 and NY = $NY0 starting at $nymd0 $nhms0 ==="
 
-   @OCEAN_PRELOAD $RUN_CMD $NPES ./GEOSgcm.x --logging_config 'logging.yaml'
+   @OCEAN_PRELOAD $RUN_CMD $NPES $GEOSEXE --logging_config 'logging.yaml'
 
    set date = `cat cap_restart`
    set nymde4 = $date[1]

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -33,18 +33,6 @@ setenv GEOSETC          @GEOSETC
 setenv GEOSUTIL         @GEOSSRC
 
 source $GEOSBIN/g5_modules
-# We only prepend to DY/LD_LIBRARY_PATH if it exists
-if ( $?@LD_LIBRARY_PATH_CMD ) then
-   setenv @LD_LIBRARY_PATH_CMD "${@LD_LIBRARY_PATH_CMD}:${GEOSDIR}/lib"
-else
-   setenv @LD_LIBRARY_PATH_CMD "${GEOSDIR}/lib"
-endif
-# We only add BASEDIR to the @LD_LIBRARY_PATH_CMD if BASEDIR is defined (i.e., not running with Spack)
-if ( $?BASEDIR ) then
-    setenv @LD_LIBRARY_PATH_CMD "${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib"
-    setenv PATH "${PATH}:${BASEDIR}/${ARCH}/bin"
-endif
-
 setenv RUN_CMD "@RUN_CMD"
 
 setenv GCMVER `cat $GEOSETC/.AGCM_VERSION`
@@ -61,6 +49,20 @@ setenv  HOMDIR  @HOMDIR
 
 setenv  RSTDATE @RSTDATE
 setenv  GCMEMIP @GCMEMIP
+
+setenv  EXPBINDIR $EXPDIR/install/bin
+setenv  EXPLIBDIR $EXPDIR/install/lib
+
+# We only prepend to DY/LD_LIBRARY_PATH if it exists
+# We only add BASEDIR to the @LD_LIBRARY_PATH_CMD if BASEDIR is defined (i.e., not running with Spack)
+if ( $?BASEDIR ) then
+   if ( $?@LD_LIBRARY_PATH_CMD ) then
+      setenv @LD_LIBRARY_PATH_CMD "${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib"
+   else
+      setenv @LD_LIBRARY_PATH_CMD "${BASEDIR}/${ARCH}/lib"
+   endif
+   setenv PATH "${PATH}:${BASEDIR}/${ARCH}/bin"
+endif
 
 #######################################################################
 #                          DSL configuration
@@ -471,37 +473,10 @@ chmod +x linkbcs
 @SINGULARITY_BUILD # Set a variable to encapsulate all Singularity details
 @SINGULARITY_BUILD setenv SINGULARITY_RUN "singularity exec $SINGULARITY_BIND_PATH $SINGULARITY_SANDBOX"
 @SINGULARITY_BUILD
-@SINGULARITY_BUILD # Detect if GEOSgcm.x is in the experiment directory
-@SINGULARITY_BUILD if (-e $EXPDIR/GEOSgcm.x) then
-@SINGULARITY_BUILD    echo "Found GEOSgcm.x in $EXPDIR"
-@SINGULARITY_BUILD
-@SINGULARITY_BUILD    # If SINGULARITY_SANDBOX is non-empty and GEOSgcm.x is found in the experiment directory,
-@SINGULARITY_BUILD    # force the use of GEOSgcm.x in the installation directory
-@SINGULARITY_BUILD    if( $SINGULARITY_SANDBOX != "" ) then
-@SINGULARITY_BUILD       echo "NOTE: Testing has shown Singularity only works when running with"
-@SINGULARITY_BUILD       echo "      the GEOSgcm.x executable directly from the installation bin directory"
-@SINGULARITY_BUILD       echo ""
-@SINGULARITY_BUILD       echo "      So, we will *ignore* the local GEOSgcm.x and "
-@SINGULARITY_BUILD       echo "      instead use $GEOSBIN/GEOSgcm.x"
-@SINGULARITY_BUILD       echo ""
-@SINGULARITY_BUILD    else
-@SINGULARITY_BUILD       echo "Using GEOSgcm.x from $GEOSBIN"
-@SINGULARITY_BUILD    endif
-@SINGULARITY_BUILD    setenv GEOSEXE $GEOSBIN/GEOSgcm.x
-@SINGULARITY_BUILD else
-@SINGULARITY_BUILD    echo "Using GEOSgcm.x from $GEOSBIN"
-@SINGULARITY_BUILD    setenv GEOSEXE $GEOSBIN/GEOSgcm.x
-@SINGULARITY_BUILD endif
+@SINGULARITY_BUILD echo "Using GEOSgcm.x from $GEOSBIN"
+@SINGULARITY_BUILD setenv GEOSEXE $GEOSBIN/GEOSgcm.x
 
-@NATIVE_BUILD if (-e $EXPDIR/GEOSgcm.x) then
-@NATIVE_BUILD    echo "Copying $EXPDIR/GEOSgcm.x to $SCRDIR"
-@NATIVE_BUILD    echo ""
-@NATIVE_BUILD    /bin/cp $EXPDIR/GEOSgcm.x $SCRDIR/GEOSgcm.x
-@NATIVE_BUILD else
-@NATIVE_BUILD    echo "$EXPDIR/GEOSgcm.x not found. Please link or copy the executable to the experiment directory."
-@NATIVE_BUILD    exit 4
-@NATIVE_BUILD endif
-@NATIVE_BUILD setenv GEOSEXE $SCRDIR/GEOSgcm.x
+@NATIVE_BUILD setenv GEOSEXE $EXPBINDIR/GEOSgcm.x
 
 #######################################################################
 #                         Get RESTARTS
@@ -871,7 +846,7 @@ else
 endif
 
 if (! -e tile.bin) then
-$GEOSBIN/binarytile.x tile.data tile.bin
+$EXPBINDIR/binarytile.x tile.data tile.bin
 endif
 
 # If running in dual ocean mode, link sst and fraci data here
@@ -893,11 +868,11 @@ endif
 # Test Openwater Restart for Number of tiles correctness
 # ------------------------------------------------------
 
-if ( -x $GEOSBIN/rs_numtiles.x ) then
+if ( -x $EXPBINDIR/rs_numtiles.x ) then
 
    set N_OPENW_TILES_EXPECTED = `grep '^\s*0' tile.data | wc -l`
-   @SINGULARITY_BUILD set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $SINGULARITY_RUN $GEOSBIN/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
-   @NATIVE_BUILD set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $GEOSBIN/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
+   @SINGULARITY_BUILD set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $SINGULARITY_RUN $EXPBINDIR/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
+   @NATIVE_BUILD set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $EXPBINDIR/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
 
    if ( $N_OPENW_TILES_EXPECTED != $N_OPENW_TILES_FOUND ) then
       echo "Error! Found $N_OPENW_TILES_FOUND tiles in openwater. Expect to find $N_OPENW_TILES_EXPECTED tiles."

--- a/gcm_run_benchmark.j
+++ b/gcm_run_benchmark.j
@@ -56,6 +56,9 @@ setenv  HOMDIR  @BENCH_DIR/@EXPID
 setenv  RSTDATE @RSTDATE
 setenv  GCMEMIP @GCMEMIP
 
+setenv EXPBINDIR $EXPDIR/install/bin
+setenv EXPLIBDIR $EXPDIR/install/lib
+
 #######################################################################
 #                 Create Experiment Sub-Directories
 #######################################################################
@@ -421,8 +424,6 @@ cp  linkbcs $EXPDIR
 #                    Get Executable and RESTARTS
 #######################################################################
 
-cp $EXPDIR/GEOSgcm.x .
-
 set rst_files      = `grep "RESTART_FILE"    AGCM.rc | grep -v VEGDYN | grep -v "#" | cut -d ":" -f1 | cut -d "_" -f1-2`
 set rst_file_names = `grep "RESTART_FILE"    AGCM.rc | grep -v VEGDYN | grep -v "#" | cut -d ":" -f2`
 
@@ -658,8 +659,8 @@ if (! -e gwd_internal_rst ) then
 endif
 
 if (! -e tile.bin) then
-$GEOSBIN/binarytile.x tile.data tile.bin
-@MOM5 $GEOSBIN/binarytile.x tile_hist.data tile_hist.bin
+$EXPBINDIR/binarytile.x tile.data tile.bin
+@MOM5 $EXPBINDIR/binarytile.x tile_hist.data tile_hist.bin
 endif
 
 # If running in dual ocean mode, link sst and fraci data here
@@ -671,10 +672,10 @@ endif
 # Test Openwater Restart for Number of tiles correctness
 # ------------------------------------------------------
 
-if ( -x $GEOSBIN/rs_numtiles.x ) then
+if ( -x $EXPBINDIR/rs_numtiles.x ) then
 
    set N_OPENW_TILES_EXPECTED = `grep '^\s*0' tile.data | wc -l`
-   set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $GEOSBIN/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
+   set N_OPENW_TILES_FOUND = `$RUN_CMD 1 $EXPBINDIR/rs_numtiles.x openwater_internal_rst | grep Total | awk '{print $NF}'`
 
    if ( $N_OPENW_TILES_EXPECTED != $N_OPENW_TILES_FOUND ) then
       echo "Error! Found $N_OPENW_TILES_FOUND tiles in openwater. Expect to find $N_OPENW_TILES_EXPECTED tiles."
@@ -780,7 +781,7 @@ else
    set IOSERVER_EXTRA = ""
 endif
 
-$RUN_CMD $NPES ./GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
+$RUN_CMD $NPES $EXPBINDIR/GEOSgcm.x $IOSERVER_OPTIONS $IOSERVER_EXTRA --logging_config 'logging.yaml'
 
 if( $USE_SHMEM == 1 ) $GEOSBIN/RmShmKeys_sshmpi.csh >& /dev/null
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -1878,7 +1878,7 @@ if ( $USING_SINGULARITY == FALSE ) then
 
    # Copy over shared object libraries that might be needed by the binaries
    mkdir -p $EXPDIR/install/lib
-   cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
+   cp -RP $GEOSDIR/lib/*@CMAKE_SHARED_LIBRARY_SUFFIX@ $EXPDIR/install/lib
 
    # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
    # be in the installation etc directory. We'll copy it into the EXPDIR/install

--- a/gcm_setup
+++ b/gcm_setup
@@ -1880,6 +1880,11 @@ if ( $USING_SINGULARITY == FALSE ) then
    mkdir -p $EXPDIR/install/lib
    cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
 
+   # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
+   # be in the installation etc directory. We'll copy it into the EXPDIR/install
+   # directory
+   cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"
    set NATIVE_BUILD = ""

--- a/gcm_setup
+++ b/gcm_setup
@@ -1883,7 +1883,9 @@ if ( $USING_SINGULARITY == FALSE ) then
    # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
    # be in the installation etc directory. We'll copy it into the EXPDIR/install
    # directory
-   cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+    if (-f $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256) then
+       cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+    endif
 
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"

--- a/gcm_setup
+++ b/gcm_setup
@@ -598,7 +598,7 @@ if( $OGCM == TRUE ) then
     if ( "$OCNMODEL" == "MOM5" ) then
        set OCEAN_NAME="MOM"
        set OGRIDTYP  = "M5TP"
-       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=$GEOSDIR/lib/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=$EXPLIBDIR/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM5=""
        set MOM6 = "#DELETE"
        set DEFAULT_HISTORY_TEMPLATE="HISTORY.AOGCM-MOM5.rc.tmpl"
@@ -609,7 +609,7 @@ if( $OGCM == TRUE ) then
     else if ( "$OCNMODEL" == "MOM6" ) then
        set OCEAN_NAME="MOM6"
        set OGRIDTYP  = "M6TP"
-       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=\$GEOSDIR/lib/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=\$EXPLIBDIR/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM6=""
        set MOM5 = "#DELETE"
        set DEFAULT_HISTORY_TEMPLATE="HISTORY.AOGCM.rc.tmpl"
@@ -783,13 +783,13 @@ if( $OGCM == TRUE ) then
     # suffix is different on Linux and macOS. This is set by configure_file()
     if ( $SEAICEMODEL == "CICE4" ) then
        set SEAICE_NAME="CICE4"
-       set SEAICE_PRELOAD = '$GEOSDIR/lib/libCICE4@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set SEAICE_PRELOAD = '$EXPLIBDIR/libCICE4@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set CICE4=""
        set CICE6 = "#DELETE"
        set HIST_CICE4 = ""
     else if ( $SEAICEMODEL == "CICE6" ) then
        set SEAICE_NAME="CICE6"
-       set SEAICE_PRELOAD = '$GEOSDIR/lib/libcice6@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set SEAICE_PRELOAD = '$EXPLIBDIR/libcice6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set CICE6=""
        set CICE4 = "#DELETE"
        set HIST_CICE4 = "#DELETE"
@@ -1865,11 +1865,20 @@ rm -f $EXPDIR/RC/fvcore_layout.rc
 
 # Copy or link GEOSgcm.x if USING_SINGULARITY is FALSE
 if ( $USING_SINGULARITY == FALSE ) then
+
+   # Binaries that might use shared object libraries we build
+   mkdir -p $EXPDIR/install/bin
    if ( $LINKX == "TRUE" ) then
-      if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+      if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR/install/bin
    else
-      if ( -e $GEOSBIN/GEOSgcm.x ) cp $GEOSBIN/GEOSgcm.x $EXPDIR
+      if ( -e $GEOSBIN/GEOSgcm.x ) cp $GEOSBIN/GEOSgcm.x $EXPDIR/install/bin
    endif
+   cp $GEOSBIN/binarytile.x $EXPDIR/install/bin
+   cp $GEOSBIN/rs_numtiles.x $EXPDIR/install/bin
+
+   # Copy over shared object libraries that might be needed by the binaries
+   mkdir -p $EXPDIR/install/lib
+   cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
 
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"
@@ -2952,7 +2961,8 @@ sh $COPYSCRIPT
 # ----------------------------------------------------
 
 echo "$NEWHOMDIR" >> $NEWEXPDIR/.HOMDIR
-/bin/cp $OLDEXPDIR/GEOSgcm.x $NEWEXPDIR
+mkdir -p $NEWEXPDIR/install
+/bin/cp -a $OLDEXPDIR/install/* $NEWEXPDIR/install/
 /bin/cp -a $OLDEXPDIR/RC $NEWEXPDIR/RC
 
 # -----------------------------------------------------

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -598,7 +598,7 @@ if( $OGCM == TRUE ) then
     if ( "$OCNMODEL" == "MOM5" ) then
        set OCEAN_NAME="MOM"
        set OGRIDTYP  = "M5TP"
-       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=$GEOSDIR/lib/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=$EXPLIBDIR/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM5=""
        set MOM6 = "#DELETE"
        set DEFAULT_HISTORY_TEMPLATE="HISTORY.AOGCM-MOM5.rc.tmpl"
@@ -609,7 +609,7 @@ if( $OGCM == TRUE ) then
     else if ( "$OCNMODEL" == "MOM6" ) then
        set OCEAN_NAME="MOM6"
        set OGRIDTYP  = "M6TP"
-       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=\$GEOSDIR/lib/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=\$EXPLIBDIR/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM6=""
        set MOM5 = "#DELETE"
        set DEFAULT_HISTORY_TEMPLATE="HISTORY.AOGCM.rc.tmpl"
@@ -783,13 +783,13 @@ if( $OGCM == TRUE ) then
     # suffix is different on Linux and macOS. This is set by configure_file()
     if ( $SEAICEMODEL == "CICE4" ) then
        set SEAICE_NAME="CICE4"
-       set SEAICE_PRELOAD = '$GEOSDIR/lib/libCICE4@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set SEAICE_PRELOAD = '$EXPLIBDIR/libCICE4@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set CICE4=""
        set CICE6 = "#DELETE"
        set HIST_CICE4 = ""
     else if ( $SEAICEMODEL == "CICE6" ) then
        set SEAICE_NAME="CICE6"
-       set SEAICE_PRELOAD = '$GEOSDIR/lib/libcice6@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set SEAICE_PRELOAD = '$EXPLIBDIR/libcice6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set CICE6=""
        set CICE4 = "#DELETE"
        set HIST_CICE4 = "#DELETE"
@@ -1880,11 +1880,20 @@ rm -f $EXPDIR/RC/fvcore_layout.rc
 
 # Copy or link GEOSgcm.x if USING_SINGULARITY is FALSE
 if ( $USING_SINGULARITY == FALSE ) then
+
+   # Binaries that might use shared object libraries we build
+   mkdir -p $EXPDIR/install/bin
    if ( $LINKX == "TRUE" ) then
-      if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+      if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR/install/bin
    else
-      if ( -e $GEOSBIN/GEOSgcm.x ) cp $GEOSBIN/GEOSgcm.x $EXPDIR
+      if ( -e $GEOSBIN/GEOSgcm.x ) cp $GEOSBIN/GEOSgcm.x $EXPDIR/install/bin
    endif
+   cp $GEOSBIN/binarytile.x $EXPDIR/install/bin
+   cp $GEOSBIN/rs_numtiles.x $EXPDIR/install/bin
+
+   # Copy over shared object libraries that might be needed by the binaries
+   mkdir -p $EXPDIR/install/lib
+   cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
 
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"
@@ -3150,7 +3159,8 @@ sh $COPYSCRIPT
 # ----------------------------------------------------
 
 echo "$NEWHOMDIR" >> $NEWEXPDIR/.HOMDIR
-/bin/cp $OLDEXPDIR/GEOSgcm.x $NEWEXPDIR
+mkdir -p $NEWEXPDIR/install
+/bin/cp -a $OLDEXPDIR/install/* $NEWEXPDIR/install/
 /bin/cp -a $OLDEXPDIR/RC $NEWEXPDIR/RC
 
 # -----------------------------------------------------

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1898,7 +1898,9 @@ if ( $USING_SINGULARITY == FALSE ) then
    # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
    # be in the installation etc directory. We'll copy it into the EXPDIR/install
    # directory
-   cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+    if (-f $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256) then
+       cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+    endif
 
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1893,7 +1893,7 @@ if ( $USING_SINGULARITY == FALSE ) then
 
    # Copy over shared object libraries that might be needed by the binaries
    mkdir -p $EXPDIR/install/lib
-   cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
+   cp -RP $GEOSDIR/lib/*@CMAKE_SHARED_LIBRARY_SUFFIX@ $EXPDIR/install/lib
 
    # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
    # be in the installation etc directory. We'll copy it into the EXPDIR/install

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -1895,6 +1895,11 @@ if ( $USING_SINGULARITY == FALSE ) then
    mkdir -p $EXPDIR/install/lib
    cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
 
+   # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
+   # be in the installation etc directory. We'll copy it into the EXPDIR/install
+   # directory
+   cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"
    set NATIVE_BUILD = ""

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2073,7 +2073,7 @@ if ( $USING_SINGULARITY == FALSE ) then
 
    # Copy over shared object libraries that might be needed by the binaries
    mkdir -p $EXPDIR/install/lib
-   cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
+   cp -RP $GEOSDIR/lib/*@CMAKE_SHARED_LIBRARY_SUFFIX@ $EXPDIR/install/lib
 
    # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
    # be in the installation etc directory. We'll copy it into the EXPDIR/install

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2075,6 +2075,11 @@ if ( $USING_SINGULARITY == FALSE ) then
    mkdir -p $EXPDIR/install/lib
    cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
 
+   # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
+   # be in the installation etc directory. We'll copy it into the EXPDIR/install
+   # directory
+   cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"
    set NATIVE_BUILD = ""

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -2078,7 +2078,9 @@ if ( $USING_SINGULARITY == FALSE ) then
    # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
    # be in the installation etc directory. We'll copy it into the EXPDIR/install
    # directory
-   cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+    if (-f $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256) then
+       cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+    endif
 
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -598,7 +598,7 @@ if( $OGCM == TRUE ) then
     if ( "$OCNMODEL" == "MOM5" ) then
        set OCEAN_NAME="MOM"
        set OGRIDTYP  = "M5TP"
-       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=$GEOSDIR/lib/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=$EXPLIBDIR/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM5=""
        set MOM6 = "#DELETE"
        set DEFAULT_HISTORY_TEMPLATE="HISTORY.AOGCM-MOM5.rc.tmpl"
@@ -609,7 +609,7 @@ if( $OGCM == TRUE ) then
     else if ( "$OCNMODEL" == "MOM6" ) then
        set OCEAN_NAME="MOM6"
        set OGRIDTYP  = "M6TP"
-       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=\$GEOSDIR/lib/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=\$EXPLIBDIR/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM6=""
        set MOM5 = "#DELETE"
        set DEFAULT_HISTORY_TEMPLATE="HISTORY.AOGCM.rc.tmpl"
@@ -783,13 +783,13 @@ if( $OGCM == TRUE ) then
     # suffix is different on Linux and macOS. This is set by configure_file()
     if ( $SEAICEMODEL == "CICE4" ) then
        set SEAICE_NAME="CICE4"
-       set SEAICE_PRELOAD = '$GEOSDIR/lib/libCICE4@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set SEAICE_PRELOAD = '$EXPLIBDIR/libCICE4@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set CICE4=""
        set CICE6 = "#DELETE"
        set HIST_CICE4 = ""
     else if ( $SEAICEMODEL == "CICE6" ) then
        set SEAICE_NAME="CICE6"
-       set SEAICE_PRELOAD = '$GEOSDIR/lib/libcice6@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set SEAICE_PRELOAD = '$EXPLIBDIR/libcice6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set CICE6=""
        set CICE4 = "#DELETE"
        set HIST_CICE4 = "#DELETE"
@@ -2060,11 +2060,20 @@ rm -f $EXPDIR/RC/fvcore_layout.rc
 
 # Copy or link GEOSgcm.x if USING_SINGULARITY is FALSE
 if ( $USING_SINGULARITY == FALSE ) then
+
+   # Binaries that might use shared object libraries we build
+   mkdir -p $EXPDIR/install/bin
    if ( $LINKX == "TRUE" ) then
-      if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+      if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR/install/bin
    else
-      if ( -e $GEOSBIN/GEOSgcm.x ) cp $GEOSBIN/GEOSgcm.x $EXPDIR
+      if ( -e $GEOSBIN/GEOSgcm.x ) cp $GEOSBIN/GEOSgcm.x $EXPDIR/install/bin
    endif
+   cp $GEOSBIN/binarytile.x $EXPDIR/install/bin
+   cp $GEOSBIN/rs_numtiles.x $EXPDIR/install/bin
+
+   # Copy over shared object libraries that might be needed by the binaries
+   mkdir -p $EXPDIR/install/lib
+   cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
 
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"
@@ -3373,7 +3382,8 @@ sh $COPYSCRIPT
 # ----------------------------------------------------
 
 echo "$NEWHOMDIR" >> $NEWEXPDIR/.HOMDIR
-/bin/cp $OLDEXPDIR/GEOSgcm.x $NEWEXPDIR
+mkdir -p $NEWEXPDIR/install
+/bin/cp -a $OLDEXPDIR/install/* $NEWEXPDIR/install/
 /bin/cp -a $OLDEXPDIR/RC $NEWEXPDIR/RC
 
 # -----------------------------------------------------

--- a/scm_run.j
+++ b/scm_run.j
@@ -24,23 +24,24 @@ if ( $?USE_DSL ) then
     endif
 endif
 
+setenv EXPDIR  @EXPDIR
+setenv EXPBINDIR $EXPDIR/install/bin
+setenv EXPLIBDIR $EXPDIR/install/lib
+
 # We only prepend to DY/LD_LIBRARY_PATH if it exists
-if ( $?@LD_LIBRARY_PATH_CMD ) then
-   setenv @LD_LIBRARY_PATH_CMD "${@LD_LIBRARY_PATH_CMD}:${GEOSDIR}/lib"
-else
-   setenv @LD_LIBRARY_PATH_CMD "${GEOSDIR}/lib"
-endif
 # We only add BASEDIR to the @LD_LIBRARY_PATH_CMD if BASEDIR is defined (i.e., not running with Spack)
 if ( $?BASEDIR ) then
-   setenv @LD_LIBRARY_PATH_CMD "${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib"
+   if ( $?@LD_LIBRARY_PATH_CMD ) then
+      setenv @LD_LIBRARY_PATH_CMD "${@LD_LIBRARY_PATH_CMD}:${BASEDIR}/${ARCH}/lib"
+   else
+      setenv @LD_LIBRARY_PATH_CMD "${BASEDIR}/${ARCH}/lib"
+   endif
 endif
 
 setenv RUN_CMD "@RUN_CMD"
 
 setenv GCMVER `cat $GEOSETC/.AGCM_VERSION`
 echo   VERSION: $GCMVER
-
-setenv EXPDIR  @EXPDIR
 
 cd $EXPDIR
 
@@ -55,4 +56,4 @@ echo "file_weights: @FILE_WEIGHTS" >> extdata.yaml
 
 setenv OMP_NUM_THREADS 1
 
-$RUN_CMD 1 ./GEOSgcm.x --logging_config 'logging.yaml'
+$RUN_CMD 1 $EXPBINDIR/GEOSgcm.x --logging_config 'logging.yaml'

--- a/scm_setup
+++ b/scm_setup
@@ -453,7 +453,13 @@ SOURCEDIR=$SCMDIR/$selected_case
 
 mkdir -p $expdir
 
-/bin/cp $INSTALLDIR/bin/GEOSgcm.x $expdir
+mkdir -p $expdir/install/bin
+
+/bin/cp $INSTALLDIR/bin/GEOSgcm.x $expdir/install/bin
+
+mkdir -p $expdir/install/lib
+/bin/cp $INSTALLDIR/lib/*.so $expdir/install/lib
+
 /bin/cp $INSTALLDIR/etc/logging.yaml $expdir
 
 /bin/cp $SOURCEDIR/$DATFILE $expdir

--- a/scm_setup
+++ b/scm_setup
@@ -462,6 +462,13 @@ mkdir -p $expdir/install/bin
 mkdir -p $expdir/install/lib
 /bin/cp $INSTALLDIR/lib/*.${SHARED_LIB_EXT} $expdir/install/lib
 
+# CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
+# be in the installation etc directory. We'll copy it into the expdir/install
+# directory
+if [[ -f $INSTALLDIR/etc/GEOS_RUNTIME_MANIFEST.sha256 ]]; then
+   /bin/cp $INSTALLDIR/etc/GEOS_RUNTIME_MANIFEST.sha256 $expdir/install
+fi
+
 /bin/cp $INSTALLDIR/etc/logging.yaml $expdir
 
 /bin/cp $SOURCEDIR/$DATFILE $expdir

--- a/scm_setup
+++ b/scm_setup
@@ -240,6 +240,7 @@ then
    fi
    PRELOAD_COMMAND='DYLD_INSERT_LIBRARIES'
    LD_LIBRARY_PATH_CMD='DYLD_LIBRARY_PATH'
+   SHARED_LIB_EXT='dylib'
    # On macOS we seem to need to call mpirun directly and not use esma_mpirun
    # For some reason SIP does not let the libraries be preloaded
    RUN_CMD='mpirun -np '
@@ -249,6 +250,7 @@ else
    ISED="$SED -i "
    PRELOAD_COMMAND='LD_PRELOAD'
    LD_LIBRARY_PATH_CMD='LD_LIBRARY_PATH'
+   SHARED_LIB_EXT='so'
    RUN_CMD='$GEOSBIN/esma_mpirun -np '
    FILE_WEIGHTS='true'
 fi
@@ -458,7 +460,7 @@ mkdir -p $expdir/install/bin
 /bin/cp $INSTALLDIR/bin/GEOSgcm.x $expdir/install/bin
 
 mkdir -p $expdir/install/lib
-/bin/cp $INSTALLDIR/lib/*.so $expdir/install/lib
+/bin/cp $INSTALLDIR/lib/*.${SHARED_LIB_EXT} $expdir/install/lib
 
 /bin/cp $INSTALLDIR/etc/logging.yaml $expdir
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1878,7 +1878,7 @@ if ( $USING_SINGULARITY == FALSE ) then
 
    # Copy over shared object libraries that might be needed by the binaries
    mkdir -p $EXPDIR/install/lib
-   cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
+   cp -RP $GEOSDIR/lib/*@CMAKE_SHARED_LIBRARY_SUFFIX@ $EXPDIR/install/lib
 
    # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
    # be in the installation etc directory. We'll copy it into the EXPDIR/install

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -598,7 +598,7 @@ if( $OGCM == TRUE ) then
     if ( "$OCNMODEL" == "MOM5" ) then
        set OCEAN_NAME="MOM"
        set OGRIDTYP  = "M5TP"
-       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=$GEOSDIR/lib/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=$EXPLIBDIR/libmom@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM5=""
        set MOM6 = "#DELETE"
        set DEFAULT_HISTORY_TEMPLATE="HISTORY.AOGCM-MOM5.rc.tmpl"
@@ -609,7 +609,7 @@ if( $OGCM == TRUE ) then
     else if ( "$OCNMODEL" == "MOM6" ) then
        set OCEAN_NAME="MOM6"
        set OGRIDTYP  = "M6TP"
-       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=\$GEOSDIR/lib/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set OCEAN_PRELOAD = 'env @PRELOAD_COMMAND=\$EXPLIBDIR/libmom6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set MOM6=""
        set MOM5 = "#DELETE"
        set DEFAULT_HISTORY_TEMPLATE="HISTORY.AOGCM.rc.tmpl"
@@ -783,13 +783,13 @@ if( $OGCM == TRUE ) then
     # suffix is different on Linux and macOS. This is set by configure_file()
     if ( $SEAICEMODEL == "CICE4" ) then
        set SEAICE_NAME="CICE4"
-       set SEAICE_PRELOAD = '$GEOSDIR/lib/libCICE4@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set SEAICE_PRELOAD = '$EXPLIBDIR/libCICE4@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set CICE4=""
        set CICE6 = "#DELETE"
        set HIST_CICE4 = ""
     else if ( $SEAICEMODEL == "CICE6" ) then
        set SEAICE_NAME="CICE6"
-       set SEAICE_PRELOAD = '$GEOSDIR/lib/libcice6@CMAKE_SHARED_LIBRARY_SUFFIX@'
+       set SEAICE_PRELOAD = '$EXPLIBDIR/libcice6@CMAKE_SHARED_LIBRARY_SUFFIX@'
        set CICE6=""
        set CICE4 = "#DELETE"
        set HIST_CICE4 = "#DELETE"
@@ -1865,11 +1865,20 @@ rm -f $EXPDIR/RC/fvcore_layout.rc
 
 # Copy or link GEOSgcm.x if USING_SINGULARITY is FALSE
 if ( $USING_SINGULARITY == FALSE ) then
+
+   # Binaries that might use shared object libraries we build
+   mkdir -p $EXPDIR/install/bin
    if ( $LINKX == "TRUE" ) then
-      if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR
+      if ( -e $GEOSBIN/GEOSgcm.x ) ln -s $GEOSBIN/GEOSgcm.x $EXPDIR/install/bin
    else
-      if ( -e $GEOSBIN/GEOSgcm.x ) cp $GEOSBIN/GEOSgcm.x $EXPDIR
+      if ( -e $GEOSBIN/GEOSgcm.x ) cp $GEOSBIN/GEOSgcm.x $EXPDIR/install/bin
    endif
+   cp $GEOSBIN/binarytile.x $EXPDIR/install/bin
+   cp $GEOSBIN/rs_numtiles.x $EXPDIR/install/bin
+
+   # Copy over shared object libraries that might be needed by the binaries
+   mkdir -p $EXPDIR/install/lib
+   cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
 
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"
@@ -3067,7 +3076,8 @@ sh $COPYSCRIPT
 # ----------------------------------------------------
 
 echo "$NEWHOMDIR" >> $NEWEXPDIR/.HOMDIR
-/bin/cp $OLDEXPDIR/GEOSgcm.x $NEWEXPDIR
+mkdir -p $NEWEXPDIR/install
+/bin/cp -a $OLDEXPDIR/install/* $NEWEXPDIR/install/
 /bin/cp -a $OLDEXPDIR/RC $NEWEXPDIR/RC
 
 # -----------------------------------------------------

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1880,6 +1880,11 @@ if ( $USING_SINGULARITY == FALSE ) then
    mkdir -p $EXPDIR/install/lib
    cp -RP $GEOSDIR/lib/*.so $EXPDIR/install/lib
 
+   # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
+   # be in the installation etc directory. We'll copy it into the EXPDIR/install
+   # directory
+   cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"
    set NATIVE_BUILD = ""

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -1883,7 +1883,9 @@ if ( $USING_SINGULARITY == FALSE ) then
    # CMake makes a file called GEOS_RUNTIME_MANIFEST.sha256 which will
    # be in the installation etc directory. We'll copy it into the EXPDIR/install
    # directory
-   cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+    if (-f $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256) then
+       cp $GEOSETC/GEOS_RUNTIME_MANIFEST.sha256 $EXPDIR/install
+    endif
 
    # Set a couple variables for sed'ing out bits of the run script
    set SINGULARITY_BUILD = "#DELETE"


### PR DESCRIPTION
This is part of a suite of PRs to try and change how we handle `GEOSgcm.x` in GEOS. The issue is that more and more of GEOS subcomponents are becoming shared object libraries instead of static. 

## Overall Problem

That means the old trick of "copy someone else's `GEOSgcm.x` to my experiment" might not work. Why? Well, in GEOSgcm v11.10+, the Moist GridComp (for example) is now a shared object library and so just copying `GEOSgcm.x` isn't enough to actually use that other person's Moist GC code. 

## What we change here

What we do now is *copy* into experiments a new `install/bin` and `install/lib` directory. The former has `GEOSgcm.x` as well as `binarytile.x` and `rs_numtiles.x` (as they are the main executables in the run scripts) and then all the `.so` into `install/lib`. We then update the scripts to use those executables. 

Since CMake encodes in the executable's `RUNPATH`, `$ORIGIN/../lib` then if you run:
```
mpirun -np 6 $EXPDIR/install/bin/GEOSgcm.x
```
it will look for libraries it needs in `$ORIGIN/../lib` and that is just the `lib/` dir at the same level as `EXPDIR/install/bin`.