### PR TITLE
Add macOS sed portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GEOSgcm_app
+
 Applications for GEOSgcm fixture
 
 ## Contributing

--- a/gcm_regress.j
+++ b/gcm_regress.j
@@ -94,6 +94,17 @@ set argv = ()
 
 setenv ARCH `uname`
 
+if ($ARCH == Darwin) then
+   set GSED = `which gsed`
+   if ( "$GSED" != "" ) then
+      set ISED = ( $GSED -i )
+   else
+      set ISED = ( sed -i.bak )
+   endif
+else
+   set ISED = ( sed -i )
+endif
+
 setenv SITE    @SITE
 setenv GEOSDIR @GEOSDIR
 setenv GEOSBIN @GEOSBIN
@@ -199,7 +210,7 @@ if ( ! -e gwd_internal_rst ) then
   if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
     echo "NCAR_NRDG: 0" >> AGCM.rc
   else
-    sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+    $ISED '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
   endif
 endif
 
@@ -355,7 +366,7 @@ endif
 @RRTMGP_RADIATION set instance_files = `/bin/ls -1 *_instance*.rc`
 @RRTMGP_RADIATION foreach instance ($instance_files)
    @RRTMGP_RADIATION /bin/mv $instance $instance.tmp
-   @RRTMGP_RADIATION cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
+   @RRTMGP_RADIATION cat $instance.tmp | sed -E -e 's/(^|[^[:alnum:]_])RRTMG([^[:alnum:]_]|$)/\1RRTMGP\2/' > $instance
    @RRTMGP_RADIATION /bin/rm $instance.tmp
 @RRTMGP_RADIATION end
 
@@ -606,7 +617,7 @@ if ($RUN_STARTSTOP == TRUE) then
    @MOM6# When you restart in MOM6 mode, you must change input_filename
    @MOM6# in the input.nml file from 'n' to 'r'
    @MOM6 /bin/cp input.nml input.nml.orig
-   @MOM6 sed -i -e "s/input_filename = 'n'/input_filename = 'r'/g" input.nml
+   @MOM6 $ISED -e "s/input_filename = 'n'/input_filename = 'r'/g" input.nml
 
    ./strip CAP.rc
    set oldstring = `cat CAP.rc | grep JOB_SGMT:`
@@ -625,7 +636,7 @@ if ($RUN_STARTSTOP == TRUE) then
       if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
          echo "NCAR_NRDG: 0" >> AGCM.rc
       else
-         sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+         $ISED '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
       endif
    endif
 
@@ -760,7 +771,7 @@ if ( $RUN_LAYOUT == TRUE) then
       if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
          echo "NCAR_NRDG: 0" >> AGCM.rc
       else
-         sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+          $ISED '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
       endif
    endif
 
@@ -819,7 +830,7 @@ if ( $RUN_OPENMP == TRUE) then
      echo KMP_AFFINITY     $KMP_AFFINITY
      echo OMP_NUM_THREADS $OMP_NUM_THREADS
      ./strip GWD_GridComp.rc
-     sed -i -e "s|FALSE|TRUE|g" GWD_GridComp.rc
+      $ISED -e "s|FALSE|TRUE|g" GWD_GridComp.rc
    endif
 
    # Copy Original Restarts to Regress directory
@@ -883,7 +894,7 @@ if ( $RUN_OPENMP == TRUE) then
       if ( `grep -c "NCAR_NRDG:" AGCM.rc` == 0 ) then
          echo "NCAR_NRDG: 0" >> AGCM.rc
       else
-         sed -i '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
+          $ISED '/NCAR_NRDG:/c\NCAR_NRDG: 0' AGCM.rc
       endif
    endif
 
@@ -922,7 +933,7 @@ if ( $RUN_OPENMP == TRUE) then
    # Reset OpenMP Threads to 1
    setenv OMP_NUM_THREADS 1
    ./strip GWD_GridComp.rc
-   sed -i -e "s|TRUE|FALSE|g" GWD_GridComp.rc
+    $ISED -e "s|TRUE|FALSE|g" GWD_GridComp.rc
 
 endif
 

