### PR TITLE
Clarify old deprecated v14 comment

### DIFF
--- a/AGCM.rc.tmpl
+++ b/AGCM.rc.tmpl
@@ -131,9 +131,10 @@ CLOSURE_CONGESTUS: 3
 # ------------------------
 HGT_SURFACE: 0.0
 NCAR_NRDG: @NCAR_NRDG
-# The below settings are only for v14 BCs currently being tested
-#v14 NCAR_EFFGWORO: 0.35
-#v14 NCAR_ORO_TNDMAX: 250
+# The below settings are only for v15 BCs currently being tested
+# with v2 topo
+#v15 NCAR_EFFGWORO: 0.35
+#v15 NCAR_ORO_TNDMAX: 250
 ###########################################################
 
 ###########################################################


### PR DESCRIPTION
Per @biljanaorescanin `AGCM.rc` had an old comment about v14 BCs. This was true for older v14 BCs that were based on the v2 topo. 

But now, v14 does not need this and it more accurately reflects v15 (perhaps).