--- a/gcm_run.j
+++ b/gcm_run.j
@@ -26,6 +26,17 @@ limit stacksize unlimited
 
 setenv ARCH `uname`
 
+if ($ARCH == Darwin) then
+   set GSED = `which gsed`
+   if ( "$GSED" != "" ) then
+      set ISED = ( $GSED -i )
+   else
+      set ISED = ( sed -i.bak )
+   endif
+else
+   set ISED = ( sed -i )
+endif
+
 setenv SITE             @SITE
 setenv GEOSDIR          @GEOSDIR
 setenv GEOSBIN          @GEOSBIN
@@ -805,12 +816,12 @@ endif
 
 @COUPLEDset HEARTBEAT_DT = `grep '^\s*HEARTBEAT_DT:' CAP.rc | cut -d: -f2 | awk '{print $1}'`
 
-@COUPLED sed -i -e "s/OGCM_RUN_DT: [0-9]\+\(\.[0-9]\+\)\?/OGCM_RUN_DT: $HEARTBEAT_DT/g" AGCM.rc
-@MOM5 sed -i -e "s/dt_cpld = [0-9]\+\(\.[0-9]\+\)\?,/dt_cpld = $HEARTBEAT_DT,/g" \
+@COUPLED $ISED -e "s/OGCM_RUN_DT: [0-9]\+\(\.[0-9]\+\)\?/OGCM_RUN_DT: $HEARTBEAT_DT/g" AGCM.rc
+@MOM5 $ISED -e "s/dt_cpld = [0-9]\+\(\.[0-9]\+\)\?,/dt_cpld = $HEARTBEAT_DT,/g" \
 @MOM5        -e "s/dt_atmos = [0-9]\+\(\.[0-9]\+\)\?,/dt_atmos = $HEARTBEAT_DT,/g" MOM_override
-@MOM6 sed -i -e "s/DT = [0-9]\+\(\.[0-9]\+\)\?/DT = $HEARTBEAT_DT/g" \
+@MOM6 $ISED -e "s/DT = [0-9]\+\(\.[0-9]\+\)\?/DT = $HEARTBEAT_DT/g" \
 @MOM6        -e "s/DT_THERM = [0-9]\+\(\.[0-9]\+\)\?/DT_THERM = $HEARTBEAT_DT/g" MOM_override
-@CICE6 sed -i -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${HEARTBEAT_DT}/" ice_in
+@CICE6 $ISED -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${HEARTBEAT_DT}/" ice_in
 
 if( $AGCM_LM  != 72 ) then
     set files = `/bin/ls  *.yaml`
@@ -839,7 +850,7 @@ touch ExtData.rc
 @RRTMGP_RADIATION set instance_files = `/bin/ls -1 *_instance*.rc`
 @RRTMGP_RADIATION foreach instance ($instance_files)
    @RRTMGP_RADIATION /bin/mv $instance $instance.tmp
-   @RRTMGP_RADIATION cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
+   @RRTMGP_RADIATION cat $instance.tmp | sed -E -e 's/(^|[^[:alnum:]_])RRTMG([^[:alnum:]_]|$)/\1RRTMGP\2/' > $instance
    @RRTMGP_RADIATION /bin/rm $instance.tmp
 @RRTMGP_RADIATION end
 
@@ -884,10 +895,10 @@ endif
 @CICE6 ncdump -h INPUT/iced.nc | grep 'apnd' > /dev/null
 @CICE6 if( $status == 0 ) then
 @CICE6    echo 'pond state in restart, turn on restart flag if not already'
-@CICE6    sed -i -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.false\./    restart_pond_lvl  = .true./' ice_in
+@CICE6    $ISED -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.false\./    restart_pond_lvl  = .true./' ice_in
 @CICE6 else
 @CICE6    echo 'pond state NOT in restart, turn off restart flag if already on'
-@CICE6    sed -i -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.true\./    restart_pond_lvl  = .false./' ice_in
+@CICE6    $ISED -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.true\./    restart_pond_lvl  = .false./' ice_in
 @CICE6 endif
 
 # Test Openwater Restart for Number of tiles correctness

--- a/gcm_run.j-new_rst_approach
+++ b/gcm_run.j-new_rst_approach
@@ -26,6 +26,17 @@ limit stacksize unlimited
 
 setenv ARCH `uname`
 
+if ($ARCH == Darwin) then
+   set GSED = `which gsed`
+   if ( "$GSED" != "" ) then
+      set ISED = ( $GSED -i )
+   else
+      set ISED = ( sed -i.bak )
+   endif
+else
+   set ISED = ( sed -i )
+endif
+
 setenv SITE             @SITE
 setenv GEOSDIR          @GEOSDIR
 setenv GEOSBIN          @GEOSBIN
@@ -748,7 +759,7 @@ touch ExtData.rc
 @RRTMGP_RADIATION set instance_files = `/bin/ls -1 *_instance*.rc`
 @RRTMGP_RADIATION foreach instance ($instance_files)
    @RRTMGP_RADIATION /bin/mv $instance $instance.tmp
-   @RRTMGP_RADIATION cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
+   @RRTMGP_RADIATION cat $instance.tmp | sed -E -e 's/(^|[^[:alnum:]_])RRTMG([^[:alnum:]_]|$)/\1RRTMGP\2/' > $instance
    @RRTMGP_RADIATION /bin/rm $instance.tmp
 @RRTMGP_RADIATION end
 
@@ -785,10 +796,10 @@ endif
 @CICE6 ncdump -h INPUT/iced.nc | grep 'apnd' > /dev/null
 @CICE6 if( $status == 0 ) then
 @CICE6    echo 'pond state in restart, turn on restart flag if not already'
-@CICE6    sed -i -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.false\./    restart_pond_lvl  = .true./' ice_in
+@CICE6    $ISED -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.false\./    restart_pond_lvl  = .true./' ice_in
 @CICE6 else
 @CICE6    echo 'pond state NOT in restart, turn off restart flag if already on'
-@CICE6    sed -i -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.true\./    restart_pond_lvl  = .false./' ice_in
+@CICE6    $ISED -E 's/^[[:space:]]*restart_pond_lvl[[:space:]]*=[[:space:]]*\.true\./    restart_pond_lvl  = .false./' ice_in
 @CICE6 endif
 
 # Test Openwater Restart for Number of tiles correctness

--- a/gcm_run_benchmark.j
+++ b/gcm_run_benchmark.j
@@ -636,7 +636,7 @@ touch ExtData.rc
 @RRTMGP_RADIATION set instance_files = `/bin/ls -1 *_instance*.rc`
 @RRTMGP_RADIATION foreach instance ($instance_files)
    @RRTMGP_RADIATION /bin/mv $instance $instance.tmp
-   @RRTMGP_RADIATION cat $instance.tmp | sed -e '/\bRRTMG\b/ s#RRTMG#RRTMGP#' > $instance
+   @RRTMGP_RADIATION cat $instance.tmp | sed -E -e 's/(^|[^[:alnum:]_])RRTMG([^[:alnum:]_]|$)/\1RRTMGP\2/' > $instance
    @RRTMGP_RADIATION /bin/rm $instance.tmp
 @RRTMGP_RADIATION end
 

--- a/gcm_setup
+++ b/gcm_setup
@@ -37,12 +37,19 @@ setenv ARCH `uname -s`
 setenv NODE `uname -n`
 
 if ($ARCH == Darwin) then
+   set GSED = `which gsed`
+   if ( "$GSED" != "" ) then
+      set ISED = ( $GSED -i )
+   else
+      set ISED = ( sed -i.bak )
+   endif
    set PRELOAD_COMMAND = 'DYLD_INSERT_LIBRARIES'
    set LD_LIBRARY_PATH_CMD = 'DYLD_LIBRARY_PATH'
    # On macOS we seem to need to call mpirun directly and not use esma_mpirun
    # For some reason SIP does not let the libraries be preloaded
    set RUN_CMD = 'mpirun -np '
 else
+   set ISED = ( sed -i )
    set PRELOAD_COMMAND = 'LD_PRELOAD'
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
@@ -2422,7 +2429,7 @@ foreach rsname ($RSNAMES)
    if( $test == FALSE ) then
        foreach type ($RSTYPES)
           set  string = ${name}_${type}
-          sed -i -e "s/${string}/#${string}/g" $LOCDIR/$FILE
+           $ISED -e "s/${string}/#${string}/g" $LOCDIR/$FILE
        end
    endif
 end
@@ -2602,19 +2609,20 @@ if( $OGCM == TRUE ) then
       # and change MOM_override to match. NOTE: This sed
       # assumes floating point number with a decimal
 
-      sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+       $ISED -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
              -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
    else if ("$OCNMODEL" == "MOM5" ) then
       # With MOM5 we need to change dt lines in input.nml to
       # use $OCEAN_DT instead. NOTE: This sed assumes integer followed by comma
 
-      sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
+       $ISED -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
              -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
    endif
 
    # We also need to change the dt in ice_in as well for CICE6
    if ( $SEAICE_NAME == "CICE6" ) then
-      sed -i -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${OCEAN_DT}/" "$HOMDIR/ice_in"
+      $ISED -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${OCEAN_DT}/" "$HOMDIR/ice_in"
+      /bin/rm -f "$HOMDIR/ice_in.bak"
    endif
 
 endif
@@ -2980,7 +2988,7 @@ cat > $SEDFILE << EOF
 EOF
 
 foreach file (`cat $NEWEXPFILES`)
-   sed -i -f $SEDFILE $file
+    $ISED -f $SEDFILE $file
 end
 
 # ------------------------------------------
@@ -2989,13 +2997,13 @@ end
 # ------------------------------------------
 
 #sed -i -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${NEWEXPID}_clonedfrom_${OLDEXPID}_by_${OLDUSER}#" $NEWHOMDIR/HISTORY.rc
- sed -i -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${EXPDSC}#" $NEWHOMDIR/HISTORY.rc
- sed -i -e "/^EXPID:/ s#\(EXPID: \)\(.*\)#\1${NEWEXPID}#" $NEWHOMDIR/HISTORY.rc
+  $ISED -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${EXPDSC}#" $NEWHOMDIR/HISTORY.rc
+  $ISED -e "/^EXPID:/ s#\(EXPID: \)\(.*\)#\1${NEWEXPID}#" $NEWHOMDIR/HISTORY.rc
 
 # Change OLDEXPID to NEWEXPID in __init__.py if it exists
 # -------------------------------------------------------
 if ( -e $NEWHOMDIR/__init__.py ) then
-   sed -i -e "/$OLDEXPID/ s#$OLDEXPID#$NEWEXPID#" $NEWHOMDIR/__init__.py
+   $ISED -e "/$OLDEXPID/ s#$OLDEXPID#$NEWEXPID#" $NEWHOMDIR/__init__.py
 endif
 
 # -------------------------
@@ -3010,24 +3018,24 @@ endif
 set ARCHIVE_N=`echo $NEWEXPID | cut -b1-199`_ARCH
 set REGRESS_N=`echo $NEWEXPID | cut -b1-199`_RGRS
 
-sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$RUN_N#"     \
+$ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$RUN_N#"     \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$RUN_N#"     $NEWHOMDIR/gcm_run.j
-sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$RUN_FN#"    \
+$ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$RUN_FN#"    \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$RUN_FN#"    $NEWEXPDIR/forecasts/gcm_forecast.tmpl
-sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$POST_N#"    \
+$ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$POST_N#"    \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$POST_N#" \
        -e "/^setenv BATCHNAME/ s#\(setenv BATCHNAME *\)\(.*\)#\1 $POST_N#"      $NEWEXPDIR/post/gcm_post.j
-sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$PLOT_N#"    \
+$ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$PLOT_N#"    \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$PLOT_N#"    $NEWEXPDIR/plot/gcm_plot.tmpl
 
 if ( -e $NEWEXPDIR/plot/gcm_moveplot.j ) then
-   sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$MOVE_N#"    \
+   $ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$MOVE_N#"    \
           -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$MOVE_N#" $NEWEXPDIR/plot/gcm_moveplot.j
 endif
 
-sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$ARCHIVE_N#" \
+$ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$ARCHIVE_N#" \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$ARCHIVE_N#" $NEWEXPDIR/archive/gcm_archive.j
-sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$REGRESS_N#" \
+$ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$REGRESS_N#" \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$REGRESS_N#" $NEWEXPDIR/regress/gcm_regress.j
 
 # --------------------------

--- a/geoschemchem_setup
+++ b/geoschemchem_setup
@@ -37,12 +37,19 @@ setenv ARCH `uname -s`
 setenv NODE `uname -n`
 
 if ($ARCH == Darwin) then
+   set GSED = `which gsed`
+   if ( "$GSED" != "" ) then
+      set ISED = ( $GSED -i )
+   else
+      set ISED = ( sed -i.bak )
+   endif
    set PRELOAD_COMMAND = 'DYLD_INSERT_LIBRARIES'
    set LD_LIBRARY_PATH_CMD = 'DYLD_LIBRARY_PATH'
    # On macOS we seem to need to call mpirun directly and not use esma_mpirun
    # For some reason SIP does not let the libraries be preloaded
    set RUN_CMD = 'mpirun -np '
 else
+   set ISED = ( sed -i )
    set PRELOAD_COMMAND = 'LD_PRELOAD'
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
@@ -2452,8 +2459,8 @@ EOF
 cat >      $HOMDIR/chemchem_noNRT.txt << EOF
 
 # don't read NRT QFED data
-sed -i 's/QFED\/NRT/QFED/' ExtData.rc
-sed -i 's/v2.5r1_0.1_deg/v2.5r1\/0.1/' ExtData.rc
+  $ISED 's/QFED\/NRT/QFED/' ExtData.rc
+  $ISED 's/v2.5r1_0.1_deg/v2.5r1\/0.1/' ExtData.rc
 EOF
 
 /bin/rm -f $HOMDIR/chemchem_exit.txt
@@ -2658,7 +2665,7 @@ endif
 
 # GEOS-Chem needs a recent BEGIN Date
 # -----------------------------------
-sed -i 's/BEG_DATE.*/BEG_DATE:     19500101 000000/' $HOMDIR/CAP.rc
+  $ISED 's/BEG_DATE.*/BEG_DATE:     19500101 000000/' $HOMDIR/CAP.rc
 
 # GEOS-Chem needs resolution-dependent settings
 # ---------------------------------------------
@@ -2668,7 +2675,7 @@ setenv RES $AGCM_IM
 set RES_LINE = "`grep -i '${RES}.*OTD-LIS scaling' $EXPDIR/RC/HEMCO_Config.rc`"
 if ( $#RES_LINE == 1 ) then
    set RES_VAL = `echo $RES_LINE | cut -f2 -d:`
-   sed -i "s/@OTD_LIS_SCALING/$RES_VAL/" $EXPDIR/RC/HEMCO_Config.rc
+    $ISED "s/@OTD_LIS_SCALING/$RES_VAL/" $EXPDIR/RC/HEMCO_Config.rc
 else
    echo Expecting exactly 1 line for ${RES} OTD-LIS scaling.
    echo Please set @OTD_LIS_SCALING in $EXPDIR/RC/HEMCO_Config.rc
@@ -2677,7 +2684,7 @@ endif
 set RES_LINE = "`grep -i '${RES}.*Mass tuning factor' $EXPDIR/RC/HEMCO_Config.rc`"
 if ( $#RES_LINE == 1 ) then
    set RES_VAL = `echo $RES_LINE | cut -f2 -d:`
-   sed -i "s/@MASS_TUNING_FACTOR/$RES_VAL/" $EXPDIR/RC/HEMCO_Config.rc
+    $ISED "s/@MASS_TUNING_FACTOR/$RES_VAL/" $EXPDIR/RC/HEMCO_Config.rc
 else
    echo Expecting exactly 1 line for ${RES} Mass tuning factor.
    echo Please set @MASS_TUNING_FACTOR in $EXPDIR/RC/HEMCO_Config.rc
@@ -2783,19 +2790,19 @@ if( $OGCM == TRUE ) then
       # and change MOM_override to match. NOTE: This sed
       # assumes floating point number with a decimal
 
-      sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+       $ISED -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
              -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
    else if ("$OCNMODEL" == "MOM5" ) then
       # With MOM5 we need to change dt lines in input.nml to
       # use $OCEAN_DT instead. NOTE: This sed assumes integer followed by comma
 
-      sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
+       $ISED -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
              -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
    endif
 
    # We also need to change the dt in ice_in as well for CICE6
    if ( $SEAICE_NAME == "CICE6" ) then
-      sed -i -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${OCEAN_DT}/" "$HOMDIR/ice_in"
+       $ISED -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${OCEAN_DT}/" "$HOMDIR/ice_in"
    endif
 
 endif
@@ -3178,7 +3185,7 @@ cat > $SEDFILE << EOF
 EOF
 
 foreach file (`cat $NEWEXPFILES`)
-   sed -i -f $SEDFILE $file
+    $ISED -f $SEDFILE $file
 end
 
 # ------------------------------------------
@@ -3187,13 +3194,13 @@ end
 # ------------------------------------------
 
 #sed -i -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${NEWEXPID}_clonedfrom_${OLDEXPID}_by_${OLDUSER}#" $NEWHOMDIR/HISTORY.rc
- sed -i -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${EXPDSC}#" $NEWHOMDIR/HISTORY.rc
- sed -i -e "/^EXPID:/ s#\(EXPID: \)\(.*\)#\1${NEWEXPID}#" $NEWHOMDIR/HISTORY.rc
+  $ISED -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${EXPDSC}#" $NEWHOMDIR/HISTORY.rc
+  $ISED -e "/^EXPID:/ s#\(EXPID: \)\(.*\)#\1${NEWEXPID}#" $NEWHOMDIR/HISTORY.rc
 
 # Change OLDEXPID to NEWEXPID in __init__.py if it exists
 # -------------------------------------------------------
 if ( -e $NEWHOMDIR/__init__.py ) then
-   sed -i -e "/$OLDEXPID/ s#$OLDEXPID#$NEWEXPID#" $NEWHOMDIR/__init__.py
+    $ISED -e "/$OLDEXPID/ s#$OLDEXPID#$NEWEXPID#" $NEWHOMDIR/__init__.py
 endif
 
 # -------------------------
@@ -3219,7 +3226,7 @@ sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$PLOT_N#"    \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$PLOT_N#"    $NEWEXPDIR/plot/gcm_plot.tmpl
 
 if ( -e $NEWEXPDIR/plot/gcm_moveplot.j ) then
-   sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$MOVE_N#"    \
+   $ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$MOVE_N#"    \
           -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$MOVE_N#" $NEWEXPDIR/plot/gcm_moveplot.j
 endif
 

--- a/gmichem_setup
+++ b/gmichem_setup
@@ -37,12 +37,19 @@ setenv ARCH `uname -s`
 setenv NODE `uname -n`
 
 if ($ARCH == Darwin) then
+   set GSED = `which gsed`
+   if ( "$GSED" != "" ) then
+      set ISED = ( $GSED -i )
+   else
+      set ISED = ( sed -i.bak )
+   endif
    set PRELOAD_COMMAND = 'DYLD_INSERT_LIBRARIES'
    set LD_LIBRARY_PATH_CMD = 'DYLD_LIBRARY_PATH'
    # On macOS we seem to need to call mpirun directly and not use esma_mpirun
    # For some reason SIP does not let the libraries be preloaded
    set RUN_CMD = 'mpirun -np '
 else
+   set ISED = ( sed -i )
    set PRELOAD_COMMAND = 'LD_PRELOAD'
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
@@ -3023,19 +3030,19 @@ if( $OGCM == TRUE ) then
       # and change MOM_override to match. NOTE: This sed
       # assumes floating point number with a decimal
 
-      sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+       $ISED -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
              -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
    else if ("$OCNMODEL" == "MOM5" ) then
       # With MOM5 we need to change dt lines in input.nml to
       # use $OCEAN_DT instead. NOTE: This sed assumes integer followed by comma
 
-      sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
+       $ISED -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
              -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
    endif
 
    # We also need to change the dt in ice_in as well for CICE6
    if ( $SEAICE_NAME == "CICE6" ) then
-      sed -i -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${OCEAN_DT}/" "$HOMDIR/ice_in"
+       $ISED -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${OCEAN_DT}/" "$HOMDIR/ice_in"
    endif
 
 endif
@@ -3401,7 +3408,7 @@ cat > $SEDFILE << EOF
 EOF
 
 foreach file (`cat $NEWEXPFILES`)
-   sed -i -f $SEDFILE $file
+    $ISED -f $SEDFILE $file
 end
 
 # ------------------------------------------
@@ -3410,13 +3417,13 @@ end
 # ------------------------------------------
 
 #sed -i -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${NEWEXPID}_clonedfrom_${OLDEXPID}_by_${OLDUSER}#" $NEWHOMDIR/HISTORY.rc
- sed -i -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${EXPDSC}#" $NEWHOMDIR/HISTORY.rc
- sed -i -e "/^EXPID:/ s#\(EXPID: \)\(.*\)#\1${NEWEXPID}#" $NEWHOMDIR/HISTORY.rc
+  $ISED -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${EXPDSC}#" $NEWHOMDIR/HISTORY.rc
+  $ISED -e "/^EXPID:/ s#$OLDEXPID#$NEWEXPID#" $NEWHOMDIR/HISTORY.rc
 
 # Change OLDEXPID to NEWEXPID in __init__.py if it exists
 # -------------------------------------------------------
 if ( -e $NEWHOMDIR/__init__.py ) then
-   sed -i -e "/$OLDEXPID/ s#$OLDEXPID#$NEWEXPID#" $NEWHOMDIR/__init__.py
+    $ISED -e "/$OLDEXPID/ s#$OLDEXPID#$NEWEXPID#" $NEWHOMDIR/__init__.py
 endif
 
 # -------------------------
@@ -3442,7 +3449,7 @@ sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$PLOT_N#"    \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$PLOT_N#"    $NEWEXPDIR/plot/gcm_plot.tmpl
 
 if ( -e $NEWEXPDIR/plot/gcm_moveplot.j ) then
-   sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$MOVE_N#"    \
+   $ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$MOVE_N#"    \
           -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$MOVE_N#" $NEWEXPDIR/plot/gcm_moveplot.j
 endif
 

--- a/stratchem_setup
+++ b/stratchem_setup
@@ -37,12 +37,19 @@ setenv ARCH `uname -s`
 setenv NODE `uname -n`
 
 if ($ARCH == Darwin) then
+   set GSED = `which gsed`
+   if ( "$GSED" != "" ) then
+      set ISED = ( $GSED -i )
+   else
+      set ISED = ( sed -i.bak )
+   endif
    set PRELOAD_COMMAND = 'DYLD_INSERT_LIBRARIES'
    set LD_LIBRARY_PATH_CMD = 'DYLD_LIBRARY_PATH'
    # On macOS we seem to need to call mpirun directly and not use esma_mpirun
    # For some reason SIP does not let the libraries be preloaded
    set RUN_CMD = 'mpirun -np '
 else
+   set ISED = ( sed -i )
    set PRELOAD_COMMAND = 'LD_PRELOAD'
    set LD_LIBRARY_PATH_CMD = 'LD_LIBRARY_PATH'
    set RUN_CMD = '$GEOSBIN/esma_mpirun -np '
@@ -2713,19 +2720,19 @@ if( $OGCM == TRUE ) then
       # and change MOM_override to match. NOTE: This sed
       # assumes floating point number with a decimal
 
-      sed -i -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
+       $ISED -e "s/DT = [0-9]*\.[0-9]*/DT = $OCEAN_DT/g" \
              -e "s/DT_THERM = [0-9]*\.[0-9]*/DT_THERM = $OCEAN_DT/g" $HOMDIR/MOM_override
    else if ("$OCNMODEL" == "MOM5" ) then
       # With MOM5 we need to change dt lines in input.nml to
       # use $OCEAN_DT instead. NOTE: This sed assumes integer followed by comma
 
-      sed -i -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
+       $ISED -e "s/dt_cpld = [0-9]*,/dt_cpld = $OCEAN_DT,/g" \
              -e "s/dt_atmos = [0-9]*,/dt_atmos = $OCEAN_DT,/g" $HOMDIR/input.nml
    endif
 
    # We also need to change the dt in ice_in as well for CICE6
    if ( $SEAICE_NAME == "CICE6" ) then
-      sed -i -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${OCEAN_DT}/" "$HOMDIR/ice_in"
+       $ISED -E "s/^([[:space:]]*dt[[:space:]]*=[[:space:]]*)[0-9]+(\.[0-9]+)?/\1${OCEAN_DT}/" "$HOMDIR/ice_in"
    endif
 
 endif
@@ -3095,7 +3102,7 @@ cat > $SEDFILE << EOF
 EOF
 
 foreach file (`cat $NEWEXPFILES`)
-   sed -i -f $SEDFILE $file
+    $ISED -f $SEDFILE $file
 end
 
 # ------------------------------------------
@@ -3104,13 +3111,13 @@ end
 # ------------------------------------------
 
 #sed -i -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${NEWEXPID}_clonedfrom_${OLDEXPID}_by_${OLDUSER}#" $NEWHOMDIR/HISTORY.rc
- sed -i -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${EXPDSC}#" $NEWHOMDIR/HISTORY.rc
- sed -i -e "/^EXPID:/ s#\(EXPID: \)\(.*\)#\1${NEWEXPID}#" $NEWHOMDIR/HISTORY.rc
+  $ISED -e "/^EXPDSC:/ s#\(EXPDSC: \)\(.*\)#\1${EXPDSC}#" $NEWHOMDIR/HISTORY.rc
+  $ISED -e "/^EXPID:/ s#\(EXPID: \)\(.*\)#\1${NEWEXPID}#" $NEWHOMDIR/HISTORY.rc
 
 # Change OLDEXPID to NEWEXPID in __init__.py if it exists
 # -------------------------------------------------------
 if ( -e $NEWHOMDIR/__init__.py ) then
-   sed -i -e "/$OLDEXPID/ s#$OLDEXPID#$NEWEXPID#" $NEWHOMDIR/__init__.py
+    $ISED -e "/$OLDEXPID/ s#$OLDEXPID#$NEWEXPID#" $NEWHOMDIR/__init__.py
 endif
 
 # -------------------------
@@ -3136,7 +3143,7 @@ sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$PLOT_N#"    \
        -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$PLOT_N#"    $NEWEXPDIR/plot/gcm_plot.tmpl
 
 if ( -e $NEWEXPDIR/plot/gcm_moveplot.j ) then
-   sed -i -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$MOVE_N#"    \
+   $ISED -e "/^#PBS -N/ s#\(PBS -N \)\(.*\)#\1$MOVE_N#"    \
           -e "/^#SBATCH --job-name=/ s#\(SBATCH --job-name=\)\(.*\)#\1$MOVE_N#" $NEWEXPDIR/plot/gcm_moveplot.j
 endif
 


### PR DESCRIPTION
## Summary
- Use GNU sed on macOS when `gsed` is available.
- Fall back to BSD-compatible in-place sed syntax.
- Replace nonportable RRTMG `\b` boundaries with POSIX character classes.
- Apply fixes across setup, run, chemistry, and regression scripts.

## Testing
- `tcsh -n` checks passed for the updated setup scripts.
- Verified the portable RRTMG replacement with macOS sed.